### PR TITLE
store episode's HTML description in descr_html (schema change)

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -145,6 +145,7 @@ class PodcastEpisode(PodcastModelObject):
         episode.title = entry['title']
         episode.link = entry['link']
         episode.description = entry['description']
+        episode.descr_html = entry.get('description_html', '')
         episode.total_time = entry['total_time']
         episode.published = entry['published']
         episode.payment_url = entry['payment_url']
@@ -202,6 +203,7 @@ class PodcastEpisode(PodcastModelObject):
         self.mime_type = 'application/octet-stream'
         self.guid = ''
         self.description = ''
+        self.descr_html = ''
         self.link = ''
         self.published = 0
         self.download_filename = None
@@ -335,6 +337,8 @@ class PodcastEpisode(PodcastModelObject):
 
     @property
     def description_html(self):
+        if self.descr_html:
+            return self.descr_html
         # XXX: That's not a very well-informed heuristic to check
         # if the description already contains HTML. Better ideas?
         if '<' in self.description:
@@ -633,7 +637,7 @@ class PodcastEpisode(PodcastModelObject):
             return '-'
 
     def update_from(self, episode):
-        for k in ('title', 'url', 'description', 'link', 'published', 'guid', 'file_size', 'payment_url'):
+        for k in ('title', 'url', 'description', 'descr_html', 'link', 'published', 'guid', 'file_size', 'payment_url'):
             setattr(self, k, getattr(episode, k))
 
 

--- a/src/gpodder/schema.py
+++ b/src/gpodder/schema.py
@@ -47,6 +47,7 @@ EpisodeColumns = (
     'current_position_updated',
     'last_playback',
     'payment_url',
+    'descr_html'
 )
 
 PodcastColumns = (
@@ -69,7 +70,7 @@ PodcastColumns = (
     'cover_thumb',
 )
 
-CURRENT_VERSION = 6
+CURRENT_VERSION = 7
 
 
 # SQL commands to upgrade old database versions to new ones
@@ -102,6 +103,11 @@ UPGRADE_SQL = [
         # Version 6: Add thumbnail for cover art
         (5, 6, """
         ALTER TABLE podcast ADD COLUMN cover_thumb BLOB NULL DEFAULT NULL
+        """),
+
+        # Version 7: Add HTML description
+        (6, 7, """
+        ALTER TABLE episode ADD COLUMN descr_html TEXT NOT NULL DEFAULT ''
         """),
 ]
 
@@ -159,7 +165,8 @@ def initialize_database(db):
         current_position INTEGER NOT NULL DEFAULT 0,
         current_position_updated INTEGER NOT NULL DEFAULT 0,
         last_playback INTEGER NOT NULL DEFAULT 0,
-        payment_url TEXT NULL DEFAULT NULL
+        payment_url TEXT NULL DEFAULT NULL,
+        descr_html TEXT NOT NULL DEFAULT ''
     )
     """)
 


### PR DESCRIPTION
Keep the description_html property to fallback to description if descr_html is not set.

Contrary to previous PR, a copy of description is not stored in descr_html if episode has no HTML description.