### PR TITLE
Gtk UI: Fix UnicodeDecodeError after downloads are finished (bug 1834)

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1428,6 +1428,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         result = []
         for title in episode_list[:min(len(episode_list), max_episodes)]:
+            # Bug 1834: make sure title is a unicode string,
+            # so it may be cut correctly on UTF-8 char boundaries
+            title = util.convert_bytes(title)
             if len(title) > MAX_TITLE_LENGTH:
                 middle = (MAX_TITLE_LENGTH/2)-2
                 title = '%s...%s' % (title[0:middle], title[-middle:])


### PR DESCRIPTION
When all downloads/syncs are finished, gPodder displays a summary of
downloaded episodes, having cut the titles if they are too long.
However, Russian descriptions are regular, non-unicode python strings,
and gPodder may cut only a part of a multi-byte UTF-8 sequence. It
causes an exception like this:
UnicodeDecodeError: 'utf8' codec can't decode byte 0xbe in position 51:
invalid start byte

This patch fixes that by converting the title to a unicode string if
it's not unicode.

This bug is similar to bug 1825, commit
e1ce9b0551d6380514d255ec03d3609c574860c8.
