### PR TITLE
Add option to flattr an extensions and to show documentation

### DIFF
--- a/share/gpodder/extensions/audio_converter.py
+++ b/share/gpodder/extensions/audio_converter.py
@@ -20,6 +20,8 @@ _ = gpodder.gettext
 __title__ = _('Convert audio files')
 __description__ = _('Transcode audio files to mp3/ogg')
 __authors__ = 'Bernd Schlapsi <brot@gmx.info>, Thomas Perl <thp@gpodder.org>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/AudioConverter'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/AudioConverter'
 __category__ = 'post-download'
 
 

--- a/share/gpodder/extensions/enqueue_in_mediaplayer.py
+++ b/share/gpodder/extensions/enqueue_in_mediaplayer.py
@@ -15,7 +15,9 @@ _ = gpodder.gettext
 
 __title__ = _('Enqueue in media players')
 __description__ = _('Add a context menu item for enqueueing episodes in installed media players')
-__author__ = 'Thomas Perl <thp@gpodder.org>, Bernd Schlapsi <brot@gmx.info>'
+__authors__ = 'Thomas Perl <thp@gpodder.org>, Bernd Schlapsi <brot@gmx.info>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/EnqueueInMediaplayer'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/EnqueueInMediaplayer'
 __category__ = 'interface'
 __only_for__ = 'gtk'
 

--- a/share/gpodder/extensions/normalize_audio.py
+++ b/share/gpodder/extensions/normalize_audio.py
@@ -21,6 +21,8 @@ _ = gpodder.gettext
 __title__ = _('Normalize audio with re-encoding')
 __description__ = _('Normalize the volume of audio files with normalize-audio')
 __authors__ = 'Bernd Schlapsi <brot@gmx.info>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/NormalizeAudio'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/NormalizeAudio'
 __category__ = 'post-download'
 
 

--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -16,6 +16,8 @@ _ = gpodder.gettext
 __title__ = _('Rename episodes after download')
 __description__ = _('Rename episodes to "<Episode Title>.<ext>" on download')
 __authors__ = 'Bernd Schlapsi <brot@gmx.info>, Thomas Perl <thp@gpodder.org>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/RenameAfterDownload'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/RenameAfterDownload'
 __category__ = 'post-download'
 
 

--- a/share/gpodder/extensions/rm_ogg_cover.py
+++ b/share/gpodder/extensions/rm_ogg_cover.py
@@ -37,6 +37,8 @@ _ = gpodder.gettext
 __title__ = _('Remove cover art from OGG files')
 __description__ = _('removes coverart from all downloaded ogg files')
 __authors__ = 'Bernd Schlapsi <brot@gmx.info>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/RemoveOGGCover'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/RemoveOGGCover'
 __category__ = 'post-download'
 
 

--- a/share/gpodder/extensions/sonos.py
+++ b/share/gpodder/extensions/sonos.py
@@ -18,7 +18,7 @@ import requests
 
 __title__ = _('Stream to Sonos')
 __description__ = _('Stream podcasts to Sonos speakers')
-__author__ = 'Stefan Kögl <stefan@skoegl.net>'
+__authors__ = 'Stefan Kögl <stefan@skoegl.net>'
 __category__ = 'interface'
 __only_for__ = 'gtk'
 

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -38,6 +38,8 @@ _ = gpodder.gettext
 __title__ = _('Tag downloaded files using Mutagen')
 __description__ = _('Add episode and podcast titles to MP3/OGG tags')
 __authors__ = 'Bernd Schlapsi <brot@gmx.info>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/Tagging'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/Tagging'
 __category__ = 'post-download'
 
 

--- a/share/gpodder/extensions/update_feeds_on_startup.py
+++ b/share/gpodder/extensions/update_feeds_on_startup.py
@@ -14,6 +14,8 @@ _ = gpodder.gettext
 __title__ = _('Search for new episodes on startup')
 __description__ = _('Starts the search for new episodes on startup')
 __authors__ = 'Bernd Schlapsi <brot@gmx.info>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/SearchEpisodeOnStartup'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/SearchEpisodeOnStartup'
 __category__ = 'interface'
 __only_for__ = 'gtk'
 

--- a/share/gpodder/extensions/video_converter.py
+++ b/share/gpodder/extensions/video_converter.py
@@ -22,6 +22,8 @@ _ = gpodder.gettext
 __title__ = _('Convert video files')
 __description__ = _('Transcode video files to avi/mp4/m4v')
 __authors__ = 'Thomas Perl <thp@gpodder.org>, Bernd Schlapsi <brot@gmx.info>'
+__doc__ = 'http://wiki.gpodder.org/wiki/Extensions/VideoConverter'
+__payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/VideoConverter'
 __category__ = 'post-download'
 
 DefaultConfig = {

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -191,7 +191,8 @@
                         <property name="reorderable">False</property>
                         <property name="enable_search">True</property>
                         <property name="search_column">1</property>
-                        <signal name="row-activated" handler="on_treeview_extensions_row_activated" swapped="no"/>
+                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
+                        <signal name="button-release-event" handler="on_treeview_extension_button_released" swapped="no"/>
                       </object>
                     </child>
                   </object>

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -98,12 +98,14 @@ class ExtensionMetadata(object):
     # Default fallback metadata in case metadata fields are missing
     DEFAULTS = {
         'description': _('No description for this extension.'),
+        'doc': None,
+        'payment': None,
     }
     SORTKEYS = {
         'title': 1,
         'description': 2,
         'category': 3,
-        'author': 4,
+        'authors': 4,
         'only_for': 5,
         'mandatory_in': 6,
         'disable_in': 7,

--- a/src/gpodder/flattr.py
+++ b/src/gpodder/flattr.py
@@ -226,3 +226,13 @@ class Flattr(object):
             self._worker_thread = util.run_in_background(lambda: self._worker_proc(), True)
 
         return (True, content.get('description', _('No description')))
+
+    def is_flattr_url(self, url):
+        if 'flattr.com' in url:
+            return True
+        return False
+
+    def is_flattrable(self, url):
+        if self._config.token and self.is_flattr_url(url):
+            return True
+        return False


### PR DESCRIPTION
If an extension author adds an flattr url to the extensions metadata
gPodder shows the "Flattr this" menu entry in the popup menu for an
extension in the preference dialog.
Alternative the extension author can add an url to the extensions
metadata to link to the authors donation page (Support the author).

Also the extension author can add an url to the extensions metadata
to link to the extensions user documentation.
