### PR TITLE
Fix notifications when unicode characters

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1424,7 +1424,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         finished_downloads = [unicode(task)
                 for task in download_tasks if task.notify_as_finished()]
-        failed_downloads = ['%s (%s)' % (str(task), task.error_message)
+        failed_downloads = ['%s (%s)' % (task, task.error_message)
                 for task in download_tasks if task.notify_as_failed()]
 
         sync_tasks = filter_by_activity(download.DownloadTask.ACTIVITY_SYNCHRONIZE,
@@ -1449,15 +1449,15 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.show_message(message, _('Downloads failed'))
 
         if finished_syncs and failed_syncs:
-            message = self.format_episode_list(map((lambda task: str(task)),finished_syncs), 5)
+            message = self.format_episode_list(map((lambda task: unicode(task)),finished_syncs), 5)
             message += '\n\n<i>%s</i>\n' % _('Could not sync some episodes:')
-            message += self.format_episode_list(map((lambda task: str(task)),failed_syncs), 5)
+            message += self.format_episode_list(map((lambda task: unicode(task)),failed_syncs), 5)
             self.show_message(message, _('Device synchronization finished'), True)
         elif finished_syncs:
-            message = self.format_episode_list(map((lambda task: str(task)),finished_syncs))
+            message = self.format_episode_list(map((lambda task: unicode(task)),finished_syncs))
             self.show_message(message, _('Device synchronization finished'))
         elif failed_syncs:
-            message = self.format_episode_list(map((lambda task: str(task)),failed_syncs))
+            message = self.format_episode_list(map((lambda task: unicode(task)),failed_syncs))
             self.show_message(message, _('Device synchronization failed'), True)
 
         # Do post-sync processing if required


### PR DESCRIPTION
When an episode has a unicode character in its title, notifications related to the episode fail and an exception dialog is displayed instead.

### Dialog

> Unhandled exception
>
> Please report this problem and restart gPodder:
>
> 'ascii' codec can't encode character u'\u201c' in position 13: ordinal not in range(128)

### Stacktrace
> Traceback (most recent call last):
  File "/home/user/dev/gpodder/src/gpodder/download.py", line 772, in run
    self.tempname, reporthook=self.status_updated)
  File "/home/user/dev/gpodder/src/gpodder/download.py", line 274, in retrieve_resume
    fp = self.open(url, data)
  File "/usr/lib/python2.7/urllib.py", line 213, in open
    return getattr(self, name)(url)
  File "/usr/lib/python2.7/urllib.py", line 350, in open_http
    h.endheaders(data)
  File "/usr/lib/python2.7/httplib.py", line 1053, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 897, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 859, in send
    self.connect()
  File "/usr/lib/python2.7/httplib.py", line 836, in connect
    self.timeout, self.source_address)
  File "/usr/lib/python2.7/socket.py", line 557, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
IOError: [Errno socket error] [Errno -3] Temporary failure in name resolution
1479185435.108479 [gpodder.gtkui.main] ERROR: Exception happened while updating download list.
Traceback (most recent call last):
  File "/home/user/dev/gpodder/src/gpodder/gtkui/main.py", line 1217, in update_downloads_list
    self.downloads_finished(self.download_tasks_seen)
  File "/home/user/dev/gpodder/src/gpodder/gtkui/main.py", line 1428, in downloads_finished
    for task in download_tasks if task.notify_as_failed()]
UnicodeEncodeError: 'ascii' codec can't encode character u'\u201c' in position 13: ordinal not in range(128)

### Steps to reproduce:
1. Add this podcast: http://feeds.megaphone.fm/aboutrace
2. Disable network
3. Try do download episode #1643-B (NB. Episode title contains unicode smart quotes)


There are a number of other instances of `str` being used on error messages that I speculate could include could include the episode title; however, as I am not very familiar with it, I only changed uses directly related to getting the string representation of a task.