### PR TITLE
Device sync: add option to disable sync for specific channels

### DIFF
--- a/share/gpodder/ui/gtk/gpodderchannel.ui
+++ b/share/gpodder/ui/gtk/gpodderchannel.ui
@@ -58,7 +58,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">10</property>
-                <property name="n_rows">6</property>
+                <property name="n_rows">7</property>
                 <property name="n_columns">4</property>
                 <property name="column_spacing">5</property>
                 <property name="row_spacing">10</property>
@@ -102,8 +102,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options"/>
                   </packing>
@@ -126,8 +126,8 @@
                   </object>
                   <packing>
                     <property name="right_attach">4</property>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
+                    <property name="top_attach">6</property>
+                    <property name="bottom_attach">7</property>
                   </packing>
                 </child>
                 <child>
@@ -145,6 +145,24 @@
                     <property name="right_attach">4</property>
                     <property name="top_attach">2</property>
                     <property name="bottom_attach">3</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="cbEnableDeviceSync">
+                    <property name="label" translatable="yes">Synchronize to MP3 player devices</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_action_appearance">False</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">4</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -183,8 +201,8 @@
                   <packing>
                     <property name="left_attach">3</property>
                     <property name="right_attach">4</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
@@ -197,8 +215,8 @@
                   <packing>
                     <property name="left_attach">2</property>
                     <property name="right_attach">3</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -211,8 +229,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="x_options">GTK_FILL</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
@@ -225,8 +243,8 @@
                   <packing>
                     <property name="left_attach">2</property>
                     <property name="right_attach">4</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>

--- a/src/gpodder/gtkui/desktop/channel.py
+++ b/src/gpodder/gtkui/desktop/channel.py
@@ -37,6 +37,7 @@ class gPodderChannel(BuilderWidget):
         self.entryTitle.set_text( self.channel.title)
         self.labelURL.set_text(self.channel.url)
         self.cbSkipFeedUpdate.set_active(self.channel.pause_subscription)
+        self.cbEnableDeviceSync.set_active(self.channel.sync_to_mp3_player)
 
         self.section_list = gtk.ListStore(str)
         active_index = 0
@@ -186,6 +187,7 @@ class gPodderChannel(BuilderWidget):
 
     def on_btnOK_clicked(self, widget, *args):
         self.channel.pause_subscription = self.cbSkipFeedUpdate.get_active()
+        self.channel.sync_to_mp3_player = self.cbEnableDeviceSync.get_active()
         self.channel.rename(self.entryTitle.get_text())
         self.channel.auth_username = self.FeedUsername.get_text().strip()
         self.channel.auth_password = self.FeedPassword.get_text()

--- a/src/gpodder/gtkui/desktop/sync.py
+++ b/src/gpodder/gtkui/desktop/sync.py
@@ -69,7 +69,7 @@ class gPodderSyncUI(object):
         """
         episodes = []
         for channel in channels:
-            if only_downloaded:
+            if only_downloaded or not channel.sync_to_mp3_player:
                 logger.info('Skipping channel: %s', channel.title)
                 continue
 

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -441,6 +441,7 @@ class PodcastChannelProxy(object):
         self.auth_username = None
         self.auth_password = None
         self.pause_subscription = False
+        self.sync_to_mp3_player = False
         self.auto_archive_episodes = False
 
     def get_statistics(self):

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -819,6 +819,7 @@ class PodcastChannel(PodcastModelObject):
         self.auto_archive_episodes = False
         self.download_folder = None
         self.pause_subscription = False
+        self.sync_to_mp3_player = True
 
         self.section = _('Other')
         self._common_prefix = None

--- a/src/gpodder/schema.py
+++ b/src/gpodder/schema.py
@@ -62,9 +62,10 @@ PodcastColumns = (
     'section',
     'payment_url',
     'download_strategy',
+    'sync_to_mp3_player',
 )
 
-CURRENT_VERSION = 4
+CURRENT_VERSION = 5
 
 
 # SQL commands to upgrade old database versions to new ones
@@ -87,6 +88,12 @@ UPGRADE_SQL = [
         # Version 4: Per-podcast download strategy management
         (3, 4, """
         ALTER TABLE podcast ADD COLUMN download_strategy INTEGER NOT NULL DEFAULT 0
+        """),
+        
+        # Version 5: add sync_to_mp3_player row to skip device sync for
+        # specific channels
+        (4, 5, """
+        ALTER TABLE podcast ADD COLUMN sync_to_mp3_player INTEGER NOT NULL DEFAULT 1
         """)
 ]
 
@@ -109,7 +116,8 @@ def initialize_database(db):
         pause_subscription INTEGER NOT NULL DEFAULT 0,
         section TEXT NOT NULL DEFAULT '',
         payment_url TEXT NULL DEFAULT NULL,
-        download_strategy INTEGER NOT NULL DEFAULT 0
+        download_strategy INTEGER NOT NULL DEFAULT 0,
+        sync_to_mp3_player INTEGER NOT NULL DEFAULT 1
     )
     """)
 
@@ -232,6 +240,7 @@ def convert_gpodder2_db(old_db, new_db):
                 '',
                 None,
                 0,
+                row['sync_to_devices'],
         )
         new_db.execute("""
         INSERT INTO podcast VALUES (%s)


### PR DESCRIPTION
This is based on a previous patch by Rafi Rubin (https://github.com/rafiyr/gpodder/commit/b067bd) and incorporates the suggestions from the mailing list (http://www.freelists.org/post/gpodder/device-sync-perchannel-settings,1), namely it bumps the schema version to 4 and adds sql upgrade instructions. It also renames the column to sync_enabled and uses the value from a gpodder2 db when upgrading.
