### PR TITLE
Add 'set_artist_to_album' config option to 'tagging' extension.

### DIFF
--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -55,6 +55,7 @@ DefaultConfig = {
     'genre_tag': 'Podcast',
     'always_remove_tags': False,
     'auto_embed_coverart': False,
+    'set_artist_to_album': False,
 }
 
 
@@ -90,6 +91,9 @@ class AudioFile(object):
 
         if self.pubDate is not None:
             audio.tags['date'] = self.pubDate
+
+        if self.container.config.set_artist_to_album:
+            audio.tags['artist'] = self.album
 
         audio.save()
 


### PR DESCRIPTION
Effect of this new setting is to set the 'artist' tag equivalent to whatever the 'album' tag value is.

Signed-off-by: Brian J. Cohen <brian@intercarve.net>