### PR TITLE
Added date to the pattern of "rename episode"

### DIFF
--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 _ = gpodder.gettext
 
 __title__ = _('Rename episodes after download')
-__description__ = _('Rename episodes to "<Episode Title>.<ext>" on download')
+__description__ = _('Rename episodes to "<Date>-<Episode Title>.<ext>" on download')
 __authors__ = 'Bernd Schlapsi <brot@gmx.info>, Thomas Perl <thp@gpodder.org>'
 __doc__ = 'http://wiki.gpodder.org/wiki/Extensions/RenameAfterDownload'
 __payment__ = 'https://flattr.com/submit/auto?user_id=BerndSch&url=http://wiki.gpodder.org/wiki/Extensions/RenameAfterDownload'
@@ -28,19 +28,19 @@ class gPodderExtension:
     def on_episode_downloaded(self, episode):
         current_filename = episode.local_filename(create=False)
 
-        new_filename = self.make_filename(current_filename, episode.title)
+        new_filename = self.make_filename(current_filename, episode.title, episode.sortdate + '-')
 
         if new_filename != current_filename:
             logger.info('Renaming: %s -> %s', current_filename, new_filename)
             os.rename(current_filename, new_filename)
             util.rename_episode_file(episode, new_filename)
 
-    def make_filename(self, current_filename, title):
+    def make_filename(self, current_filename, title, sortdate = ''):
         dirname = os.path.dirname(current_filename)
         filename = os.path.basename(current_filename)
         basename, ext = os.path.splitext(filename)
 
-        new_basename = util.sanitize_encoding(title) + ext
+        new_basename = sortdate + util.sanitize_encoding(title) + ext
         # On Windows, force ASCII encoding for filenames (bug 1724)
         new_basename = util.sanitize_filename(new_basename,
                 use_ascii=gpodder.ui.win32)


### PR DESCRIPTION
Post download extension rename_download.py:
* Added date (in ISO 8601 format) to the new filename pattern.

Reasoning: if podcast maintainer doesn't add a sequenced number to the title, the episodes won't be in chronological order in the filesystem. ISO 8601 makes it easily sortable.

I reported this as feature request https://bugs.gpodder.org/show_bug.cgi?id=2031.