### PR TITLE
Upload episode actions in batches

### DIFF
--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -73,6 +73,7 @@ from mygpoclient import util as mygpoutil
 
 EXAMPLES_OPML = 'http://gpodder.org/directory.opml'
 TOPLIST_OPML = 'http://gpodder.org/toplist.opml'
+EPISODE_ACTIONS_BATCH_SIZE=100
 
 # Database model classes
 class SinceValue(object):
@@ -508,14 +509,20 @@ class MygPoClient(object):
 
             # Step 2: Upload Episode actions
 
-            # Convert actions to the mygpoclient format for uploading
-            episode_actions = [convert_to_api(a) for a in actions]
+            # Uploads are done in batches; uploading can resume if only parts
+            # be uploaded; avoids empty uploads as well
+            for lower in range(0, len(actions), EPISODE_ACTIONS_BATCH_SIZE):
+                batch = actions[lower:lower+EPISODE_ACTIONS_BATCH_SIZE]
 
-            # Upload the episode actions
-            self._client.upload_episode_actions(episode_actions)
+                # Convert actions to the mygpoclient format for uploading
+                episode_actions = [convert_to_api(a) for a in batch]
 
-            # Actions have been uploaded to the server - remove them
-            self._store.remove(actions)
+                # Upload the episode actions
+                self._client.upload_episode_actions(episode_actions)
+
+                # Actions have been uploaded to the server - remove them
+                self._store.remove(batch)
+
             logger.debug('Episode actions have been uploaded to the server.')
             return True
 


### PR DESCRIPTION
Uploading of episode actions to gpodder.net should be done in batches. This would solve two main causes of high traffic on the webservice:
- empty uploads
- large uploads that do not finish within gPodder's timeout (1min) and are constantly retried

A major part of gpodder.net's traffic is caused by these two types of episode action uploads. When uploading in batches, each batch is more likely to succeed than one large batch, and the client only needs to send the remaining actions, if the first few batches succeed. This also eliminates empty uploads which currently account for ~70% of all episode action uploads.
