### PR TITLE
YouTube Show Image Sometimes Low-Res

### DIFF
--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -213,14 +213,17 @@ def get_real_cover(url):
         try:
             api_url = 'https://www.youtube.com/channel/{0}'.format(channel)
             data = util.urlopen(api_url).read()
-            m = re.search('<img class="channel-header-profile-image"[^>]* src=[\'"]([^\'"]+)[\'"][^>]*>', data)
+            # Look for 900x900px image first.
+            m = re.search('<link rel="image_src"[^>]* href=[\'"]([^\'"]+)[\'"][^>]*>', data)
+            if m is None:
+                # Fallback to image that may only be 100x100px.
+                m = re.search('<img class="channel-header-profile-image"[^>]* src=[\'"]([^\'"]+)[\'"][^>]*>', data)
             if m is not None:
                 logger.debug('YouTube userpic for %s is: %s', url, m.group(1))
                 return m.group(1)
         except Exception as e:
             logger.warn('Could not retrieve cover art', exc_info=True)
             return None
-
 
         return None
 


### PR DESCRIPTION
The link being parsed for the YouTube cover art image is sometimes only 100x100px, it appears to be inconsistent from show to show, sometimes 100x100, and sometimes 900x900px.  There is a link in the channel page source that appears to always have a 900x900px image.

This change looks for the "new" link first, to grab the higher quality image.  If not found it falls back to the original link.

Here are two examples of YouTube channels showing the links to the two different sized images:

The Ben Heck Show
https://www.youtube.com/user/thebenheckshow

Element 14
https://www.youtube.com/user/element14