### PR TITLE
Show covers directly after adding feeds (bug 1987)

### DIFF
--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -796,6 +796,9 @@ class PodcastListModel(gtk.ListStore):
             del self._cover_cache[podcast_url]
 
     def add_cover_by_channel(self, channel, pixbuf):
+        # Remove older images from cache
+        self.clear_cover_cache(channel.url)
+
         # Resize and add the new cover image
         pixbuf = self._resize_pixbuf(channel.url, pixbuf)
         if channel.pause_subscription:


### PR DESCRIPTION
When adding a new podcast feed a cover will get downloaded in the
background. Once it is finished gPodder.cover_download_finished() calls
PodcastListModel.add_cover_by_channel(), however by then a placeholder
cover will already be in the cache and the new cover will not be shown.

cover_download_finished() is the only caller of add_cover_by_channel(),
so generally clearing the cache when adding a new cover should be fine.

I reported this as https://bugs.gpodder.org/show_bug.cgi?id=1987, earlier.