### PR TITLE
Added a directory to QMLFILES in Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,8 @@ MOFILES = $(patsubst po/%.po,$(LOCALEDIR)/%/LC_MESSAGES/gpodder.mo, $(POFILES))
 
 UIFILES=$(wildcard share/gpodder/ui/gtk/*.ui)
 UIFILES_H=$(subst .ui,.ui.h,$(UIFILES))
-QMLFILES=$(wildcard share/gpodder/ui/qml/*.qml)
+QMLFILES=$(wildcard share/gpodder/ui/qml/*.qml \
+ 		    share/gpodder/ui/qml/harmattan/org/gpodder/qmlui/*.qml)
 GETTEXT_SOURCE=$(wildcard src/gpodder/*.py \
 		          src/gpodder/gtkui/*.py \
 		          src/gpodder/gtkui/interface/*.py \


### PR DESCRIPTION
I added the directory share/gpodder/ui/qml/harmattan/org/gpodder/qmlui to QMLFILES in Makefile because I noticed both the 'Pull down to refresh' and 'Release to refresh' strings were not included in the translatable strings list.
