### PR TITLE
signature is in the url itself now, not as an extra parameter any longer

### DIFF
--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -116,7 +116,7 @@ def get_real_download_url(url, preferred_fmt_ids=None):
                 fmt_url_map = urllib.unquote(r4.group(1))
                 for fmt_url_encoded in fmt_url_map.split(','):
                     video_info = parse_qs(fmt_url_encoded)
-                    yield int(video_info['itag'][0]), video_info['url'][0] + "&signature=" + video_info['sig'][0]
+                    yield int(video_info['itag'][0]), video_info['url'][0]
             else:
                 error_info = parse_qs(page)
                 error_message = util.remove_html_tags(error_info['reason'][0])


### PR DESCRIPTION
youtube changed the API again but this time for the better. they now include the signature in the URL, before this change it was an extra parameter.
