### PR TITLE
Provide option for episode count to be on the right on QML UI

### DIFF
--- a/share/gpodder/ui/qml/Main.qml
+++ b/share/gpodder/ui/qml/Main.qml
@@ -29,6 +29,8 @@ Item {
     property bool hasPlayButton: ((mediaPlayer.episode !== undefined)) && !progressIndicator.opacity
     property bool hasSearchButton: !progressIndicator.opacity
 
+    property bool rightCounter: configProxy.episodeCountOnRight
+
     property bool loadingEpisodes: false
 
     function clearEpisodeListModel() {

--- a/share/gpodder/ui/qml/PodcastItem.qml
+++ b/share/gpodder/ui/qml/PodcastItem.qml
@@ -9,12 +9,31 @@ import 'util.js' as Util
 SelectableItem {
     id: podcastItem
 
+    // true if the counter and busy indicator should be on the right
+    property bool rightCounter: main.rightCounter
+
+    Item {
+        id: leftAnchor
+        width: rightCounter ? 0 : Config.iconSize * 1.3
+        anchors {
+            left: parent.left
+            leftMargin:  Config.smallSpacing
+        }
+    }
+    Item {
+        id: rightAnchor
+        anchors {
+            right: parent.right
+            rightMargin: Config.smallSpacing
+        }
+    }
+
     Item {
         id: counterBox
         width: Config.iconSize * 1.3
 
         anchors {
-            left: parent.left
+            right : rightCounter ? rightAnchor.left : cover.left
             top: parent.top
             bottom: parent.bottom
         }
@@ -27,12 +46,14 @@ SelectableItem {
 
             anchors {
                 verticalCenter: parent.verticalCenter
+                left: parent.left
                 right: parent.right
                 rightMargin: 3
             }
 
             visible: !spinner.visible && (downloadedEpisodes > 0)
             text: counters.downloadedEpisodes
+            horizontalAlignment: Text.AlignRight
             color: "white"
 
             font.pixelSize: podcastItem.height * .4
@@ -43,7 +64,7 @@ SelectableItem {
         id: spinner
         anchors {
             verticalCenter: parent.verticalCenter
-            right: cover.left
+            right: rightCounter ? rightAnchor.left : cover.left
             rightMargin: Config.smallSpacing
         }
         visible: modelData.qupdating
@@ -88,7 +109,7 @@ SelectableItem {
 
         anchors {
             verticalCenter: parent.verticalCenter
-            left: counterBox.right
+            left: leftAnchor.right
             leftMargin: Config.smallSpacing
         }
     }
@@ -103,7 +124,6 @@ SelectableItem {
             verticalCenter: parent.verticalCenter
             left: cover.visible?cover.right:cover.left
             leftMargin: Config.smallSpacing * 2
-            right: parent.right
             rightMargin: Config.smallSpacing
         }
 

--- a/share/gpodder/ui/qml/main_default.qml
+++ b/share/gpodder/ui/qml/main_default.qml
@@ -227,6 +227,8 @@ WindowWindow {
             settingsAutorotate.checked = configProxy.autorotate
             settingsIndexing.checked = trackerMinerConfig.get_index_podcasts()
 
+            settingsCountRight.checked = configProxy.episodeCountOnRight
+
             flattrOnPlaySwitch.checked = configProxy.flattrOnPlay
 
             myGpoEnableSwitch.checked = controller.myGpoEnabled
@@ -263,6 +265,16 @@ WindowWindow {
                         text: _('Automatic rotation')
                         onCheckedChanged: {
                             configProxy.autorotate = checked
+                        }
+                    }
+
+                    SettingsHeader { text: _('Display settings') }
+ 
+                    SettingsSwitch {
+                        id: settingsCountRight
+                        text: _('Episode count on the right')
+                        onCheckedChanged: {
+                            configProxy.episodeCountOnRight = checked
                         }
                     }
 

--- a/src/gpodder/qmlui/__init__.py
+++ b/src/gpodder/qmlui/__init__.py
@@ -88,6 +88,8 @@ class ConfigProxy(QObject):
     def _on_config_changed(self, name, old_value, new_value):
         if name == 'ui.qml.autorotate':
             self.autorotateChanged.emit()
+        if name == 'ui.qml.episodecountonright':
+            self.episodeCountOnRightChanged.emit()
         elif name == 'flattr.token':
             self.flattrTokenChanged.emit()
         elif name == 'flattr.flattr_on_play':
@@ -126,6 +128,17 @@ class ConfigProxy(QObject):
     flattrOnPlay = Property(bool, get_flattr_on_play, set_flattr_on_play,
             notify=flattrOnPlayChanged)
 
+    def get_episode_count_on_right(self):
+        return self._config.ui.qml.episodecountonright
+
+    def set_episode_count_on_right(self, episode_count_on_right):
+        self._config.ui.qml.episodecountonright = episode_count_on_right
+
+    episodeCountOnRightChanged = Signal()
+
+    episodeCountOnRight = Property(bool, get_episode_count_on_right,
+                                   set_episode_count_on_right,
+                                   notify=episodeCountOnRightChanged)
 
 class Controller(QObject):
     def __init__(self, root):


### PR DESCRIPTION
I really prefer the episode count on the left, and have been using that on a custom gPodder build for harmattan.

I improved that change so that it is configurable on the settings page
