### PR TITLE
add a python2 ui flag for extensions

### DIFF
--- a/bin/gpodder
+++ b/bin/gpodder
@@ -112,6 +112,7 @@ def main():
     options, args = parser.parse_args(sys.argv)
 
     gpodder.ui.gtk = True
+    gpodder.ui.python2 = True
 
     gpodder.ui.unity = (os.environ.get('DESKTOP_SESSION', 'unknown').lower() in 
         ('ubuntu', 'ubuntu-2d'))

--- a/share/gpodder/extensions/gtk_statusicon.py
+++ b/share/gpodder/extensions/gtk_statusicon.py
@@ -14,7 +14,7 @@ _ = gpodder.gettext
 __title__ = _('Gtk Status Icon')
 __description__ = _('Show a status icon for Gtk-based Desktops.')
 __category__ = 'desktop-integration'
-__only_for__ = 'gtk'
+__only_for__ = 'gtk,python2'
 __disable_in__ = 'unity,win32'
 
 import gtk


### PR DESCRIPTION
to mark python2 (gtk2) / python3 (gtk3) only extensions.
Also mark the status icon extension python2 (gtk2) only (#160).
TODO: change flag to python3 when merging to gtk3 branch.

Fixes #252.