### PR TITLE
Add smart grouping of extension context menu

### DIFF
--- a/share/gpodder/extensions/enqueue_in_mediaplayer.py
+++ b/share/gpodder/extensions/enqueue_in_mediaplayer.py
@@ -19,9 +19,10 @@ __author__ = 'Thomas Perl <thp@gpodder.org>, Bernd Schlapsi <brot@gmx.info>'
 __category__ = 'interface'
 __only_for__ = 'gtk'
 
-AMAROK = (['amarok', '--play', '--append'], 'Enqueue in Amarok')
+AMAROK = (['amarok', '--play', '--append'],
+    '%s/%s' % (_('Enqueue in'), 'Amarok'))
 VLC = (['vlc', '--started-from-file', '--playlist-enqueue'],
-    'Enqueue in VLC')
+    '%s/%s' % (_('Enqueue in'), 'VLC'))
 
 
 class gPodderExtension:
@@ -42,10 +43,10 @@ class gPodderExtension:
             stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
 
-    def _enqueue_episodes_amarok(self, episodes):
+    def enqueue_episodes_amarok(self, episodes):
         self._enqueue_episodes_cmd(episodes, AMAROK[0])
 
-    def _enqueue_episodes_vlc(self, episodes):
+    def enqueue_episodes_vlc(self, episodes):
         self._enqueue_episodes_cmd(episodes, VLC[0])
 
     def on_episodes_context_menu(self, episodes):
@@ -55,9 +56,9 @@ class gPodderExtension:
         menu_entries = []
 
         if self.amarok_available:
-            menu_entries.append((AMAROK[1], self._enqueue_episodes_amarok))
+            menu_entries.append((AMAROK[1], self.enqueue_episodes_amarok))
 
         if self.vlc_available:
-            menu_entries.append((VLC[1], self._enqueue_episodes_vlc))
+            menu_entries.append((VLC[1], self.enqueue_episodes_vlc))
 
         return menu_entries

--- a/share/gpodder/extensions/normalize_audio.py
+++ b/share/gpodder/extensions/normalize_audio.py
@@ -61,7 +61,7 @@ class gPodderExtension:
         if 'audio/ogg' not in mimetypes and 'audio/mpeg' not in mimetypes:
             return None
 
-        return [(self.container.metadata.title, self._convert_episodes)]
+        return [(self.container.metadata.title, self.convert_episodes)]
 
     def _convert_episode(self, episode):
         if episode.file_type() != 'audio':
@@ -82,11 +82,11 @@ class gPodderExtension:
         if p.returncode == 0:
             logger.info('normalize-audio processing successful.')
             gpodder.user_extensions.on_notification_show(_('File normalized'),
-                    episode)
+                    episode.title)
         else:
             logger.warn('normalize-audio failed: %s / %s', stdout, stderr)
 
-    def _convert_episodes(self, episodes):
+    def convert_episodes(self, episodes):
         for episode in episodes:
             self._convert_episode(episode)
 


### PR DESCRIPTION
Context menues from extensions were grouped by string parsing.
If "/" is in the string the string before the seperator is used as
root menu entry and the string after the seperator is used as
sub-menu entry
