### PR TITLE
Fixes error that breaks other downloaders

### DIFF
--- a/src/gpodder/escapist_videos.py
+++ b/src/gpodder/escapist_videos.py
@@ -57,6 +57,9 @@ class EscapistError(BaseException): pass
 def get_real_download_url(url):
     logger.info('Download: %s', url)
     video_id = get_escapist_id(url)
+    if video_id is None:
+        return url
+
     web_data = get_escapist_web(video_id)
 
     data_config_frag = DATA_CONFIG_RE.search(web_data)


### PR DESCRIPTION
Well, this is embarrassing. In #123 I forgot to check if the URL was from the escapist and it breaks youtube and vimeo downloading. I was so focused on adding this feature I forgot to check the rest still worked.

This fixes that issue. Once again I apologize for this rookie error.
