### PR TITLE
Gtk UI: Fix device sync progress not updating (bug 1832)

### DIFF
--- a/src/gpodder/gtkui/desktop/sync.py
+++ b/src/gpodder/gtkui/desktop/sync.py
@@ -203,7 +203,8 @@ class gPodderSyncUI(object):
                 # Finally start the synchronization process
                 @util.run_in_background
                 def sync_thread_func():
-                    device.add_sync_tasks(episodes, force_played=force_played)
+                    device.add_sync_tasks(episodes, force_played=force_played,
+                            done_callback=self.enable_download_list_update)
 
                 return
 

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -202,7 +202,7 @@ class Device(services.ObservableService):
             logger.warning('Not syncing disks. Unmount your device before unplugging.')
         return True
 
-    def add_sync_tasks(self,tracklist, force_played=False):
+    def add_sync_tasks(self,tracklist, force_played=False, done_callback=None):
         for track in list(tracklist):
             # Filter tracks that are not meant to be synchronized
             does_not_exist = not track.was_downloaded(and_exists=True)
@@ -228,6 +228,9 @@ class Device(services.ObservableService):
                 self.download_queue_manager.add_task(sync_task)
         else:
             logger.warning("No episodes to sync")
+
+        if done_callback:
+            done_callback()
 
         return True
 


### PR DESCRIPTION
When the verbose mode is on, and the database is big, it can take
several seconds for gPodder to log all excluded from sync episodes. At
that time, the update downloads list timer stops, because there are no
sync tasks yet. This patch ensures the download list is updated after
all the sync tasks are added to the download queue.
