### PR TITLE
remove pre-python 2.6 compat code

### DIFF
--- a/src/gpodder/escapist_videos.py
+++ b/src/gpodder/escapist_videos.py
@@ -30,12 +30,7 @@ from gpodder import util
 import logging
 logger = logging.getLogger(__name__)
 
-try:
-    # For Python < 2.6, we use the "simplejson" add-on module
-    import simplejson as json
-except ImportError:
-    # Python 2.6 already ships with a nice "json" module
-    import json
+import json
 
 import re
 import urllib.request, urllib.parse, urllib.error

--- a/src/gpodder/gtkui/desktop/episodeselector.py
+++ b/src/gpodder/gtkui/desktop/episodeselector.py
@@ -19,7 +19,6 @@
 
 from gi.repository import Gtk
 from gi.repository import Pango
-import cgi
 
 import gpodder
 

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -22,7 +22,6 @@ from gi.repository import Gdk
 from gi.repository import GObject
 from gi.repository import Pango
 import os
-import cgi
 
 
 import gpodder

--- a/src/gpodder/jsonconfig.py
+++ b/src/gpodder/jsonconfig.py
@@ -26,12 +26,7 @@
 import copy
 from functools import reduce
 
-try:
-    # For Python < 2.6, we use the "simplejson" add-on module
-    import simplejson as json
-except ImportError:
-    # Python 2.6 already ships with a nice "json" module
-    import json
+import json
 
 
 class JsonConfigSubtree(object):

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -28,12 +28,7 @@ _ = gpodder.gettext
 from gpodder import model
 from gpodder import util
 
-try:
-    # For Python < 2.6, we use the "simplejson" add-on module
-    import simplejson as json
-except ImportError:
-    # Python 2.6 already ships with a nice "json" module
-    import json
+import json
 
 import os
 import time

--- a/src/gpodder/vimeo.py
+++ b/src/gpodder/vimeo.py
@@ -32,12 +32,7 @@ from gpodder import util
 import logging
 logger = logging.getLogger(__name__)
 
-try:
-    # For Python < 2.6, we use the "simplejson" add-on module
-    import simplejson as json
-except ImportError:
-    # Python 2.6 already ships with a nice "json" module
-    import json
+import json
 
 import re
 

--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -30,20 +30,12 @@ import os.path
 import logging
 logger = logging.getLogger(__name__)
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
 
 import re
 import urllib.request, urllib.parse, urllib.error
 
-try:
-    # Python >= 2.6
-    from urllib.parse import parse_qs
-except ImportError:
-    # Python < 2.6
-    from cgi import parse_qs
+from urllib.parse import parse_qs
 
 # http://en.wikipedia.org/wiki/YouTube#Quality_and_codecs
 # format id, (preferred ids, path(?), description) # video bitrate, audio bitrate


### PR DESCRIPTION
Also removed unused cgi imports.

By the way, cgi.escape is deprecated in favor of html.escape, because it escapes quotes also, to prevent html injection in attributes. None of our uses is affected, but I'd recommend moving to html.escape. Thoughts?