### PR TITLE
respect theme colors in shownotes

### DIFF
--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -98,9 +98,6 @@ def rounded_rectangle(ctx, x, y, width, height, radius=4.):
 def draw_text_box_centered(ctx, widget, w_width, w_height, text, font_desc=None, add_progress=None):
     style_context = widget.get_style_context()
     text_color = style_context.get_color(Gtk.StateFlags.PRELIGHT)
-    red, green, blue = text_color.red, text_color.green, text_color.blue
-    text_color = [x/65535. for x in (red, green, blue)]
-    text_color.append(.5)
 
     if font_desc is None:
         font_desc = style_context.get_font(Gtk.StateFlags.NORMAL)
@@ -113,7 +110,7 @@ def draw_text_box_centered(ctx, widget, w_width, w_height, text, font_desc=None,
     width, height = layout.get_pixel_size()
 
     ctx.move_to(w_width/2-width/2, w_height/2-height/2)
-    ctx.set_source_rgba(*text_color)
+    ctx.set_source_rgba(text_color.red, text_color.green, text_color.blue, 0.5)
     PangoCairo.show_layout(ctx, layout)
 
     # Draw an optional progress bar below the text (same width)
@@ -138,15 +135,9 @@ def draw_cake(percentage, text=None, emblem=None, size=None):
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size, size)
     ctx = cairo.Context(surface)
 
-    # ELL: get all black
-    #widget = Gtk.ProgressBar()
-    #style_context = widget.get_style_context()
-    bgc = Gdk.RGBA() #style_context.get_background_color(Gtk.StateFlags.NORMAL)
-    bgc.parse('white')
-    fgc = Gdk.RGBA() #style_context.get_background_color(Gtk.StateFlags.SELECTED)
-    fgc.parse('#4a90d9')
-    txc = Gdk.RGBA() #style_context.get_color(Gtk.StateFlags.NORMAL)
-    txc.parse('#333333')
+    bgc = get_background_color(Gtk.StateFlags.ACTIVE)
+    fgc = get_background_color(Gtk.StateFlags.SELECTED)
+    txc = get_foreground_color(Gtk.StateFlags.NORMAL)
 
     border = 1.5
     height = int(size*.4)
@@ -351,3 +342,36 @@ def progressbar_pixbuf(width, height, percentage):
     ctx.stroke()
 
     return cairo_surface_to_pixbuf(surface)
+
+def get_background_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
+    """
+    @param state state flag (e.g. Gtk.StateFlags.SELECTED to get selected background)
+    @param widget specific widget to get info from.
+           defaults to TreeView which has all one usually wants.
+    @return background color from theme for widget or from its parents if transparent.
+    """
+    p = widget
+    color = Gdk.RGBA(0, 0, 0, 0)
+    while p is not None and color.alpha == 0:
+        style_context = p.get_style_context()
+        color = style_context.get_background_color(0)
+        p = p.get_parent()
+    return color
+
+
+def get_foreground_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
+    """
+    @param state state flag (e.g. Gtk.StateFlags.SELECTED to get selected text color)
+    @param widget specific widget to get info from
+           defaults to TreeView which has all one usually wants.
+    @return text color from theme for widget or its parents if transparent
+    """
+    p = widget
+    color = Gdk.RGBA(0, 0, 0, 0)
+    style_context = widget.get_style_context()
+    foreground = style_context.get_color(0)
+    while p is not None and color.alpha == 0:
+        style_context = p.get_style_context()
+        color = style_context.get_color(0)
+        p = p.get_parent()
+    return color

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -222,15 +222,15 @@ class gPodderShownotesHTML(gPodderShownotes):
             self._base_uri += '/'
         self._loaded = False
 
+        stylesheet = self.get_stylesheet()
         if stylesheet:
-            self.manager.add_style_sheet(self.stylesheet)
+            self.manager.add_style_sheet(stylesheet)
         description_html = episode.description_html
         if description_html:
             # uncomment to prevent background override in html shownotes
             # self.manager.remove_all_style_sheets ()
             self.html_view.load_html(description_html, self._base_uri)
         else:
-            stylesheet = self.get_stylesheet()
             self.html_view.load_plain_text(episode.description)
             # uncomment to show web inspector
             # self.html_view.get_inspector().show()

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -178,11 +178,15 @@ class gPodderShownotesText(gPodderShownotes):
 class gPodderShownotesHTML(gPodderShownotes):
     def init(self):
         # basic restrictions
-        settings = WebKit2.Settings()
+        self.stylesheet = None
+        self.manager = WebKit2.UserContentManager()
+        self.html_view = WebKit2.WebView.new_with_user_content_manager(self.manager)
+        settings = self.html_view.get_settings()
         settings.set_enable_java(False)
         settings.set_enable_plugins(False)
         settings.set_enable_javascript(False)
-        self.html_view = WebKit2.WebView.new_with_settings(settings)
+        # uncomment to show web inspector
+        # settings.set_enable_developer_extras(True)
         self.html_view.set_property('expand', True)
         self.html_view.connect('mouse-target-changed', self.on_mouse_over)
         self.html_view.connect('context-menu', self.on_context_menu)
@@ -218,11 +222,18 @@ class gPodderShownotesHTML(gPodderShownotes):
             self._base_uri += '/'
         self._loaded = False
 
+        if stylesheet:
+            self.manager.add_style_sheet(self.stylesheet)
         description_html = episode.description_html
         if description_html:
+            # uncomment to prevent background override in html shownotes
+            # self.manager.remove_all_style_sheets ()
             self.html_view.load_html(description_html, self._base_uri)
         else:
+            stylesheet = self.get_stylesheet()
             self.html_view.load_plain_text(episode.description)
+            # uncomment to show web inspector
+            # self.html_view.get_inspector().show()
 
     def on_mouse_over(self, webview, hit_test_result, modifiers):
         if hit_test_result.context_is_link():
@@ -293,3 +304,13 @@ class gPodderShownotesHTML(gPodderShownotes):
 
     def set_status(self, text):
         self.status.set_label(text or " ")
+
+    def get_stylesheet(self):
+        if self.stylesheet is None:
+            foreground = get_foreground_color()
+            background = get_background_color(Gtk.StateFlags.ACTIVE)
+            if background is not None:
+                style = "html { background: %s; color: %s;}" % \
+                            (background.to_string(), foreground.to_string())
+                self.stylesheet = WebKit2.UserStyleSheet(style, 0, 1, None, None)
+        return self.stylesheet

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -28,7 +28,8 @@ import logging
 import gpodder
 
 from gpodder import util
-from gpodder.gtkui.draw import draw_text_box_centered
+from gpodder.gtkui.draw import draw_text_box_centered, \
+                                get_background_color, get_foreground_color
 
 _ = gpodder.gettext
 
@@ -106,8 +107,10 @@ class gPodderShownotes:
             self.show_pane(selected_episodes)
 
     def on_shownotes_message_expose_event(self, drawingarea, ctx):
-        # paint the background white
-        ctx.set_source_rgba(1, 1, 1)
+        background = get_background_color()
+        if background is None:
+            background = Gdk.RGBA(1, 1, 1, 1)
+        ctx.set_source_rgba(background.red, background.green, background.blue, 1)
         x1, y1, x2, y2 = ctx.clip_extents()
         ctx.rectangle(x1, y1, x2 - x1, y2 - y1)
         ctx.fill()


### PR DESCRIPTION
Dark/Light theme aware:
 - back and foreground shownote colors (also when no episode selected).
 - progress pills in episode list (was hardcoded to white/blue with black border)

Needs a bit more review with different themes so I'm not merging it until 3.10.1 is out.