### PR TITLE
Fix detection of wireless interfaces in FreeBSD

### DIFF
--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1833,7 +1833,7 @@ def unix_get_active_interfaces():
     process = subprocess.Popen(['ifconfig'], stdout=subprocess.PIPE)
     stdout, _ = process.communicate()
     for i in re.split('\n(?!\t)', stdout, re.MULTILINE):
-        b = re.match('(\\w+):.*status: active$', i, re.MULTILINE | re.DOTALL)
+        b = re.match('(\\w+):.*status: (active|associated)$', i, re.MULTILINE | re.DOTALL)
         if b:
             yield b.group(1)
 


### PR DESCRIPTION
At least in FreeBSD status of wireless interface is show as

status: associated

not

status: active

So unix_get_active_interfaces() routine fails here. Add 'associated' to regex
to fix up things.