### PR TITLE
Python3: Do integer division

### DIFF
--- a/share/gpodder/extensions/mpris-listener.py
+++ b/share/gpodder/extensions/mpris-listener.py
@@ -199,8 +199,8 @@ class CurrentTrackTracker(object):
         return '%s: %s at %d/%d (@%f)' % (
             self.uri or 'None',
             self.status or 'None',
-            (self.pos or 0) / USECS_IN_SEC,
-            (self.length or 0) / USECS_IN_SEC,
+            (self.pos or 0) // USECS_IN_SEC,
+            (self.length or 0) // USECS_IN_SEC,
             self.rate or 0)
             
 class MPRISDBusReceiver(object):

--- a/share/gpodder/extensions/rockbox_convert2mp4.py
+++ b/share/gpodder/extensions/rockbox_convert2mp4.py
@@ -88,8 +88,8 @@ class gPodderExtension:
         if video_height is None:
             return None
 
-        width_ratio = device_width / video_width
-        height_ratio = device_height / video_height
+        width_ratio = device_width // video_width
+        height_ratio = device_height // video_height
 
         dest_width = device_width
         dest_height = width_ratio * video_height

--- a/src/gpodder/common.py
+++ b/src/gpodder/common.py
@@ -68,7 +68,7 @@ def find_partial_downloads(channels, start_progress_callback, progress_callback,
                 filename = episode.local_filename(create=False, check_only=True)
                 if filename in candidates:
                     found += 1
-                    progress_callback(episode.title, float(found)/count)
+                    progress_callback(episode.title, found/count)
                     candidates.remove(filename)
                     partial_files.remove(filename+'.partial')
 

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -288,7 +288,7 @@ class DownloadURLOpener(urllib.request.FancyURLopener):
         bs = 1024*8
         size = -1
         read = current_size
-        blocknum = int(current_size/bs)
+        blocknum = current_size//bs
         if reporthook:
             if "content-length" in headers:
                 size = int(headers['Content-Length'])  + current_size
@@ -599,7 +599,7 @@ class DownloadTask(object):
             try:
                 already_downloaded = os.path.getsize(self.tempname)
                 if self.total_size > 0:
-                    self.progress = max(0.0, min(1.0, float(already_downloaded)/self.total_size))
+                    self.progress = max(0.0, min(1.0, already_downloaded/self.total_size))
             except OSError as os_error:
                 logger.error('Cannot get size for %s', os_error)
         else:
@@ -645,7 +645,7 @@ class DownloadTask(object):
                 self.__episode.save()
 
         if self.total_size > 0:
-            self.progress = max(0.0, min(1.0, float(count*blockSize)/self.total_size))
+            self.progress = max(0.0, min(1.0, count*blockSize/self.total_size))
             if self._progress_updated is not None:
                 diff = time.time() - self._last_progress_updated
                 if diff > self.MIN_TIME_BETWEEN_UPDATES or self.progress == 1.:
@@ -694,7 +694,7 @@ class DownloadTask(object):
             if self._config.limit_rate and speed > self._config.limit_rate_value:
                 # calculate the time that should have passed to reach
                 # the desired download rate and wait if necessary
-                should_have_passed = float((count-self.__start_blocks)*blockSize)/(self._config.limit_rate_value*1024.0)
+                should_have_passed = (count-self.__start_blocks)*blockSize/(self._config.limit_rate_value*1024.0)
                 if should_have_passed > passed:
                     # sleep a maximum of 10 seconds to not cause time-outs
                     delay = min(10.0, float(should_have_passed-passed))

--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -97,7 +97,7 @@ def draw_text_box_centered(ctx, widget, w_width, w_height, text, font_desc=None,
     style_context = widget.get_style_context()
     text_color = style_context.get_color(Gtk.StateFlags.PRELIGHT)
     red, green, blue = text_color.red, text_color.green, text_color.blue
-    text_color = [float(x)/65535. for x in (red, green, blue)]
+    text_color = [x/65535. for x in (red, green, blue)]
     text_color.append(.5)
 
     if font_desc is None:
@@ -321,7 +321,7 @@ def progressbar_pixbuf(width, height, percentage):
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
     ctx = cairo.Context(surface)
 
-    padding = int(float(width)/8.0)
+    padding = int(width/8.0)
     bar_width = 2*padding
     bar_height = height - 2*padding
     bar_height_fill = bar_height*percentage

--- a/src/gpodder/gtkui/interface/tagcloud.py
+++ b/src/gpodder/gtkui/interface/tagcloud.py
@@ -64,8 +64,8 @@ class TagCloud(Gtk.Layout):
             self.relayout()
 
     def _scale(self, weight):
-        weight_range = float(self._max_weight-self._min_weight)
-        ratio = float(weight-self._min_weight)/weight_range
+        weight_range = self._max_weight-self._min_weight
+        ratio = (weight-self._min_weight)/weight_range
         return int(self._min_size + (self._max_size-self._min_size)*ratio)
 
     def relayout(self):
@@ -75,10 +75,10 @@ class TagCloud(Gtk.Layout):
         pw, ph = self._size
         def fixup_row(widgets, x, y, max_h):
             residue = (pw - x)
-            x = int(residue/2)
+            x = int(residue//2)
             for widget in widgets:
                 cw, ch = widget.size_request()
-                self.move(widget, x, y+max(0, int((max_h-ch)/2)))
+                self.move(widget, x, y+max(0, int(max_h-ch)//2))
                 x += cw + 10
         for child in self.get_children():
             w, h = child.size_request()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1202,7 +1202,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     percentage = 100.0*done_size/total_size
                 else:
                     percentage = 0.0
-                self.set_download_progress(percentage/100.)
+                self.set_download_progress(percentage/100)
                 total_speed = util.format_filesize(total_speed)
                 title[1] += ' (%d%%, %s/s)' % (percentage, total_speed)
             if synchronizing > 0:
@@ -1491,7 +1491,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             # so it may be cut correctly on UTF-8 char boundaries
             title = util.convert_bytes(title)
             if len(title) > MAX_TITLE_LENGTH:
-                middle = (MAX_TITLE_LENGTH/2)-2
+                middle = (MAX_TITLE_LENGTH//2)-2
                 title = '%s...%s' % (title[0:middle], title[-middle:])
             result.append(cgi.escape(title))
             result.append('\n')
@@ -2698,7 +2698,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
             episodes_status_update = []
             for idx, episode in enumerate(episodes):
-                progress.on_progress(float(idx)/float(len(episodes)))
+                progress.on_progress(idx/len(episodes))
                 if not episode.archive or not skip_locked:
                     progress.on_message(episode.title)
                     episode.delete_from_disk()
@@ -3097,7 +3097,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
             for idx, channel in enumerate(channels):
                 # Update the UI for correct status messages
-                progress.on_progress(float(idx)/float(len(channels)))
+                progress.on_progress(idx/len(channels))
                 progress.on_message(channel.title)
 
                 # Delete downloaded episodes
@@ -3588,8 +3588,8 @@ class gPodderApplication(Gtk.Application):
         self.set_app_menu(builder.get_object('app-menu'))
 
         for i in range(EpisodeListModel.PROGRESS_STEPS + 1):
-           pixbuf = draw_cake_pixbuf(float(i) /
-                   float(EpisodeListModel.PROGRESS_STEPS))
+           pixbuf = draw_cake_pixbuf(i /
+                   EpisodeListModel.PROGRESS_STEPS)
            icon_name = 'gpodder-progress-%d' % i
            Gtk.IconTheme.add_builtin_icon(icon_name, pixbuf.get_width(), pixbuf)
     

--- a/src/gpodder/gtkui/widgets.py
+++ b/src/gpodder/gtkui/widgets.py
@@ -110,8 +110,8 @@ class SpinningProgressIndicator(Gtk.Image):
             width, height = icon.get_width(), icon.get_height()
             if width < size or height < size:
                 size = min(width, height)
-            for row in range(height/size):
-                for column in range(width/size):
+            for row in range(height//size):
+                for column in range(width//size):
                     frame = icon.subpixbuf(column*size, row*size, size, size)
                     self._frames.append(frame)
             # Remove the first frame (the "idle" icon)

--- a/src/gpodder/query.py
+++ b/src/gpodder/query.py
@@ -69,7 +69,7 @@ class Matcher(object):
 
         # Nouns (for comparisons)
         if k in ('megabytes', 'mb'):
-            return float(episode.file_size) / (1024*1024)
+            return episode.file_size / (1024*1024)
         elif k == 'title':
             return episode.title
         elif k == 'description':
@@ -79,9 +79,9 @@ class Matcher(object):
         elif k == 'age':
             return episode.age_in_days()
         elif k in ('minutes', 'min'):
-            return float(episode.total_time) / 60
+            return episode.total_time / 60
         elif k in ('remaining', 'rem'):
-            return float(episode.total_time - episode.current_position) / 60
+            return episode.total_time - episode.current_position / 60
 
         raise KeyError(k)
 

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -705,7 +705,7 @@ class MTPDevice(Device):
     def __callback(self, sent, total):
         if self.cancelled:
             return -1
-        percentage = round(float(sent)/float(total)*100)
+        percentage = round(sent/total*100)
         text = ('%i%%' % percentage)
         self.notify('progress', sent, total, text)
 
@@ -1040,7 +1040,7 @@ class SyncTask(download.DownloadTask):
             self.total_size = float(totalSize)
 
         if self.total_size > 0:
-            self.progress = max(0.0, min(1.0, float(count*blockSize)/self.total_size))
+            self.progress = max(0.0, min(1.0, (count*blockSize)/self.total_size))
             self._progress_updated(self.progress)
 
         if self.status == SyncTask.CANCELLED:

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1358,11 +1358,11 @@ def format_seconds_to_hour_min_sec(seconds):
 
     seconds = int(seconds)
 
-    hours = int(seconds/3600)
-    seconds = int(seconds%3600)
+    hours = seconds//3600
+    seconds = seconds%3600
 
-    minutes = int(seconds/60)
-    seconds = int(seconds%60)
+    minutes = seconds//60
+    seconds = seconds%60
 
     if hours:
         result.append(N_('%(count)d hour', '%(count)d hours', hours) % {'count':hours})

--- a/tools/i18n/summary.py
+++ b/tools/i18n/summary.py
@@ -22,13 +22,13 @@ class Language(object):
         self.untranslated = int(untranslated)
 
     def get_translated_ratio(self):
-        return float(self.translated)/float(self.translated+self.fuzzy+self.untranslated)
+        return self.translated/(self.translated+self.fuzzy+self.untranslated)
 
     def get_fuzzy_ratio(self):
-        return float(self.fuzzy)/float(self.translated+self.fuzzy+self.untranslated)
+        return self.fuzzy/(self.translated+self.fuzzy+self.untranslated)
 
     def get_untranslated_ratio(self):
-        return float(self.untranslated)/float(self.translated+self.fuzzy+self.untranslated)
+        return self.untranslated/(self.translated+self.fuzzy+self.untranslated)
 
     def __cmp__(self, other):
         return cmp(self.get_translated_ratio(), other.get_translated_ratio())

--- a/tools/localdepends.py
+++ b/tools/localdepends.py
@@ -41,7 +41,7 @@ for module, required_files in MODULES:
         print('Cannot determine download URL for', module, '- aborting!')
         break
     data = urllib.request.urlopen(tarball_url).read()
-    print('%d KiB' % (len(data)/1024))
+    print('%d KiB' % (len(data)//1024))
     tar = tarfile.open(fileobj=io.BytesIO(data))
     for name in tar.getnames():
         match = re.match(required_files, name)

--- a/tools/progressbar_icon_tester.py
+++ b/tools/progressbar_icon_tester.py
@@ -26,7 +26,7 @@ for y in xrange(1):
     v.add(h)
     PARTS = 20
     for x in xrange(PARTS + 1):
-        h.add(gen(float(x)/float(PARTS)))
+        h.add(gen(x/PARTS))
 w.set_default_size(400, 100)
 w.show_all()
 Gtk.main()


### PR DESCRIPTION
Python3 does floating point division on integers when using the '/' operator, unlike Python2 where integer division was done.

This lead the following exception:

> 
> 1487079580.102072 [gpodder.gtkui.main] ERROR: Exception happened while updating download list.
> Traceback (most recent call last):
>   File "/home/vossad01/dev/gpodder/src/gpodder/gtkui/main.py", line 1214, in update_downloads_list
>     self.downloads_finished(self.download_tasks_seen)
>   File "/home/vossad01/dev/gpodder/src/gpodder/gtkui/main.py", line 1442, in downloads_finished
>     message = self.format_episode_list(finished_downloads)
>   File "/home/vossad01/dev/gpodder/src/gpodder/gtkui/main.py", line 1495, in format_episode_list
>     title = '%s...%s' % (title[0:middle], title[-middle:])
> TypeError: slice indices must be integers or None or have an __index__ method


In addition to fixing the above bug, a manual search for the '/' character was done and changes were made on other noticed usages to reflect Python3 behavior.

No efforts were made to try to run all affected code paths.