### PR TITLE
Add "on_channel_context_menu" callback

### DIFF
--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -419,6 +419,21 @@ class ExtensionManager(object):
         pass
 
     @call_extensions
+    def on_channel_context_menu(self, channel):
+        """Called when the channel list context menu is opened
+
+        You can add additional context menu entries here. You have to return a
+        list of tuples, where the first item is a label and the second item is a
+        callable that will get the channel as its first and only parameter.
+
+        Example return value:
+
+        [('Update channel', lambda channel: ...)]
+        @param channel: A gpodder.model.PodcastChannel instance
+        """
+        pass
+
+    @call_extensions
     def on_episode_delete(self, episode, filename):
         """Called just before the episode's disk file is about to be
         deleted."""

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1540,7 +1540,15 @@ class gPodder(BuilderWidget, dbus.service.Object):
             item.connect( 'activate', self.on_itemRemoveChannel_activate)
             menu.append( item)
 
-            menu.append( gtk.SeparatorMenuItem())
+            result = gpodder.user_extensions.on_channel_context_menu(self.active_channel)
+            if result:
+                menu.append(gtk.SeparatorMenuItem())
+                for label, callback in result:
+                    item = gtk.MenuItem(label)
+                    item.connect('activate', lambda item, callback: callback(self.active_channel), callback)
+                    menu.append(item)
+
+            menu.append(gtk.SeparatorMenuItem())
 
             item = gtk.ImageMenuItem(_('Podcast settings'))
             item.set_image(gtk.image_new_from_stock(gtk.STOCK_INFO, gtk.ICON_SIZE_MENU))


### PR DESCRIPTION
Add an extension callback for reacting to a user activating the context menu on a channel. Allows the extension developer to add menu items to the channel context menu if desired.

I am lurking the #gpodder channel as nick_s so feel free to reach out with questions/comments.
