### PR TITLE
Fix unicode renaming problems

### DIFF
--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -3,6 +3,10 @@
 # Copyright (c) 2011-04-04 Thomas Perl <thp.io>
 # Licensed under the same terms as gPodder itself
 
+import sys
+reload(sys)
+sys.setdefaultencoding("utf-8")
+
 import os
 
 import gpodder


### PR DESCRIPTION
I'm assuming that this is not the correct way to fix this, but I'm submitting it as a pull request rather than an issue because this was the hack I found on stackoverflow that fixed the problem for me.  The download renaming extension fails >75% of the time due to unicode errors, even when there are no obviously unusual characters.  The traceback follows the format:

```
[gpodder.extensions] ERROR: Error in /usr/share/gpodder/extensions/rename_download.py in on_episode_downloaded: 'ascii' codec can't decode byte 0xe2 in position 11: ordinal not in range(128)
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/gpodder/extensions.py", line 83, in handler
    cb_res = callback(*args, **kwargs)
  File "/usr/share/gpodder/extensions/rename_download.py", line 38, in on_episode_downloaded
    episode.sortdate, episode.channel.title)
  File "/usr/share/gpodder/extensions/rename_download.py", line 56, in make_filename
    new_basename = ' - '.join(new_basename)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 11: ordinal not in range(128)
```

Again, I know minimal python, but I do know that this technically fixes the problem, so if this PR could be done the right way and added it would be greatly appreciated.