### PR TITLE
Clean up preferences dialog

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -181,6 +181,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="shadow_type">in</property>
+		    <property name="hscrollbar-policy">GTK_POLICY_AUTOMATIC</property>
+		    <property name="vscrollbar-policy">GTK_POLICY_AUTOMATIC</property>
                     <child>
                       <object class="GtkTreeView" id="treeviewExtensions">
                         <property name="visible">True</property>
@@ -220,6 +222,7 @@
                     <property name="bottom_attach">2</property>
                     <property name="top_attach">1</property>
                     <property name="x_options">fill</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -232,6 +235,7 @@
                     <property name="bottom_attach">3</property>
                     <property name="x_options">fill</property>
                     <property name="top_attach">2</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -243,6 +247,7 @@
                   <packing>
                     <property name="bottom_attach">4</property>
                     <property name="top_attach">3</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
               </object>
@@ -269,6 +274,7 @@
                     <property name="bottom_attach">2</property>
                     <property name="right_attach">3</property>
                     <property name="top_attach">1</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -281,6 +287,7 @@
                     <property name="bottom_attach">3</property>
                     <property name="top_attach">2</property>
                     <property name="x_options">fill</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -293,6 +300,7 @@
                     <property name="bottom_attach">4</property>
                     <property name="top_attach">3</property>
                     <property name="x_options">fill</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -305,6 +313,7 @@
                     <property name="bottom_attach">6</property>
                     <property name="right_attach">3</property>
                     <property name="top_attach">5</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -317,6 +326,7 @@
                     <property name="bottom_attach">5</property>
                     <property name="top_attach">4</property>
                     <property name="x_options">fill</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -329,6 +339,7 @@
                     <property name="left_attach">1</property>
                     <property name="right_attach">3</property>
                     <property name="top_attach">2</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -343,6 +354,7 @@
                     <property name="left_attach">1</property>
                     <property name="right_attach">3</property>
                     <property name="top_attach">3</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
                 <child>
@@ -355,6 +367,7 @@
                     <property name="left_attach">1</property>
                     <property name="right_attach">3</property>
                     <property name="top_attach">4</property>
+		    <property name="y_options"></property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
-  Makes the gpodder.net and Flattr tabs behave the way the rest of the tabs in the preferences dialog do (the widgets dont expand in the y direction) .
- Sets the vertical and horizontal scrollbars in the Extension tab so that they are only used if necessary. 
