### PR TITLE
Filter `None` entries from `get_selected_episodes`

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -3293,6 +3293,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         model, paths = selection.get_selected_rows()
 
         episodes = [model.get_value(model.get_iter(path), EpisodeListModel.C_EPISODE) for path in paths]
+        episodes = [e for e in episodes if e is not None]
         return episodes
 
     def on_playback_selected_episodes(self, *params):


### PR DESCRIPTION
Filter `None` entries from `get_selected_episodes`.  Enough callers will blow up if this is the case and it has been shown to happen.  Additionally, there would not be much useful a caller could do with the `None` value.