### PR TITLE
Updates the Help destination url

### DIFF
--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -21,7 +21,7 @@
     <section>
       <item>
         <attribute name="label" translatable="yes">Help</attribute>
-        <attribute name="action">app.wiki</attribute>
+        <attribute name="action">app.help</attribute>
       </item>
       <item>
         <attribute name="action">app.about</attribute>

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -3612,8 +3612,8 @@ class gPodderApplication(Gtk.Application):
         action.connect('activate', self.on_quit)
         self.add_action(action)
 
-        action = Gio.SimpleAction.new('wiki', None)
-        action.connect('activate', self.on_wiki_activate)
+        action = Gio.SimpleAction.new('help', None)
+        action.connect('activate', self.on_help_activate)
         self.add_action(action)
 
         action = Gio.SimpleAction.new('preferences', None)
@@ -3740,8 +3740,8 @@ class gPodderApplication(Gtk.Application):
     def on_window_removed(self, *args):
         self.quit()
 
-    def on_wiki_activate(self, action, param):
-        util.open_website('https://gpodder.github.io/docs/user-manual.html')
+    def on_help_activate(self, action, param):
+        util.open_website('https://gpodder.github.io/docs/')
 
     def on_itemPreferences_activate(self, action, param=None):
         gPodderPreferences(self.window.gPodder, \


### PR DESCRIPTION
I think the docs landing page is a little more useful than the user manual, especially since there is currently no backwards navigation from the user manual.   Also, trivial cleanup of a method name.