### PR TITLE
gpodder: Fix crash on OS X when displaying episode tooltip (bug 1825)

### DIFF
--- a/src/gpodder/gtkui/desktop/episodeselector.py
+++ b/src/gpodder/gtkui/desktop/episodeselector.py
@@ -260,6 +260,9 @@ class gPodderEpisodeSelector(BuilderWidget):
             self.last_tooltip_episode = index
 
             description = util.remove_html_tags(description)
+            # Bug 1825: make sure description is a unicode string,
+            # so it may be cut correctly on UTF-8 char boundaries
+            description = util.convert_bytes(description)
             if description is not None:
                 if len(description) > 400:
                     description = description[:398]+'[...]'


### PR DESCRIPTION
When displaying a long episode description in a tooltip in the
"New episodes available" dialog, gPodder cuts it at a certain
number of characters. However, Russian descriptions are regular,
non-unicode python strings, and gPodder may cut only a part of a
multi-byte UTF-8 sequence. Displaying such a string crashes
gPodder on OS X.

This patch fixes that by converting the description to a unicode
string if it's not unicode.
