### PR TITLE
correct wrong config variable in the sync module

### DIFF
--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -196,7 +196,7 @@ class Device(services.ObservableService):
 
     def close(self):
         self.notify('status', _('Writing data to disk'))
-        if self._config.device_sync.sync_disks_after_transfer and not gpodder.win32:
+        if self._config.device_sync.after_sync.sync_disks and not gpodder.win32:
             os.system('sync')
         else:
             logger.warning('Not syncing disks. Unmount your device before unplugging.')


### PR DESCRIPTION
I found a wrong config variable used in the sync.py module. This is the small patch
