### PR TITLE
python 3.6 SQLite compat vacuum in transaction

### DIFF
--- a/src/gpodder/dbsqlite.py
+++ b/src/gpodder/dbsqlite.py
@@ -55,9 +55,9 @@ class Database(object):
         self.commit()
 
         with self.lock:
-            cur = self.cursor()
-            cur.execute("VACUUM")
-            cur.close()
+            self.db.isolation_level = None
+            self.db.execute('VACUUM')
+            self.db.isolation_level = ''
 
         self._db.close()
         self._db = None

--- a/src/gpodder/minidb.py
+++ b/src/gpodder/minidb.py
@@ -66,7 +66,9 @@ class Store(object):
 
     def close(self):
         with self.lock:
+            self.db.isolation_level = None
             self.db.execute('VACUUM')
+            self.db.isolation_level = ''
             self.db.close()
 
     def _register(self, class_):


### PR DESCRIPTION
fixes a blocking exception on exit:
sqlite3.OperationalError: cannot VACUUM from within a transaction.
Solution comes from https://bugs.python.org/issue28518