### PR TITLE
Refactor async tasks: Download/Synchronize/SendTo

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1449,7 +1449,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 message = self.format_episode_list(list(map(format_task_finished, finished_tasks)))
                 self.show_message(message, self._task_messages[activity]['finished_title'])
             elif failed_tasks:
-                message = self.format_episode_list(list(map(format_task_finished, finished_tasks)))
+                message = self.format_episode_list(list(map(format_task_failed, failed_tasks)))
                 self.show_message(message, self._task_messages[activity]['failed_title'], True)
 
             # Do post-sync processing if required
@@ -1717,11 +1717,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
         setattr(self, PRIVATE_FOLDER_ATTRIBUTE, folder)
 
         if notCancelled and folder is not None: # folder is None if not double-clicking on folder in "Recent"
-            @util.run_in_background
-            def sync_thread_func():
-                st = sendto.SendTo(self.download_status_model, self.download_queue_manager)
-                st.add_send_to(episodes, folder,
-                               done_callback=self.enable_download_list_update)
+            st = sendto.SendTo(self.download_status_model, self.download_queue_manager)
+            st.add_send_to(episodes, folder,
+                           done_callback=self.enable_download_list_update)
 
     def copy_episodes_bluetooth(self, episodes):
         episodes_to_copy = [e for e in episodes if e.was_downloaded(and_exists=True)]

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -291,7 +291,7 @@ class PodcastEpisode(PodcastModelObject):
         if task is None:
             return False
 
-        return task.status in (task.DOWNLOADING, task.QUEUED, task.PAUSED)
+        return task.status in (task.ACTIVE, task.QUEUED, task.PAUSED)
 
     def check_is_new(self):
         return (self.state == gpodder.STATE_NORMAL and self.is_new and

--- a/src/gpodder/sendto.py
+++ b/src/gpodder/sendto.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+#
+# gPodder - A media aggregator and podcast client
+# Copyright (c) 2005-2016 Thomas Perl and the gPodder Team
+#
+# gPodder is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# gPodder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import gpodder
+
+from gpodder import util
+from gpodder import services
+from gpodder.task import Task, TaskCancelledException
+
+import logging
+logger = logging.getLogger(__name__)
+
+import calendar
+
+_ = gpodder.gettext
+
+import os.path
+import time
+
+class SendToFailedException(Exception): pass
+
+
+class SendTo(object):
+    def __init__(self,
+            download_status_model,
+            download_queue_manager):
+        self.download_status_model = download_status_model
+        self.download_queue_manager = download_queue_manager
+
+    def add_send_to(self, episodes, folder, done_callback=None):
+        if episodes:
+            for episode in sorted(episodes, key=lambda e: e.pubdate_prop):
+                if episode.was_downloaded(and_exists=True):
+                    sync_task=SendToTask(episode, folder)
+                    sync_task.status=sync_task.QUEUED
+                    self.download_status_model.register_task(sync_task)
+                    # Executes after task has been registered
+                    util.idle_add(self.download_queue_manager.queue_task, sync_task)
+        else:
+            logger.warning("No episodes to send")
+
+        if done_callback:
+            done_callback()
+
+
+class SendToTask(Task):
+    """ An object representing copying an Episode """
+
+    # Possible states this send to task can be in
+    STATUS_MESSAGE = (_('Added'), _('Queued'), _('Copying'),
+            _('Finished'), _('Failed'), _('Cancelled'), _('Paused'))
+    ACTIVITY = "SendTo"
+
+    def cleanup(self):
+        # XXX: Should we delete temporary/incomplete files here?
+        pass
+
+    def __init__(self, episode, target_folder):
+        super(SendToTask, self).__init__(SendToTask.ACTIVITY, episode)
+
+        self.target_folder = target_folder
+        self.copy_from = episode.local_filename(create=False)
+        assert self.copy_from is not None
+        base, extension = os.path.splitext(self.copy_from)
+        self.filename = self.build_filename(episode.sync_filename(), extension)
+
+        self.total_size = util.calculate_size(self.copy_from)
+        self.buffer_size = 1024*1024 # 1 MiB
+
+    def do_run(self):
+        try:
+            logger.info('Starting SendToTask')
+            self.sendto()
+        except TaskCancelledException as e:
+            raise
+        except Exception as e:
+            self.status = Task.FAILED
+            logger.error('Send-To failed: %s', str(e), exc_info=True)
+            self.error_message = _('Error: %s') % (str(e),)
+
+        if self.status == Task.ACTIVE:
+            # Everything went well - we're done
+            self.status = Task.DONE
+            if self.total_size <= 0:
+                self.total_size = util.calculate_size(self.filename)
+                logger.info('Total size updated to %d', self.total_size)
+            self.progress = 1.0
+            return True
+
+        # We finished, but not successfully (at least not really)
+        return False
+
+    def sendto(self):
+        """ synchronously copy file to target """
+        # verify free space
+        needed = util.calculate_size(self.copy_from)
+        free = util.get_free_disk_space(self.target_folder)
+        if free == -1:
+            logger.warn('Cannot determine free disk space on device')
+        elif needed > free:
+            d = {'path': self.destination, 'free': util.format_filesize(free), 'need': util.format_filesize(needed)}
+            message =_('Not enough space in %(path)s: %(free)s available, but need at least %(need)s')
+            raise SendToFailedException(message % d)
+
+        self.copy_file_progress(self.status_updated)
+
+    def copy_file_progress(self, reporthook):
+        try:
+            in_file = open(self.copy_from, 'rb')
+        except IOError as ioerror:
+            d = {'filename': ioerror.filename, 'message': ioerror.strerror}
+            message = _('Error opening %(filename)s: %(message)s')
+            raise SendToFailedException(message % d)
+
+        copy_to = os.path.join(self.target_folder, self.filename)
+        try:
+            out_file = open(copy_to, 'wb')
+        except (OSError, IOError) as ioerror:
+            # Remove characters not supported by VFAT (#282)
+            new_filename = re.sub(r"[\"*/:<>?\\|]", "_", self.filename)
+            destination = os.path.join(self.target_folder, new_filename)
+            if (copy_to == destination):
+                d = {'filename': ioerror.filename, 'message': ioerror.strerror}
+                message = _('Error opening %(filename)s: %(message)s')
+                raise SendToFailedException(message % d)
+
+        logger.info('Copying %s => %s', os.path.basename(self.copy_from), copy_to)
+
+        in_file.seek(0, os.SEEK_END)
+        total_bytes = in_file.tell()
+        in_file.seek(0)
+
+        bytes_read = 0
+        s = in_file.read(self.buffer_size)
+        while s:
+            bytes_read += len(s)
+            try:
+                out_file.write(s)
+                # debug: slow down to see progress
+                # time.sleep(1)
+            except IOError as ioerror:
+                try:
+                    out_file.close()
+                except:
+                    pass
+                try:
+                    logger.info('Trying to remove partially copied file: %s' % copy_to)
+                    os.unlink( copy_to)
+                    logger.info('Yeah! Unlinked %s at least..' % copy_to)
+                except:
+                    logger.error('Error while trying to unlink %s. OH MY!' % copy_to)
+                raise SendToFailedException(ioerror.strerror)
+            reporthook(bytes_read, 1, total_bytes)
+            s = in_file.read(self.buffer_size)
+        out_file.close()
+        in_file.close()
+
+    @staticmethod
+    def build_filename(filename, extension):
+        filename = util.sanitize_filename(filename)
+        if not filename.endswith(extension):
+            filename += extension
+        return filename

--- a/src/gpodder/sendto.py
+++ b/src/gpodder/sendto.py
@@ -114,7 +114,7 @@ class SendToTask(Task):
         if free == -1:
             logger.warn('Cannot determine free disk space on device')
         elif needed > free:
-            d = {'path': self.destination, 'free': util.format_filesize(free), 'need': util.format_filesize(needed)}
+            d = {'path': self.target_folder, 'free': util.format_filesize(free), 'need': util.format_filesize(needed)}
             message =_('Not enough space in %(path)s: %(free)s available, but need at least %(need)s')
             raise SendToFailedException(message % d)
 

--- a/src/gpodder/task.py
+++ b/src/gpodder/task.py
@@ -1,0 +1,447 @@
+# -*- coding: utf-8 -*-
+#
+# gPodder - A media aggregator and podcast client
+# Copyright (c) 2005-2016 Thomas Perl and the gPodder Team
+#
+# gPodder is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# gPodder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+#
+#  task.py -- Task queue management
+#  Thomas Perl <thp@perli.net>   2007-09-15
+#
+#  Based on libwget.py (2005-10-29)
+#
+
+import logging
+
+from gpodder import util
+import gpodder
+
+import math
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+_ = gpodder.gettext
+
+# special activity, which has a configurable worker count limit
+# other activities only get 1 worker
+DOWNLOAD_ACTIVITY = "Download"
+
+
+class QueueWorker(object):
+    def __init__(self, queue, exit_callback, continue_check_callback, activity):
+        self.queue = queue
+        self.exit_callback = exit_callback
+        self.continue_check_callback = continue_check_callback
+        self.activity = activity
+
+    def __repr__(self):
+        return "%s (handling %s)" % (threading.current_thread().getName(), self.activity) 
+
+    def run(self):
+        logger.info('Starting new thread: %s', self)
+        while True:
+            if not self.continue_check_callback(self):
+                return
+
+            try:
+                task = self.queue.get_next(self.activity)
+                logger.info('%s is processing: %s', self, task)
+                task.run()
+                task.recycle()
+            except StopIteration as e:
+                logger.info('No more tasks for %s to carry out.', self)
+                break
+        self.exit_callback(self)
+
+
+class ForceWorker(object):
+    def __init__(self, task):
+        self.task = task
+
+    def __repr__(self):
+        return threading.current_thread().getName()
+
+    def run(self):
+        logger.info('Starting new thread: %s', self)
+        logger.info('%s is processing: %s', self, self.task)
+        self.task.run()
+
+
+class QueueManager(object):
+    def __init__(self, config, queue):
+        self._config = config
+        self.tasks = queue
+
+        self.worker_threads_access = threading.RLock()
+        self.worker_threads = {}
+
+    def __exit_callback(self, worker_thread):
+        with self.worker_threads_access:
+            if worker_thread.activity in self.worker_threads:
+                self.worker_threads[worker_thread.activity].remove(worker_thread)
+
+    def __max_thread_count(self, activity):
+        if activity == DOWNLOAD_ACTIVITY:
+            if self._config.max_downloads_enabled and self._config.max_downloads > 0:
+                max_threads = self._config.max_downloads
+            else:
+                max_threads = math.inf
+        else:
+            max_threads = 1
+        return max_threads
+
+    def __continue_check_callback(self, worker_thread):
+        with self.worker_threads_access:
+            if worker_thread.activity in self.worker_threads:
+                max_threads = self.__max_thread_count(worker_thread.activity)
+                if len(self.worker_threads[worker_thread.activity]) > max_threads:
+                    self.worker_threads.remove(worker_thread)
+                    return False
+                else:
+                    return True
+            else:
+                # stray thread => stop it
+                return False
+
+    def __spawn_threads(self, activity=DOWNLOAD_ACTIVITY):
+        """Spawn new worker threads if necessary
+        """
+        with self.worker_threads_access:
+            if not self.tasks.has_work(activity):
+                return
+
+            max_threads = self.__max_thread_count(activity)
+            if len(self.worker_threads.get(activity, [])) < max_threads:
+                # We have to create a new thread here, there's work to do
+                logger.info('Starting new worker thread for %s.', activity)
+
+                worker = QueueWorker(self.tasks, self.__exit_callback,
+                                     self.__continue_check_callback,
+                                     activity)
+                if activity not in self.worker_threads:
+                    self.worker_threads[activity] = [worker]
+                else:
+                    self.worker_threads[activity].append(worker)
+                util.run_in_background(worker.run)
+
+    def update_max_downloads(self):
+        self.__spawn_threads()
+
+    def force_start_task(self, task):
+        if self.tasks.set_active(task):
+            worker = ForceWorker(task)
+            util.run_in_background(worker.run)
+
+    def queue_task(self, task):
+        """Marks a task as queued
+        """
+        task.status = Task.QUEUED
+        self.__spawn_threads(task.activity)
+
+
+class TaskCancelledException(Exception):
+    pass
+
+
+class Task(object):
+    """An object representing an I/O task
+
+    The task's nature (Download, Sync, SendTo) is given by task.activity
+
+    While the task is in progress, you can access its properties:
+
+        str(task)             # name of the episode
+        task.episode          # Episode object of this task
+        task.podcast_url      # URL of the podcast this download belongs to
+        task.progress         # from 0.0 to 1.0
+        task.speed            # in bytes per second (0.0)
+        task.status           # current status
+        task.status_changed   # True if the status has been changed (see below)
+        task.total_size       # in bytes
+        task.url              # URL of the episode being downloaded
+
+
+    You can cancel a running task by setting its status:
+
+        task.status = Task.CANCELLED
+
+    The task will then abort as soon as possible (due to the nature
+    of downloading data, this can take a while when the Internet is
+    busy).
+    TODO: interrupt the worker thread after some time for stuck tasks?
+
+    The "status_changed" attribute gets set to True everytime the
+    "status" attribute changes its value. After you get the value of
+    the "status_changed" attribute, it is always reset to False:
+
+        if task.status_changed:
+            new_status = task.status
+            # .. update the UI accordingly ..
+
+    Obviously, this also means that you must have at most *one*
+    place in your UI code where you check for status changes and
+    broadcast the status updates from there.
+
+    While the task is taking place and after the .run() method
+    has finished, you can get the final status to check if the task
+    was successful:
+
+        if task.status == Task.DONE:
+            # .. everything ok ..
+        elif task.status == Task.FAILED:
+            # .. an error happened, and the
+            #    error_message attribute is set ..
+            print task.error_message
+        elif task.status == Task.PAUSED:
+            # .. user paused the task..
+        elif task.status == Task.CANCELLED:
+            # .. user cancelled the task..
+
+    Depending on the task, there might be a difference between and pausing,
+    e.g. a temporary file gets deleted when cancelling, but does
+    not get deleted when pausing.
+
+    Be sure to call .removed_from_list() on this task when removing
+    it from the UI, so that it can carry out any pending clean-up
+    actions (e.g. removing the temporary file when the task has not
+    finished successfully; i.e. task.status != Task.DONE).
+    """
+    # Possible states a task can be in
+    STATUS_MESSAGE = (_('Added'), _('Queued'), _('Active'),
+            _('Finished'), _('Failed'), _('Cancelled'), _('Paused'))
+    (INIT, QUEUED, ACTIVE, DONE, FAILED, CANCELLED, PAUSED) = list(range(7))
+
+    # Minimum time between progress updates (in seconds)
+    MIN_TIME_BETWEEN_UPDATES = 1.
+
+    def __str__(self):
+        return self.episode.title
+
+    def __get_episode(self):
+        return self.__episode
+
+    episode = property(fget=__get_episode)
+
+    def __get_status(self):
+        return self.__status
+
+    def __set_status(self, status):
+        if status != self.__status:
+            self.__status_changed = True
+            self.__status = status
+
+    status = property(fget=__get_status, fset=__set_status)
+
+    def __get_status_changed(self):
+        if self.__status_changed:
+            self.__status_changed = False
+            return True
+        else:
+            return False
+
+    status_changed = property(fget=__get_status_changed)
+
+    def __get_activity(self):
+        return self.__activity
+
+    def __set_activity(self, activity):
+        self.__activity = activity
+
+    activity = property(fget=__get_activity, fset=__set_activity)
+
+    def __get_url(self):
+        return self.episode.url
+
+    url = property(fget=__get_url)
+
+    def __get_podcast_url(self):
+        return self.episode.channel.url
+
+    podcast_url = property(fget=__get_podcast_url)
+
+    @staticmethod
+    def status_message(status):
+        """ method called to get a string representation of a status.
+            Override this in subclasses as needed.
+        """
+        return STATUS_MESSAGE[status]
+
+    def cancel(self):
+        if self.status in (self.ACTIVE, self.QUEUED):
+            self.status = self.CANCELLED
+
+    def removed_from_list(self):
+        """
+        Called to cleanup if necessary.
+        """
+        if self.status != self.DONE:
+            self.cleanup()
+
+    def __init__(self, activity, episode):
+        self.__status = Task.INIT
+        self.__activity = activity
+        self.__episode = episode
+        self.__status_changed = True
+
+        self.total_size = 0
+        self.progress = 0.0
+        self.speed = 0.0
+        self.error_message = None
+        
+        # Variables for speed calculation
+        self._start_time = 0
+        self._start_blocks = 0
+        self._speed_refresh_period = 1
+
+        # Have we already shown this task in a notification?
+        self._notification_shown = False
+
+        # Progress update functions
+        self._progress_updated = None
+        self._last_progress_updated = 0.
+
+    def notify_as_finished(self):
+        """
+        The UI can call the method "notify_as_finished()" to determine if
+        this task still has still to be shown as "finished"
+        in a notification window. This will return True only the first time
+        it is called when the status is DONE. After returning True once,
+        it will always return False afterwards.
+        """
+        if self.status == Task.DONE:
+            if self._notification_shown:
+                return False
+            else:
+                self._notification_shown = True
+                return True
+
+        return False
+
+    def notify_as_failed(self):
+        """
+        Same as notify_as_finished() for failed tasks
+        """
+        if self.status == Task.FAILED:
+            if self._notification_shown:
+                return False
+            else:
+                self._notification_shown = True
+                return True
+
+        return False
+
+    def add_progress_callback(self, callback):
+        self._progress_updated = callback
+
+    def status_updated(self, count, blockSize, totalSize):
+        """
+        Call this method from run() to report progress update,
+        after updating self.total_size.
+
+        Raises TaskCancelledException if status is cancelled or paused,
+        to stop the run() method in its thread.
+        Don't catch it.
+        """
+        if self.total_size > 0:
+            self.progress = max(0.0, min(1.0, count*blockSize/self.total_size))
+            if self._progress_updated is not None:
+                diff = time.time() - self._last_progress_updated
+                if diff > self.MIN_TIME_BETWEEN_UPDATES or self.progress == 1.:
+                    self._progress_updated(self.progress)
+                    self._last_progress_updated = time.time()
+
+        self.calculate_speed(count, blockSize)
+
+        if self.status in (Task.CANCELLED, Task.PAUSED):
+            raise TaskCancelledException()
+
+    def calculate_speed(self, count, blockSize):
+        """
+        Compute download/sync speed.
+        Called from status_updated().
+        """
+        if count % self._speed_refresh_period == 0:
+            now = time.time()
+            if self._start_time == 0:
+                self._start_time = now
+                self._start_blocks = count
+
+            passed = now - self._start_time
+            if passed > 0:
+                speed = ((count-self._start_blocks)*blockSize)/passed
+            else:
+                speed = 0
+
+            self.speed = float(speed)
+
+    def recycle(self):
+        """ hook for subclasses """
+        pass
+
+    def cleanup(self):
+        """
+        hook for subclasses.
+        Called on cancel
+        """
+        pass
+
+    def run(self):
+        """ perform the task synchronously """
+        # Speed calculation (re-)starts here
+        self._start_time = 0
+        self._start_blocks = 0
+
+        # If the download has already been cancelled, skip it
+        if self.status == Task.CANCELLED:
+            self.cleanup()
+            self.progress = 0.0
+            self.speed = 0.0
+            return False
+
+        # We only start this task if its status is "active"
+        # FIXME: setting status to ACTIVE afterwards is useless
+        if self.status != Task.ACTIVE:
+            return False
+
+        # We are running this task right now
+        self._notification_shown = False
+
+        # do the actual work in subclass
+        try:
+            success = self.do_run()
+        except TaskCancelledException:
+            success = False
+            logger.info('Task has been cancelled/paused: %s', self)
+            if self.status == Task.CANCELLED:
+                self.cleanup()
+                self.progress = 0.0
+
+        self.speed = 0.0
+        return success
+
+    def do_run(self):
+        """
+        main method to implement in subclasses.
+        @return Success?
+        """
+        pass
+
+    def post_run(self):
+        """ code to run in the GUI Thread after task finished """
+        pass


### PR DESCRIPTION
Download Tasks are rate and thread limited in the UI as before.
Sync, SendTo Tasks are thread limited to 1 (I've yet to see an MP3
player performing well on concurrent write).

task.py is moderately activity-kind agnostic.

SendTo has a similar algorithm as Sync to file-based device:
 - check if FS has enough room;
 - copy file chunk by chunk to track progress/cancel.