### PR TITLE
Disable linux specific extensions in windows (bug 1729)

### DIFF
--- a/share/gpodder/extensions/ubuntu_appindicator.py
+++ b/share/gpodder/extensions/ubuntu_appindicator.py
@@ -13,6 +13,7 @@ __authors__ = 'Thomas Perl <thp@gpodder.org>'
 __category__ = 'desktop-integration'
 __only_for__ = 'gtk'
 __mandatory_in__ = 'unity'
+__disable_in__ = 'win32'
 
 
 import appindicator

--- a/share/gpodder/extensions/ubuntu_unity.py
+++ b/share/gpodder/extensions/ubuntu_unity.py
@@ -13,6 +13,7 @@ __authors__ = 'Thomas Perl <thp@gpodder.org>'
 __category__ = 'desktop-integration'
 __only_for__ = 'unity'
 __mandatory_in__ = 'unity'
+__disable_in__ = 'win32'
 
 
 # FIXME: Due to the fact that we do not yet use the GI-style bindings, we will

--- a/share/gpodder/extensions/woodchuck.py
+++ b/share/gpodder/extensions/woodchuck.py
@@ -21,6 +21,7 @@
 
 __title__ = 'Woodchuck Plugin'
 __description__ = 'Let the woodchuck analyze your download habits.'
+__disable_in__ = 'win32'
 
 import gpodder
 from gpodder import feedcore


### PR DESCRIPTION
[Bug1729](https://bugs.gpodder.org/show_bug.cgi?id=1729)

Add disable_in attributes to linux specific extensions to disable them on windows. 
