### PR TITLE
Further changes to support the switch to Python 3

### DIFF
--- a/share/gpodder/examples/hello_world.py
+++ b/share/gpodder/examples/hello_world.py
@@ -21,15 +21,15 @@ class gPodderExtension:
     # into various parts of gPodder.
     def on_load(self):
         logger.info('Extension is being loaded.')
-        print '='*40
-        print 'container:', self.container
-        print 'container.manager:', self.container.manager
-        print 'container.config:', self.container.config
-        print 'container.manager.core:', self.container.manager.core
-        print 'container.manager.core.db:', self.container.manager.core.db
-        print 'container.manager.core.config:', self.container.manager.core.config
-        print 'container.manager.core.model:', self.container.manager.core.model
-        print '='*40
+        print('='*40)
+        print('container:', self.container)
+        print('container.manager:', self.container.manager)
+        print('container.config:', self.container.config)
+        print('container.manager.core:', self.container.manager.core)
+        print('container.manager.core.db:', self.container.manager.core.db)
+        print('container.manager.core.config:', self.container.manager.core.config)
+        print('container.manager.core.model:', self.container.manager.core.model)
+        print('='*40)
 
     # This function will be called when the extension is disabled or
     # when gPodder shuts down. You can use this to destroy/delete any

--- a/share/gpodder/extensions/rm_ogg_cover.py
+++ b/share/gpodder/extensions/rm_ogg_cover.py
@@ -94,6 +94,6 @@ class gPodderExtension:
             if found:
                 logger.info('Removed cover art from OGG file: %s', filename)
                 ogg.save()
-        except Exception, e:
+        except Exception as e:
             logger.warn('Failed to remove OGG cover: %s', e, exc_info=True)
 

--- a/share/gpodder/extensions/ted_subtitles.py
+++ b/share/gpodder/extensions/ted_subtitles.py
@@ -58,7 +58,7 @@ class gPodderExtension(object):
     def get_data_from_url(self, url):
         try:
             response = util.urlopen(url).read()
-        except Exception, e:
+        except Exception as e:
             logger.warn("subtitle url returned error %s", e)
             return ''
         return response
@@ -93,7 +93,7 @@ class gPodderExtension(object):
             intro = episode_data.split('introDuration":')[1] \
                                 .split(',')[0] or INTRO_DEFAULT
             intro = int(float(intro)*1000)
-        except (ValueError, IndexError), e:
+        except (ValueError, IndexError) as e:
             logger.info("Couldn't parse introDuration string: %s", intro)
             intro = INTRO_DEFAULT * 1000
         current_filename = episode.local_filename(create=False)
@@ -103,7 +103,7 @@ class gPodderExtension(object):
         try:
             with open(srt_filename, 'w+') as srtFile:
                 srtFile.write(sub.encode("utf-8"))
-        except Exception, e:
+        except Exception as e:
             logger.warn("Can't write srt file: %s",e)
 
     def on_episode_delete(self, episode, filename):

--- a/share/gpodder/extensions/ubuntu_unity.py
+++ b/share/gpodder/extensions/ubuntu_unity.py
@@ -53,7 +53,7 @@ if __name__ != '__main__':
             try:
                 self.process.stdin.write('progress %f\n' % progress)
                 self.process.stdin.flush()
-            except Exception, e:
+            except Exception as e:
                 logger.debug('Ubuntu progress update failed.', exc_info=True)
 else:
     from gi.repository import Unity, GObject

--- a/src/gpodder/__init__.py
+++ b/src/gpodder/__init__.py
@@ -47,7 +47,7 @@ except ImportError:
   From a source checkout, you can download local copies of all
   CLI dependencies for debugging (will be placed into "src/"):
 
-      python tools/localdepends.py
+      python3 tools/localdepends.py
 """)
     sys.exit(1)
 del podcastparser
@@ -63,7 +63,7 @@ except ImportError:
   From a source checkout, you can download local copies of all
   CLI dependencies for debugging (will be placed into "src/"):
 
-      python tools/localdepends.py
+      python3 tools/localdepends.py
 """)
     sys.exit(1)
 del mygpoclient

--- a/tools/i18n/summary.py
+++ b/tools/i18n/summary.py
@@ -47,15 +47,15 @@ for filename in glob.glob(os.path.join(po_folder, '*.po')):
     match = re.match(COUNTS_RE, stderr).groups()
     languages.append(Language(language, match[1] or '0', match[3] or '0', match[5] or '0'))
 
-print ''
+print('')
 for language in sorted(languages):
     tc = '#'*(int(math.floor(width*language.get_translated_ratio())))
     fc = '~'*(int(math.floor(width*language.get_fuzzy_ratio())))
     uc = ' '*(width-len(tc)-len(fc))
 
-    print ' %5s [%s%s%s] -- %3.0f %% translated' % (language.language, tc, fc, uc, language.get_translated_ratio()*100)
+    print(' %5s [%s%s%s] -- %3.0f %% translated' % (language.language, tc, fc, uc, language.get_translated_ratio()*100))
 
-print """
+print("""
   Total translations: %s
-""" % (len(languages))
+""" % (len(languages)))
 

--- a/tools/test-auth-server.py
+++ b/tools/test-auth-server.py
@@ -77,21 +77,21 @@ class AuthRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             auth_data = m.group(1).decode('base64').split(':', 1)
             if len(auth_data) == 2:
                 username, password = auth_data
-                print 'Got username:', username
-                print 'Got password:', password
+                print('Got username:', username)
+                print('Got password:', password)
                 if (username, password) == (USERNAME, PASSWORD):
-                    print 'Valid credentials provided.'
+                    print('Valid credentials provided.')
                     authorized = True
 
         if self.path == self.FEEDFILE_PATH:
-            print 'Feed request.'
+            print('Feed request.')
             is_feed = True
         elif self.path.startswith(self.EPISODES_PATH):
-            print 'Episode request.'
+            print('Episode request.')
             is_episode = True
 
         if not authorized:
-            print 'Not authorized - sending WWW-Authenticate header.'
+            print('Not authorized - sending WWW-Authenticate header.')
             self.send_response(401)
             self.send_header('WWW-Authenticate',
                     'Basic realm="%s"' % sys.argv[0])
@@ -109,11 +109,11 @@ class AuthRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 if __name__ == '__main__':
     httpd = BaseHTTPServer.HTTPServer((HOST, PORT), AuthRequestHandler)
-    print """
+    print("""
     Feed URL: %(URL)s/%(FEEDFILE)s
     Username: %(USERNAME)s
     Password: %(PASSWORD)s
-    """ % locals()
+    """ % locals())
     while True:
         httpd.handle_request()
 


### PR DESCRIPTION
After hitting one issue at runtime, I fixed everything found by the command:
>`python3 -m compileall .`

I don't know if there is better tools to be using or if it is too late for something like `2to3` to be of any use.

Also, I note that the version of `mygpoclient` fetched by `python3 tools/localdepends.py` are not compatibly.  Once I manually populated that dependency for the time being, it can at least get as far as launching.