### PR TITLE
gtk3: Reinstate *.pyc in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pyc
 __pycache__
 src/podcastparser.py
 src/mygpoclient


### PR DESCRIPTION
Switching between master and the Python 3 version is still common at this point so these file appear even though they are not produced by Python 3