### PR TITLE
Fix GtkWarning from the shownotes (bug 1735)

### DIFF
--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -50,7 +50,9 @@ except ImportError:
 class gPodderShownotes:
     def __init__(self, scrolled_window):
         self.scrolled_window = scrolled_window
-        self.scrolled_window.add(self.init())
+        notes = self.init()
+        if notes.get_parent() is not self.scrolled_window:
+            self.scrolled_window.add(notes)
         self.scrolled_window.show_all()
 
     def set_episode(self, episode):


### PR DESCRIPTION
[Bug 1735](https://bugs.gpodder.org/show_bug.cgi?id=1735)

A warning is issued when the shownotes TextView is reparented.
