### PR TITLE
store episode's description_html (schema change)

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -149,10 +149,9 @@ class PodcastEpisode(PodcastModelObject):
             episode.description_html = entry['description_html']
         # XXX: That's not a very well-informed heuristic to check
         # if the description already contains HTML. Better ideas?
+        # TODO: This really should be handled in podcastparser and not here.
         elif '<' in entry['description']:
             episode.description_html = entry['description']
-        else:
-            episode.description_html = entry['description'].replace('\n', '<br>')
         episode.total_time = entry['total_time']
         episode.published = entry['published']
         episode.payment_url = entry['payment_url']

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -145,6 +145,14 @@ class PodcastEpisode(PodcastModelObject):
         episode.title = entry['title']
         episode.link = entry['link']
         episode.description = entry['description']
+        if entry.get('description_html'):
+            episode.description_html = entry['description_html']
+        # XXX: That's not a very well-informed heuristic to check
+        # if the description already contains HTML. Better ideas?
+        elif '<' in entry['description']:
+            episode.description_html = entry['description']
+        else:
+            episode.description_html = entry['description'].replace('\n', '<br>')
         episode.total_time = entry['total_time']
         episode.published = entry['published']
         episode.payment_url = entry['payment_url']
@@ -202,6 +210,7 @@ class PodcastEpisode(PodcastModelObject):
         self.mime_type = 'application/octet-stream'
         self.guid = ''
         self.description = ''
+        self.description_html = ''
         self.link = ''
         self.published = 0
         self.download_filename = None
@@ -333,14 +342,6 @@ class PodcastEpisode(PodcastModelObject):
 
     age_prop = property(fget=get_age_string)
 
-    @property
-    def description_html(self):
-        # XXX: That's not a very well-informed heuristic to check
-        # if the description already contains HTML. Better ideas?
-        if '<' in self.description:
-            return self.description
-
-        return self.description.replace('\n', '<br>')
 
     def one_line_description(self):
         MAX_LINE_LENGTH = 120
@@ -633,7 +634,7 @@ class PodcastEpisode(PodcastModelObject):
             return '-'
 
     def update_from(self, episode):
-        for k in ('title', 'url', 'description', 'link', 'published', 'guid', 'file_size', 'payment_url'):
+        for k in ('title', 'url', 'description', 'description_html', 'link', 'published', 'guid', 'file_size', 'payment_url'):
             setattr(self, k, getattr(episode, k))
 
 

--- a/src/gpodder/schema.py
+++ b/src/gpodder/schema.py
@@ -47,6 +47,7 @@ EpisodeColumns = (
     'current_position_updated',
     'last_playback',
     'payment_url',
+    'description_html',
 )
 
 PodcastColumns = (
@@ -69,7 +70,7 @@ PodcastColumns = (
     'cover_thumb',
 )
 
-CURRENT_VERSION = 6
+CURRENT_VERSION = 7
 
 
 # SQL commands to upgrade old database versions to new ones
@@ -102,6 +103,11 @@ UPGRADE_SQL = [
         # Version 6: Add thumbnail for cover art
         (5, 6, """
         ALTER TABLE podcast ADD COLUMN cover_thumb BLOB NULL DEFAULT NULL
+        """),
+
+        # Version 7: Add HTML description
+        (6, 7, """
+        ALTER TABLE episode ADD COLUMN description_html TEXT NOT NULL DEFAULT ''
         """),
 ]
 


### PR DESCRIPTION
This way we can display the `description` in one-line description and `description_html` in show notes.

This is a schema change. I hope I've not forgotten any use of description.