### PR TITLE
https://github.com/rafiyr/gpodder/commit/d91b837880eda62b59d1fac2eede23948d02f9ac

### DIFF
--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -166,7 +166,7 @@ defaults = {
 
         'max_filename_length': 999,
 
-        'custom_sync_name': '{episode.pubdate_prop}_{episode.title}',
+        'custom_sync_name': '{episode.sortdate}_{episode.title}',
         'custom_sync_name_enabled': False,
 
         'after_sync': {

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -733,6 +733,10 @@ class PodcastEpisode(PodcastModelObject):
     
     pubdate_prop = property(fget=cute_pubdate)
 
+    @property
+    def sortdate(self):
+	    return str(datetime.datetime.fromtimestamp(self.published).strftime('%F'))
+
     def calculate_filesize(self):
         filename = self.local_filename(create=False)
         if filename is None:


### PR DESCRIPTION
Add a sortable date field to Episode and update the default device-sync renaming scheme to use that instead of pubdate_prop

Signed-off-by: Rafi Rubin rafi@seas.upenn.edu
