### PR TITLE
rename_download: Handle new basename as unicode string

### DIFF
--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -48,12 +48,12 @@ class gPodderExtension:
         basename, ext = os.path.splitext(filename)
 
         new_basename = []
-        new_basename.append(util.sanitize_encoding(title) + ext)
-        if self.config.add_podcast_title:
-            new_basename.insert(0, podcast_title)
+        new_basename.append(util.to_unicode(title) + util.to_unicode(ext))
         if self.config.add_sortdate:
-            new_basename.insert(0, sortdate)
-        new_basename = ' - '.join(new_basename)
+            new_basename.insert(0, util.to_unicode(sortdate))
+        if self.config.add_podcast_title:
+            new_basename.insert(0, util.to_unicode(podcast_title))
+        new_basename = u' - '.join(new_basename)
 
         # On Windows, force ASCII encoding for filenames (bug 1724)
         new_basename = util.sanitize_filename(new_basename,

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1469,6 +1469,17 @@ def sanitize_encoding(filename):
     return filename.encode(encoding, 'ignore')
 
 
+def to_unicode(s):
+    """Convert a string or unicode object to unicode
+
+    >>> to_unicode('hello')
+    u'hello'
+    >>> to_unicode(u'world')
+    u'world'
+    """
+    return s if isinstance(s, unicode) else s.decode(encoding, 'ignore')
+
+
 def sanitize_filename(filename, max_length=0, use_ascii=False):
     """
     Generate a sanitized version of a filename that can


### PR DESCRIPTION
As alternative fix for #217. Note that I wasn't able to reproduce the original issue on macOS, so can't verify that this actually fixes the original issue.