### PR TITLE
Propagate "old" state to other gpodder.net clients

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2686,15 +2686,17 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def mark_selected_episodes_new(self):
         for episode in self.get_selected_episodes():
             episode.mark_new()
+        if self.mygpo_client.can_access_webservice():
+            self.mygpo_client.on_mark_new(self.get_selected_episodes())
+            self.mygpo_client.flush()
         self.on_selected_episodes_status_changed()
 
     def mark_selected_episodes_old(self):
         for episode in self.get_selected_episodes():
             episode.mark_old()
-            if self.mygpo_client.can_access_webservice():
-                self.mygpo_client.on_playback_full(episode, 0, episode.total_time,
-                                                   episode.total_time)
-                self.mygpo_client.flush()
+        if self.mygpo_client.can_access_webservice():
+            self.mygpo_client.on_mark_old(self.get_selected_episodes())
+            self.mygpo_client.flush()
         self.on_selected_episodes_status_changed()
 
     def on_item_toggle_played_activate( self, widget, toggle = True, new_value = False):

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2691,6 +2691,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def mark_selected_episodes_old(self):
         for episode in self.get_selected_episodes():
             episode.mark_old()
+            if self.mygpo_client.can_access_webservice():
+                self.mygpo_client.on_playback_full(episode, 0, episode.total_time,
+                                                   episode.total_time)
+                self.mygpo_client.flush()
         self.on_selected_episodes_status_changed()
 
     def on_item_toggle_played_activate( self, widget, toggle = True, new_value = False):

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -346,6 +346,16 @@ class MygPoClient(object):
                 episode.url, self.device_id, action, \
                 int(time.time()), None, None, None)
 
+    def on_mark_new(self, episodes):
+        """TODO create New action"""
+        logger.debug('Storing mark new action. (Not yet implemented)')
+
+    def on_mark_old(self, episodes):
+        """Sending played action for antennapod compatibility"""
+        logger.debug('Storing mark old action')
+        self._store.save(self._convert_played_episode(e, 0, e.total_time, e.total_time)
+                         for e in episodes)
+
     def on_delete(self, episodes):
         logger.debug('Storing %d episode delete actions', len(episodes))
         self._store.save(self._convert_episode(e, 'delete') for e in episodes)


### PR DESCRIPTION
Unchecking new status in UI trig a 'mygpo_client.on_playback_full' to propagate the read state to other gpotter.net clients