### PR TITLE
fix another stray str call

### DIFF
--- a/src/gpodder/gtkui/desktop/podcastdirectory.py
+++ b/src/gpodder/gtkui/desktop/podcastdirectory.py
@@ -72,7 +72,7 @@ class DirectoryPodcastsModel(Gtk.ListStore):
         self.callback_can_subscribe(len(self.get_selected_podcasts()) > 0)
 
     def get_selected_podcasts(self):
-        return [(str(row[self.C_TITLE],'utf8'), row[self.C_URL]) for row in self if row[self.C_SELECTED]]
+        return [(row[self.C_TITLE], row[self.C_URL]) for row in self if row[self.C_SELECTED]]
 
 
 class DirectoryProvidersModel(Gtk.ListStore):


### PR DESCRIPTION
I'm not sure if all the calls like
```
        track.title = str(episode.title)
        track.album = str(episode.channel.title)
        track.artist = str(episode.channel.title)
```
in  ̀sync.py` are necessary. Otherwise, no more unicode related errors, I hope.