### PR TITLE
Set 'Ctrl+E' as the shortcut for episode's "Toggle New Status"

### DIFF
--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -201,6 +201,7 @@
             <property name="label" translatable="yes">Toggle new status</property>
             <signal handler="on_item_toggle_played_activate" name="activate"/>
           </object>
+          <accelerator key="E" modifiers="GDK_CONTROL_MASK"/>
         </child>
         <child>
           <object class="GtkAction" id="item_toggle_lock">


### PR DESCRIPTION
Verified that it works on OSX 10.11.6 (where the shortcut is actually
'Cmd+E') for one and multiple selected episodes.

(created the patch into the `gtk2` branch because the latest released app package is for `3.9.6`; when I can run the `3.10.0` I'll create a patch into `master` as well)