### PR TITLE
Set '<Primary>E' as the shortcut for episode's "Toggle New Status"

### DIFF
--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -123,6 +123,7 @@
         <item>
           <attribute name="action">win.toggleEpisodeNew</attribute>
           <attribute name="label" translatable="yes">Toggle new status</attribute>
+          <attribute name="accel">&lt;Primary&gt;e</attribute>
         </item>
         <item>
           <attribute name="action">win.toggleEpisodeLock</attribute>


### PR DESCRIPTION
Verified that it works on OSX 10.11.6 (where the shortcut is 'Cmd+E')
for one and multiple selected episodes.

This reapplies commit bb4d31fc605285b5c0eb16bfad6091f50b1c05ca (#388) into the
`master` branch.