### PR TITLE
Fix migration to add data for cover_thumb

### DIFF
--- a/src/gpodder/schema.py
+++ b/src/gpodder/schema.py
@@ -265,6 +265,7 @@ def convert_gpodder2_db(old_db, new_db):
                 None,
                 0,
                 row['sync_to_devices'],
+                None,
         )
         new_db.execute("""
         INSERT INTO podcast VALUES (%s)


### PR DESCRIPTION
I recently upgraded to Debian stretch (which packages gpodder 3.9.3) from an older system that had gpodder 2.x.  I ran gpodder-migrate2tres, but got an error along the lines of "18 values needed, but only 17 provided" (I've fixed my local copy and would have to unfix it to recreate the exact error).

I believe I've traced the error to an omission updating the podcast table, since there's no value supplied for cover_thumb.  This patch works locally for me.  I don't know if the 2.x table had a column for cover_thumb, but I mainly use gpo so providing "None" as the value works for me.