### PR TITLE
Disable MPRIS listener extension in Windows and macOS

### DIFF
--- a/share/gpodder/extensions/mpris-listener.py
+++ b/share/gpodder/extensions/mpris-listener.py
@@ -35,6 +35,7 @@ __description__ = _('Convert MPRIS notifications to gPodder Media Player D-Bus A
 __authors__ = 'Dov Feldstern <dovdevel@gmail.com>'
 __doc__ = 'http://wiki.gpodder.org/wiki/Extensions/MprisListener'
 __category__ = 'desktop-integration'
+__only_for__ = 'freedesktop'
 
 USECS_IN_SEC = 1000000
 

--- a/src/gpodder/__init__.py
+++ b/src/gpodder/__init__.py
@@ -104,6 +104,8 @@ dbus_session_bus = None
 ui.win32 = (platform.system() == 'Windows')
 # Set "osx" to True if we are on Mac OS X
 ui.osx = (platform.system() == 'Darwin')
+# We assume it's a freedesktop.org system if it's not Windows or OS X
+ui.freedesktop = not ui.win32 and not ui.osx
 
 # i18n setup (will result in "gettext" to be available)
 # Use   _ = gpodder.gettext   in modules to enable string translations


### PR DESCRIPTION
Based on the discussion in #272.