### PR TITLE
Use html5lib to find hyperlinks in the HTML of podcast show notes

### DIFF
--- a/README
+++ b/README
@@ -55,6 +55,7 @@
     - Native OS X support: ige-mac-integration
     - MP3 Player Sync Support: python-eyed3 (0.7 or newer)
     - iPod Sync Support: python-gpod
+    - Clickable links in GTK UI show notes: html5lib
 
 
  [ BUILD DEPENDENCIES ]

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -115,6 +115,7 @@ class gPodderShownotesText(gPodderShownotes):
         self.text_view.set_border_width(10)
         self.text_view.set_editable(False)
         self.text_view.connect('button-release-event', self.on_button_release)
+        self.text_view.connect('key-press-event', self.on_key_press)
         self.text_buffer = gtk.TextBuffer()
         self.text_buffer.create_tag('heading', scale=pango.SCALE_LARGE, weight=pango.WEIGHT_BOLD)
         self.text_buffer.create_tag('subheading', scale=pango.SCALE_SMALL)
@@ -145,6 +146,17 @@ class gPodderShownotesText(gPodderShownotes):
 
     def on_button_release(self, widget, event):
         if event.button == 1:
+            self.activate_links()
+
+    def on_key_press(self, widget, event):
+        if gtk.gdk.keyval_name(event.keyval) == 'Return':
+            self.activate_links()
+            return True
+
+        return False
+
+    def activate_links(self):
+        if self.text_buffer.get_selection_bounds() == ():
             pos = self.text_buffer.props.cursor_position
             target = next((url for start, end, url in self.hyperlinks if start < pos < end), None)
             if target is not None:

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import webbrowser
 import gtk
 import gtk.gdk
 import gobject
@@ -151,4 +150,4 @@ class gPodderShownotesText(gPodderShownotes):
                 i += 1
             target = self.hyperlinks[i][1]
             if target is not None:
-                webbrowser.open(target)
+                util.open_website(target)

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -720,9 +720,8 @@ class HyperlinkExtracter(object):
 
 
 class ExtractHyperlinkedText(object):
-    def __call__(self, html):
+    def __call__(self, document):
         self.extracter = HyperlinkExtracter()
-        document = html5lib.parseFragment(html)
         self.visit(document)
         return self.extracter.get_result()
 
@@ -780,7 +779,7 @@ def extract_hyperlinked_text(html):
         return [(None, html)]
 
     if html5lib is not None:
-        return ExtractHyperlinkedText()(html)
+        return ExtractHyperlinkedText()(html5lib.parseFragment(html))
     else:
         return ExtractHyperlinkedText2()(html)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -704,7 +704,7 @@ class ExtractHyperlinkedText(object):
             [(None, '\n\n')])
 
 
-def extract_hyperlinked_text(html):
+def extract_hyperlinked_text_1(html):
     """
     Convert HTML to hyperlinked text.
 
@@ -722,6 +722,11 @@ def extract_hyperlinked_text(html):
                 (None, util.remove_html_tags(html))]
     document = html5lib.parseFragment(html)
     return ExtractHyperlinkedText()(document)
+
+
+def extract_hyperlinked_text(html):
+    a = extract_hyperlinked_text_1(html)
+    return a
 
 
 def wrong_extension(extension):

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -727,8 +727,7 @@ def extract_hyperlinked_text_1(html):
     try:
         import html5lib
     except ImportError:
-        return [(None, 'Could not import html5lib\n'),
-                (None, remove_html_tags(html))]
+        return [(None, remove_html_tags(html))]
     document = html5lib.parseFragment(html)
     return ExtractHyperlinkedText()(document)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -728,7 +728,7 @@ def extract_hyperlinked_text_1(html):
         import html5lib
     except ImportError:
         return [(None, 'Could not import html5lib\n'),
-                (None, util.remove_html_tags(html))]
+                (None, remove_html_tags(html))]
     document = html5lib.parseFragment(html)
     return ExtractHyperlinkedText()(document)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -76,6 +76,12 @@ else:
     from html.parser import HTMLParser
     from html.entities import name2codepoint
 
+try:
+    import html5lib
+except ImportError:
+    logger.warn('html5lib not found, falling back to HTMLParser')
+    html5lib = None
+
 if gpodder.ui.win32:
     try:
         import win32file

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -71,8 +71,10 @@ import collections
 
 if sys.hexversion < 0x03000000:
     from HTMLParser import HTMLParser
+    from htmlentitydefs import name2codepoint
 else:
     from html.parser import HTMLParser
+    from html.entities import name2codepoint
 
 if gpodder.ui.win32:
     try:
@@ -793,6 +795,17 @@ class ExtractHyperlinkedText2(HTMLParser):
 
     def handle_data(self, data):
         self.output(self.htmlws(data))
+
+    def handle_entityref(self, name):
+        c = unichr(name2codepoint[name])
+        self.output(c)
+
+    def handle_charref(self, name):
+        if name.startswith('x'):
+            c = unichr(int(name[1:], 16))
+        else:
+            c = unichr(int(name))
+        self.output(c)
 
     def output_newline(self, attrs=None):
         self.output('\n')

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -820,6 +820,42 @@ def extract_hyperlinked_text_2(html):
 
 def extract_hyperlinked_text(html):
     a = extract_hyperlinked_text_1(html)
+    b = extract_hyperlinked_text_2(html)
+    if a == b:
+        print("extract_hyperlinked_text: Same output")
+    else:
+        from pprint import pprint
+        pprint(a)
+        pprint(b)
+        print("extract_hyperlinked_text: Different output")
+
+        def words(parts):
+            return [(target, word)
+                    for target, text in parts
+                    for word in re.findall(ur'\S+\s*', text)]
+
+        from difflib import SequenceMatcher
+        d = SequenceMatcher()
+        a_w = words(a)
+        b_w = words(b)
+        d.set_seqs(a_w, b_w)
+
+        def smash(parts):
+            group_it = itertools.groupby(parts, key=lambda x: x[0])
+            r = []
+            for target, p in group_it:
+                r.append((target, ''.join(x[1] for x in p)))
+            return r
+
+        for tag, i1, i2, j1, j2 in d.get_opcodes():
+            if tag == 'equal':
+                continue
+            if i1 != i2:
+                print('a[%d:%d] =' % (i1, i2))
+                pprint(smash(a_w[i1:i2]))
+            if j1 != j2:
+                print('b[%d:%d] =' % (j1, j2))
+                pprint(smash(b_w[j1:j2]))
     return a
 
 


### PR DESCRIPTION
Some podcasts use HTML hyperlinks in the show notes, but currently gPodder strips away all HTML, including the hyperlinks, leaving just uninteractive text.

This patch adds HTML hyperlink handling by parsing the HTML with html5lib and walking the DOM tree to produce a plain text string with markers to indicate where the hyperlinks are and what they point to. When the TextView rendering the show notes is clicked, the cursor position is used to determine if the user has clicked on a link, in which case the web browser is launched using the [webbrowser.open](https://docs.python.org/2/library/webbrowser.html) from the Python standard library.

The style of Visitor class (ExtractHyperlinkedText in the patch) should be familiar to anyone who has used the [ast.NodeVisitor class](https://docs.python.org/2/library/ast.html#ast.NodeVisitor) in the Python standard library.