### PR TITLE
Updated to handle sync failure when no space left

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1395,7 +1395,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.show_message(message, _('Device synchronization failed'), True, widget=self.labelDownloads)
 
         # Do post-sync processing if required
-        for task in finished_syncs + failed_syncs:
+        for task in finished_syncs:
             if self.config.device_sync.after_sync.mark_episodes_played:
                 logger.info('Marking as played on transfer: %s', task.episode.url)
                 task.episode.mark(is_played=True)


### PR DESCRIPTION
Changed sync code to check needed space against available space and raise
error if there is not enough room for the track.  This causes the track
to be listed in the failed_sync list.  I could not get it to be in the
failed_sync list without raising an exception.  Added a new sync failed
exception.

Also changed the main gtkui code to not include the failed_sync tracks
in the list of tracks to perform post-sync processing on.  This prevents
tracks that were not copied from being marked as played.