### PR TITLE
Updates SoundCloud support to recognize https urls

### DIFF
--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -164,7 +164,7 @@ class SoundcloudUser(object):
             self.commit_cache()
 
 class SoundcloudFeed(object):
-    URL_REGEX = re.compile('http://([a-z]+\.)?soundcloud\.com/([^/]+)$', re.I)
+    URL_REGEX = re.compile('https?://([a-z]+\.)?soundcloud\.com/([^/]+)$', re.I)
 
     @classmethod
     def handle_url(cls, url):
@@ -207,7 +207,7 @@ class SoundcloudFeed(object):
         return episodes, seen_guids
 
 class SoundcloudFavFeed(SoundcloudFeed):
-    URL_REGEX = re.compile('http://([a-z]+\.)?soundcloud\.com/([^/]+)/favorites', re.I)
+    URL_REGEX = re.compile('https?://([a-z]+\.)?soundcloud\.com/([^/]+)/favorites', re.I)
 
 
     def __init__(self, username):


### PR DESCRIPTION
This is a simple RegEx change to make `soundclound.py` handle 'http' and 'https' urls.  Fixes the below issue:

___
If you try to add a SoundCloud url that uses https:// as the protocol, gPodder treats it as a podcast url rather than a SoundCloud page.  The result is that the podcast fails to add with the error: Got HTML document instead.

This is more common to occur now that SoundCloud automatically redirects to https://
Adding a http:// urls continue to work (because gPodder properly handles redirects).

Issue first speculated on by @Strubbl on https://github.com/gpodder/gpodder/issues/235#issuecomment-283132940

Reproduction:

* Subscriptions > Add podcast via URL: https://soundcloud.com/geedee215
   Note it fails
* Subscriptions > Add podcast via URL: http://soundcloud.com/geedee215
   Note you are given a list of episodes to download