### PR TITLE
Remove some characters from filename when copy fails

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -29,6 +29,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import GObject
 from gi.repository import Pango
 import random
+import re
 import sys
 import shutil
 import subprocess
@@ -1747,7 +1748,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     base, extension = os.path.splitext(copy_from)
                     filename = self.build_filename(episode.sync_filename(), extension)
                     copy_to = os.path.join(folder, filename)
-                    shutil.copyfile(copy_from, copy_to)
+                    try:
+                        shutil.copyfile(copy_from, copy_to)
+                    except (OSError, IOError):
+                        copy_to = os.path.join(folder, re.sub(r"[\"*/:<>?\\|]", "_", filename))
+                        shutil.copyfile(copy_from, copy_to)
 
     def copy_episodes_bluetooth(self, episodes):
         episodes_to_copy = [e for e in episodes if e.was_downloaded(and_exists=True)]

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1750,9 +1750,14 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     copy_to = os.path.join(folder, filename)
                     try:
                         shutil.copyfile(copy_from, copy_to)
-                    except (OSError, IOError):
-                        copy_to = os.path.join(folder, re.sub(r"[\"*/:<>?\\|]", "_", filename))
-                        shutil.copyfile(copy_from, copy_to)
+                    except (OSError, IOError) as e:
+                        # Remove characters not supported by VFAT (#282)
+                        new_filename = re.sub(r"[\"*/:<>?\\|]", "_", filename)
+                        destination = os.path.join(folder, new_filename)
+                        if (copy_to != destination):
+                            shutil.copyfile(copy_from, destination)
+                        else:
+                            raise
 
     def copy_episodes_bluetooth(self, episodes):
         episodes_to_copy = [e for e in episodes if e.was_downloaded(and_exists=True)]


### PR DESCRIPTION
This aims to provide better VFAT/Windows support by replacing troublesome characters if there is originally a failure. This would fix #282.