### PR TITLE
Python 3: decode bytes of text/html feed to str

### DIFF
--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -174,7 +174,13 @@ class Fetcher(object):
         if stream.headers.get('content-type', '').startswith('text/html'):
             if autodiscovery:
                 ad = FeedAutodiscovery(url)
-                ad.feed(stream.read())
+
+                # Not very robust attempt to detect encoding: http://stackoverflow.com/a/1495675/1072626
+                charset = stream.headers.get_param('charset')
+                if charset is None:
+                    charset = 'utf-8' # utf-8 appears hard-coded elsewhere in this codebase
+
+                ad.feed(stream.read().decode(charset))
                 if ad._resolved_url:
                     try:
                         self._parse_feed(ad._resolved_url, None, None, False)


### PR DESCRIPTION
Fixes another Python 3 related break

This was causing the following exception:

```
> 1488596009.081241 [gpodder.gtkui.main] ERROR: Error: Can't convert 'bytes' object to str implicitly
Traceback (most recent call last):
  File "/home/user/dev/gpodder/src/gpodder/gtkui/main.py", line 2518, in update_feed_cache_proc
    channel.update(max_episodes=self.config.max_episodes_per_feed)
  File "/home/user/dev/gpodder/src/gpodder/model.py", line 1013, in update
    result = self.feed_fetcher.fetch_channel(self)
  File "/home/user/dev/gpodder/src/gpodder/model.py", line 72, in fetch_channel
    return self.fetch(url, channel.http_etag, channel.http_last_modified)
  File "/home/vossad01/dev/gpodder/src/gpodder/feedcore.py", line 197, in fetch
    return self._parse_feed(url, etag, modified)
  File "/home/user/dev/gpodder/src/gpodder/feedcore.py", line 177, in _parse_feed
    ad.feed(stream.read())
  File "/usr/lib/python3.5/html/parser.py", line 110, in feed
    self.rawdata = self.rawdata + data
TypeError: Can't convert 'bytes' object to str implicitly
```