### PR TITLE
iPod sync alpha release

### DIFF
--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -159,6 +159,7 @@ defaults = {
     'device_sync': {
         'device_type': 'none', # Possible values: 'none', 'filesystem'
         'device_folder': '/media',
+        'ipod_mount': '/media/ipod',        
 
         'one_folder_per_podcast': True,
         'skip_played_episodes': True,

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -69,6 +69,7 @@ class DeviceTypeActionList(gtk.ListStore):
         gtk.ListStore.__init__(self, str, str)
         self._config = config
         self.append((_('None'), 'none'))
+        self.append((_('iPod'), 'ipod'))        
         self.append((_('Filesystem-based'), 'filesystem'))
 
     def get_index(self):
@@ -577,7 +578,7 @@ class gPodderPreferences(BuilderWidget):
             self.toggle_playlist_interface(True)
 
     def toggle_playlist_interface(self, enabled):
-        if enabled and self._config.device_sync.device_type != 'none':
+        if enabled and self._config.device_sync.device_type == 'filesystem':
             self.btn_playlistfolder.set_sensitive(True)
             self.btn_playlistfolder.set_label(self._config.device_sync.playlists.folder)
             self.checkbutton_delete_using_playlists.set_sensitive(True)
@@ -614,6 +615,20 @@ class gPodderPreferences(BuilderWidget):
             self.toggle_playlist_interface(self._config.device_sync.playlists.create)
             self.combobox_on_sync.set_sensitive(True)
             self.checkbutton_skip_played_episodes.set_sensitive(True)
+        elif device_type == 'ipod':
+            self.btn_filesystemMountpoint.set_label(self._config.device_sync.ipod_mount)
+            self.btn_filesystemMountpoint.set_sensitive(True)
+            self.checkbutton_create_playlists.set_sensitive(False)
+            self.toggle_playlist_interface(False)
+            self.checkbutton_delete_using_playlists.set_sensitive(False)
+            self.combobox_on_sync.set_sensitive(False)
+            self.checkbutton_skip_played_episodes.set_sensitive(False)
+
+            children = self.btn_filesystemMountpoint.get_children()
+            if children:
+                label = children.pop()
+                label.set_alignment(0., .5)
+
         else:
             # TODO: Add support for iPod and MTP devices
             pass
@@ -628,6 +643,8 @@ class gPodderPreferences(BuilderWidget):
             filename = fs.get_filename()
             if self._config.device_sync.device_type == 'filesystem':
                 self._config.device_sync.device_folder = filename
+            elif self._config.device_sync.device_type == 'ipod':
+                self._config.device_sync.ipod_mount = filename                
             # Request an update of the mountpoint button
             self.on_combobox_device_type_changed(None)
 

--- a/src/gpodder/gtkui/desktop/sync.py
+++ b/src/gpodder/gtkui/desktop/sync.py
@@ -178,7 +178,7 @@ class gPodderSyncUI(object):
                 self.commit_changes_to_database()
                 for current_channel in self.channels:
                     #only sync those channels marked for syncing
-                    if (current_channel.sync_to_mp3_player and self._config.device_sync.playlists.create):
+                    if (self._config.device_sync.device_type=='filesystem' and current_channel.sync_to_mp3_player and self._config.device_sync.playlists.create):
 
                         #get playlist object
                         playlist=gPodderDevicePlaylist(self._config,
@@ -195,7 +195,7 @@ class gPodderSyncUI(object):
                 #enable updating of UI
                 self.enable_download_list_update()
                 
-                if self._config.device_sync.playlists.create:                 
+                if (self._config.device_sync.device_type=='filesystem' and self._config.device_sync.playlists.create):                 
                     title = _('Update successful')
                     message = _('The playlist on your MP3 player has been updated.')
                     self.notification(message, title, widget=self.preferences_widget)

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -41,15 +41,13 @@ _ = gpodder.gettext
 #
 
 pymtp_available = False
-gpod_available = False
+gpod_available = True
+try:
+    import gpod
+except:
+    gpod_available = False
+    logger.warning('Could not find gpod')
 
-#gpod_available = True
-#try:
-#    import gpod
-#except:
-#    gpod_available = False
-#    logger.warning('Could not find gpod')
-#
 #pymtp_available = True
 #try:
 #    import gpodder.gpopymtp as pymtp
@@ -114,8 +112,11 @@ if pymtp_available:
 def open_device(gui):
     config = gui._config
     device_type = gui._config.device_sync.device_type
-
-    if device_type == 'filesystem':
+    if device_type == 'ipod':
+        return iPodDevice(config,
+                gui.download_status_model,
+                gui.download_queue_manager)
+    elif device_type == 'filesystem':
         return MP3PlayerDevice(config,
                 gui.download_status_model,
                 gui.download_queue_manager)
@@ -266,11 +267,14 @@ class Device(services.ObservableService):
         return None
 
 class iPodDevice(Device):
-    def __init__(self, config):
+    def __init__(self, config,
+            download_status_model,
+            download_queue_manager):
         Device.__init__(self, config)
 
-        self.mountpoint = str(self._config.ipod_mount)
-
+        self.mountpoint = str(self._config.device_sync.ipod_mount)
+        self.download_status_model = download_status_model
+        self.download_queue_manager = download_queue_manager
         self.itdb = None
         self.podcast_playlist = None
 
@@ -400,13 +404,15 @@ class iPodDevice(Device):
         gpod.itdb_track_unlink(track)
         util.delete_file(filename)
 
-    def add_track(self, episode):
+    def add_track(self, episode,reporthook=None):
         self.notify('status', _('Adding %s') % episode.title)
-        for track in gpod.sw_get_playlist_tracks(self.podcasts_playlist):
-            if episode.url == track.podcasturl:
-                # Mark as played on iPod if played locally (and set podcast flags)
-                self.set_podcast_flags(track, episode)
-                return True
+        tracklist = gpod.sw_get_playlist_tracks(self.podcasts_playlist)
+        podcasturls=map(lambda foo: foo.podcasturl,tracklist)
+
+        if episode.url in podcasturls:
+            # Mark as played on iPod if played locally (and set podcast flags)
+            self.set_podcast_flags(tracklist[podcasturls.index(episode.url)], episode)
+            return True
 
         original_filename = episode.local_filename(create=False)
         # The file has to exist, if we ought to transfer it, and therefore,
@@ -422,7 +428,7 @@ class iPodDevice(Device):
             self.cancelled = True
             return False
 
-        local_filename = self.convert_track(episode)
+        local_filename = episode.local_filename(create=False)
 
         (fn, extension) = os.path.splitext(local_filename)
         if extension.lower().endswith('ogg'):
@@ -431,17 +437,17 @@ class iPodDevice(Device):
 
         track = gpod.itdb_track_new()
 
-        # Add release time to track if pubdate has a valid value
-        if episode.pubdate > 0:
+        # Add release time to track if episode.published has a valid value
+        if episode.published > 0:
             try:
                 # libgpod>= 0.5.x uses a new timestamp format
-                track.time_released = gpod.itdb_time_host_to_mac(int(episode.pubdate))
+                track.time_released = gpod.itdb_time_host_to_mac(int(episode.published))
             except:
                 # old (pre-0.5.x) libgpod versions expect mactime, so
                 # we're going to manually build a good mactime timestamp here :)
                 #
                 # + 2082844800 for unixtime => mactime (1970 => 1904)
-                track.time_released = int(episode.pubdate + 2082844800)
+                track.time_released = int(episode.published + 2082844800)
 
         track.title = str(episode.title)
         track.album = str(episode.channel.title)
@@ -467,9 +473,10 @@ class iPodDevice(Device):
         gpod.itdb_playlist_add_track(self.master_playlist, track, -1)
         gpod.itdb_playlist_add_track(self.podcasts_playlist, track, -1)
         copied = gpod.itdb_cp_track_to_ipod(track, str(local_filename), None)
+        reporthook(episode.file_size, 1, episode.file_size)
 
-        if copied and gpodder.user_hooks is not None:
-            gpodder.user_hooks.on_file_copied_to_ipod(self, local_filename)
+#        if copied and gpodder.user_hooks is not None:
+#            gpodder.user_hooks.on_file_copied_to_ipod(self, local_filename)
 
         # If the file has been converted, delete the temporary file here
         if local_filename != original_filename:
@@ -806,7 +813,7 @@ class MTPDevice(Device):
             metadata.artist = str(episode.channel.title)
             metadata.album = str(episode.channel.title)
             metadata.genre = "podcast"
-            metadata.date = self.__date_to_mtp(episode.pubdate)
+            metadata.date = self.__date_to_mtp(episode.published)
             metadata.duration = get_track_length(str(filename))
 
             folder_name = ''


### PR DESCRIPTION
Thomas,

Here's the alpha release for iPod sync. It works well apart from the fact that the UI locks up during the sync process. I can't figure out why this is happening. The sync process is running in a separate thread, and I'm calling the reporthook after each episode is copied, but the UI is still locking up on the call to gpod.itdb_cp_track_to_ipod. (If I put a breakpoint on the line after the copy, everything works fine and I can interact with the UI while the sync thread is suspended, and it'll stop at the breakpoint with a refreshed UI after each episode, but when I disable the breakpoint and continue the UI locks up.) The process does eventually finish though, and copies the episodes to the device ok, so it's more of an annoyance than a critical issue.

Anyway, maybe we can put it as an alpha feature (as you suggested) and get feedback from users.
