### PR TITLE
Allow reordering of the download queue

### DIFF
--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -371,7 +371,7 @@
                             <property name="headers_visible">False</property>
                             <property name="rules_hint">False</property>
                             <property name="rubber-banding">True</property>
-                            <property name="reorderable">False</property>
+                            <property name="reorderable">True</property>
                             <property name="enable_search">True</property>
                             <property name="fixed_height_mode">False</property>
                             <property name="hover_selection">False</property>

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -337,16 +337,10 @@ class DownloadURLOpener(urllib.FancyURLopener):
 
 
 class DownloadQueueWorker(object):
-    def __init__(self, queue, exit_callback, continue_check_callback, minimum_tasks):
+    def __init__(self, queue, exit_callback, continue_check_callback):
         self.queue = queue
         self.exit_callback = exit_callback
         self.continue_check_callback = continue_check_callback
-
-        # The minimum amount of tasks that should be downloaded by this worker
-        # before using the continue_check_callback to determine if it might
-        # continue accepting tasks. This can be used to forcefully start a
-        # download, even if a download limit is in effect.
-        self.minimum_tasks = minimum_tasks
 
     def __repr__(self):
         return threading.current_thread().getName()
@@ -354,28 +348,37 @@ class DownloadQueueWorker(object):
     def run(self):
         logger.info('Starting new thread: %s', self)
         while True:
-            # Check if this thread is allowed to continue accepting tasks
-            # (But only after reducing minimum_tasks to zero - see above)
-            if self.minimum_tasks > 0:
-                self.minimum_tasks -= 1
-            elif not self.continue_check_callback(self):
+            if not self.continue_check_callback(self):
                 return
 
             try:
-                task = self.queue.pop()
+                task = self.queue.get_next()
                 logger.info('%s is processing: %s', self, task)
                 task.run()
                 task.recycle()
-            except IndexError, e:
+            except StopIteration, e:
                 logger.info('No more tasks for %s to carry out.', self)
                 break
         self.exit_callback(self)
 
 
+class ForceDownloadWorker(object):
+    def __init__(self, task):
+        self.task = task
+
+    def __repr__(self):
+        return threading.current_thread().getName()
+
+    def run(self):
+        logger.info('Starting new thread: %s', self)
+        logger.info('%s is processing: %s', self, self.task)
+        self.task.run()
+
+
 class DownloadQueueManager(object):
-    def __init__(self, config):
+    def __init__(self, config, queue):
         self._config = config
-        self.tasks = collections.deque()
+        self.tasks = queue
 
         self.worker_threads_access = threading.RLock()
         self.worker_threads = []
@@ -393,61 +396,37 @@ class DownloadQueueManager(object):
             else:
                 return True
 
-    def spawn_threads(self, force_start=False):
+    def __spawn_threads(self):
         """Spawn new worker threads if necessary
-
-        If force_start is True, forcefully spawn a thread and
-        let it process at least one episodes, even if a download
-        limit is in effect at the moment.
         """
         with self.worker_threads_access:
-            if not len(self.tasks):
+            if not self.tasks.has_work():
                 return
 
-            if force_start or len(self.worker_threads) == 0 or \
+            if len(self.worker_threads) == 0 or \
                     len(self.worker_threads) < self._config.max_downloads or \
                     not self._config.max_downloads_enabled:
                 # We have to create a new thread here, there's work to do
                 logger.info('Starting new worker thread.')
 
-                # The new worker should process at least one task (the one
-                # that we want to forcefully start) if force_start is True.
-                if force_start:
-                    minimum_tasks = 1
-                else:
-                    minimum_tasks = 0
-
                 worker = DownloadQueueWorker(self.tasks, self.__exit_callback,
-                        self.__continue_check_callback, minimum_tasks)
+                        self.__continue_check_callback)
                 self.worker_threads.append(worker)
                 util.run_in_background(worker.run)
 
-    def are_queued_or_active_tasks(self):
-        with self.worker_threads_access:
-            return len(self.worker_threads) > 0
+    def update_max_downloads(self):
+        self.__spawn_threads()
 
-    def add_task(self, task, force_start=False):
-        """Add a new task to the download queue
+    def force_start_task(self, task):
+        if self.tasks.set_downloading(task):
+            worker = ForceDownloadWorker(task)
+            util.run_in_background(worker.run)
 
-        If force_start is True, ignore the download limit
-        and forcefully start the download right away.
+    def queue_task(self, task):
+        """Marks a task as queued
         """
-        if task.status != DownloadTask.INIT:
-            # Remove the task from its current position in the
-            # download queue (if any) to avoid race conditions
-            # where two worker threads download the same file
-            try:
-                self.tasks.remove(task)
-            except ValueError, e:
-                pass
         task.status = DownloadTask.QUEUED
-        if force_start:
-            # Add the task to be taken on next pop
-            self.tasks.append(task)
-        else:
-            # Add the task to the end of the queue
-            self.tasks.appendleft(task)
-        self.spawn_threads(force_start)
+        self.__spawn_threads()
 
 
 class DownloadTask(object):
@@ -739,8 +718,8 @@ class DownloadTask(object):
             self.speed = 0.0
             return False
 
-        # We only start this download if its status is "queued"
-        if self.status != DownloadTask.QUEUED:
+        # We only start this download if its status is "downloading"
+        if self.status != DownloadTask.DOWNLOADING:
             return False
 
         # We are downloading this file right now

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -226,7 +226,7 @@ class Device(services.ObservableService):
                 sync_task.status=sync_task.QUEUED
                 sync_task.device=self
                 self.download_status_model.register_task(sync_task)
-                self.download_queue_manager.add_task(sync_task)
+                self.download_queue_manager.queue_task(sync_task)
         else:
             logger.warning("No episodes to sync")
 


### PR DESCRIPTION
gPodder does not allow reordering of the download queue. If a user wants to prioritize the download of a particular episode, they must do one of the following:

 - Queue the downloads in the desired download order
    - This is tedious and does not work if the user wants to use the "Download new episodes" dialog
 - Pause the downloads and resume them in the desired order
    - This is tedious and the set download order is not visible to the user.
 - Force start the desired priority downloads
    - This goes around the concurrent download limit so does not scale well.

This provides the following behavior changes in an effort to provide a better way for users to prioritize or de-prioritze a download:
 - Allows a user to reorder the download queue via the context menu (allows reordering a selection) or by clicking and dragging a row (only one row at a time, NB. on my system, GTK seems to make it really easy to accidentally do a multi-select rather than a click-and-drag for reorder on a row).
 - Makes gPodder respect the queue order in the UI when starting downloads.