### PR TITLE
Update SoundCloud-Feeds with Pagination

### DIFF
--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -136,7 +136,7 @@ class SoundcloudUser(object):
             json_url = 'http://api.soundcloud.com/users/%(user)s/%(feed)s.json?filter=downloadable&consumer_key=%(consumer_key)s&limit=50&linked_partitioning=1' \
                     % { "user":self.username, "feed":feed, "consumer_key": CONSUMER_KEY }
 
-            while not json_url == '':
+            while json_url != '':
                 result = json.load(util.urlopen(json_url))
                 json_url = result.get('next_href', '')
                 tracks = (track for track in result['collection'] \


### PR DESCRIPTION
This uses Pagination as per the SoundCloud API: https://developers.soundcloud.com/docs/api/guide#pagination to get all episodes of a feed. See Issue #180.
I don't know if this needs to respect the max_episodes_per_feed-setting. If so, could someone point me to how i can get the value of that setting?