### PR TITLE
Properly handle the shownotes and play queue buttons on media player in landscape

### DIFF
--- a/share/gpodder/ui/qml/MediaPlayer.qml
+++ b/share/gpodder/ui/qml/MediaPlayer.qml
@@ -186,18 +186,16 @@ Item {
             right: parent.right
         }
 
-        height: mediaPlayerButtonsColumn.height + 2 * Config.smallSpacing
+        Grid {
+            columns: Util.isScreenPortrait() ? 1 : 2
 
-        Column {
-            id: mediaPlayerButtonsColumn
+            spacing: 2
 
-            spacing: Config.smallSpacing
-            width: parent.width
+            anchors.horizontalCenter: parent.horizontalCenter
 
             Button {
                 id: showNotesButton
                 width: parent.width * .9
-                anchors.horizontalCenter: parent.horizontalCenter
 
                 text: _('Shownotes')
                 onClicked: {
@@ -209,7 +207,6 @@ Item {
             Button {
                 id: playQueueButton
                 width: parent.width * .9
-                anchors.horizontalCenter: parent.horizontalCenter
 
                 visible: playQueue.length > 0
 

--- a/share/gpodder/ui/qml/util.js
+++ b/share/gpodder/ui/qml/util.js
@@ -17,3 +17,7 @@ function formatDuration(duration) {
 function formatPosition(position,duration) {
   return formatDuration(position) + " / " + formatDuration(duration)
 }
+
+function isScreenPortrait() {
+  return screen.currentOrientation == Screen.Portrait || screen.currentOrientation == Screen.PortraitInverted 
+}


### PR DESCRIPTION
When in landscape the play queue button would not be visible.
This change detects the orientation and changes the number of columns on the grid, so the buttons are either arranged in the horizontal or vertical
