### PR TITLE
gtk3: Html shownotes

### DIFF
--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -148,7 +148,7 @@ defaults = {
                 'remove_finished': True,
             },
 
-            'html_shownotes': True # enable webkit renderer
+            'html_shownotes': True,  # enable webkit renderer
         },
     },
 

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -147,6 +147,8 @@ defaults = {
             'download_list': {
                 'remove_finished': True,
             },
+
+            'html_shownotes': True # enable webkit renderer
         },
     },
 

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -135,7 +135,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.config.add_observer(self.on_config_changed)
 
         self.shownotes_pane = Gtk.Box()
-        self.shownotes_object = shownotes.gPodderShownotesText(self.shownotes_pane)
+        self.shownotes_object = shownotes.get_shownotes(self.config.ui.gtk.html_shownotes, self.shownotes_pane)
 
         # Vertical paned for the episode list and shownotes
         self.vpaned = Gtk.Paned(orientation=Gtk.Orientation.VERTICAL)

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -144,8 +144,7 @@ class PodcastEpisode(PodcastModelObject):
         episode.guid = entry['guid']
         episode.title = entry['title']
         episode.link = entry['link']
-        episode.description = entry.get('description_html',
-                                        entry.get('description'))
+        episode.description = entry.get('description_html', entry.get('description'))
         episode.total_time = entry['total_time']
         episode.published = entry['published']
         episode.payment_url = entry['payment_url']

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -144,7 +144,8 @@ class PodcastEpisode(PodcastModelObject):
         episode.guid = entry['guid']
         episode.title = entry['title']
         episode.link = entry['link']
-        episode.description = entry['description']
+        episode.description = entry.get('description_html',
+                                        entry.get('description'))
         episode.total_time = entry['total_time']
         episode.published = entry['published']
         episode.payment_url = entry['payment_url']


### PR DESCRIPTION
Working implementation of html shownotes rendered using webkit2.
 - headline and subheadline distinct component
 - no navigation  (maybe have to refine this for anchors in same page)
 - context-menu  item 'Open Link in Web Browser' on links
 - context-menu item 'Open Shownotes in Web Browser' on page background.