### PR TITLE
Make the notification extension mandatory on Windows

### DIFF
--- a/share/gpodder/extensions/gtk_statusicon.py
+++ b/share/gpodder/extensions/gtk_statusicon.py
@@ -12,7 +12,7 @@ __title__ = _('Gtk Status Icon')
 __description__ = _('Show a status icon for Gtk-based Desktops.')
 __category__ = 'desktop-integration'
 __only_for__ = 'gtk'
-__disable_in__ = 'unity'
+__disable_in__ = 'unity,win32'
 
 import gtk
 import os.path

--- a/share/gpodder/extensions/notification-win32.py
+++ b/share/gpodder/extensions/notification-win32.py
@@ -24,6 +24,7 @@ __title__ = 'Notification Bubbles for Windows'
 __description__ = 'Display notification bubbles for different events.'
 __authors__ = 'Sean Munkel <SeanMunkel@gmail.com>'
 __category__ = 'desktop-integration'
+__mandatory_in__ = 'win32'
 __only_for__ = 'win32'
 
 import functools


### PR DESCRIPTION
Right now the non Windows version is mandatory, so this changes that for the windows version. Because the windows version of the notification extension creates an icon in the system tray, this patch also disables the status icon extension for Windows. 
