### PR TITLE
Commands for single episodes downloading

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -48,8 +48,10 @@
   - Episode management -
 
     download [URL]             Download new episodes (all or only from URL)
+    downloadguid URL GUID      Download single episode
     pending [URL]              List new episodes (all or only from URL)
     episodes [URL]             List episodes (all or only from URL)
+    episodesguid URL           List episodes with GUIDs
 
   - Configuration -
 
@@ -318,7 +320,7 @@ class gPodderCli(object):
             if podcast is None:
                 self._error(_('Cannot subscribe to %s.') % url)
                 return True
-                
+
             if title is not None:
                 podcast.rename(title)
             podcast.save()
@@ -387,11 +389,11 @@ class gPodderCli(object):
             self._error(_('Unsubscribed from %s.') % url)
 
         return True
-        
+
     def is_episode_new(self, episode):
         return (episode.state == gpodder.STATE_NORMAL and episode.is_new)
 
-    def _episodesList(self, podcast):
+    def _episodesList(self, podcast, show_guid=False):
         def status_str(episode):
             # is new
             if self.is_episode_new(episode):
@@ -402,10 +404,10 @@ class gPodderCli(object):
             # is deleted
             if (episode.state == gpodder.STATE_DELETED):
                 return ' ░ '
-    
+
             return '   '
 
-        episodes = ('%3d. %s %s' % (i+1, status_str(e), e.title)
+        episodes = ('%3d.%s %s %s' % (i+1, ((' %s' % e.guid) if show_guid else ''), status_str(e), e.title)
                 for i, e in enumerate(podcast.get_all_episodes()))
         return episodes
 
@@ -420,7 +422,7 @@ class gPodderCli(object):
                 if podcast.pause_subscription:
                     return "disabled"
                 return "enabled"
-            
+
             title, url, status = podcast.title, podcast.url, \
                 feed_update_status_msg(podcast)
             episodes = self._episodesList(podcast)
@@ -436,13 +438,12 @@ class gPodderCli(object):
 
         return True
 
-    @FirstArgumentIsPodcastURL
-    def episodes(self, url=None):
+    def _episodes(self, url=None, show_guid=False):
         output = []
         for podcast in self._model.get_podcasts():
             podcast_printed = False
             if url is None or podcast.url == url:
-                episodes = self._episodesList(podcast)
+                episodes = self._episodesList(podcast, show_guid=show_guid)
                 episodes = '\n      '.join(episodes)
                 output.append("""
     Episodes from %s:
@@ -451,6 +452,14 @@ class gPodderCli(object):
 
         self._pager('\n'.join(output))
         return True
+
+    @FirstArgumentIsPodcastURL
+    def episodes(self, url=None):
+      return self._episodes(url, False)
+
+    @FirstArgumentIsPodcastURL
+    def episodesguid(self, url):
+      return self._episodes(url, True)
 
     def list(self):
         for podcast in self._model.get_podcasts():
@@ -539,6 +548,25 @@ class gPodderCli(object):
 
         util.delete_empty_folders(gpodder.downloads)
         print(len(episodes), 'episodes downloaded.')
+        return True
+
+    @FirstArgumentIsPodcastURL
+    def downloadguid(self, url, guid):
+        podcast = self.get_podcast(url)
+
+        if podcast is None:
+            self._error(_('You are not subscribed to %s.') % url)
+        else:
+          episode_found = False
+          for podcast in self._model.get_podcasts():
+              if podcast.url == url:
+                  for episode in podcast.get_all_episodes():
+                      if episode.guid == guid:
+                          episode_found = True
+                          self._download_episode(episode)
+                          print(_('Episode with GUID %s downloaded.') % guid)
+          if not episode_found:
+            self._error(_('Episode with GUID %(guid)s not found in podcast %(url)s.') % { guid: guid, url: url })
         return True
 
     @FirstArgumentIsPodcastURL

--- a/bin/gpo
+++ b/bin/gpo
@@ -47,11 +47,9 @@
 
   - Episode management -
 
-    download [URL]             Download new episodes (all or only from URL)
-    downloadguid URL GUID      Download single episode
+    download [URL] [GUID]      Download new episodes (all or only from URL) or single GUID
     pending [URL]              List new episodes (all or only from URL)
-    episodes [URL]             List episodes (all or only from URL)
-    episodesguid URL           List episodes with GUIDs
+    episodes [URL] [SHOWGUID]  List episodes with or without GUIDs (all or only from URL)
 
   - Configuration -
 
@@ -438,7 +436,8 @@ class gPodderCli(object):
 
         return True
 
-    def _episodes(self, url=None, show_guid=False):
+    @FirstArgumentIsPodcastURL
+    def episodes(self, url=None, show_guid=False):
         output = []
         for podcast in self._model.get_podcasts():
             podcast_printed = False
@@ -452,14 +451,6 @@ class gPodderCli(object):
 
         self._pager('\n'.join(output))
         return True
-
-    @FirstArgumentIsPodcastURL
-    def episodes(self, url=None):
-      return self._episodes(url, False)
-
-    @FirstArgumentIsPodcastURL
-    def episodesguid(self, url):
-      return self._episodes(url, True)
 
     def list(self):
         for podcast in self._model.get_podcasts():
@@ -527,12 +518,12 @@ class gPodderCli(object):
             task.run()
 
     @FirstArgumentIsPodcastURL
-    def download(self, url=None):
+    def download(self, url=None, guid=None):
         episodes = []
         for podcast in self._model.get_podcasts():
             if url is None or podcast.url == url:
                 for episode in podcast.get_all_episodes():
-                    if self.is_episode_new(episode):
+                    if (not guid and self.is_episode_new(episode)) or (guid and episode.guid == guid):
                         episodes.append(episode)
 
         if self._config.downloads.chronological_order:
@@ -548,25 +539,6 @@ class gPodderCli(object):
 
         util.delete_empty_folders(gpodder.downloads)
         print(len(episodes), 'episodes downloaded.')
-        return True
-
-    @FirstArgumentIsPodcastURL
-    def downloadguid(self, url, guid):
-        podcast = self.get_podcast(url)
-
-        if podcast is None:
-            self._error(_('You are not subscribed to %s.') % url)
-        else:
-          episode_found = False
-          for podcast in self._model.get_podcasts():
-              if podcast.url == url:
-                  for episode in podcast.get_all_episodes():
-                      if episode.guid == guid:
-                          episode_found = True
-                          self._download_episode(episode)
-                          print(_('Episode with GUID %s downloaded.') % guid)
-          if not episode_found:
-            self._error(_('Episode with GUID %(guid)s not found in podcast %(url)s.') % { guid: guid, url: url })
         return True
 
     @FirstArgumentIsPodcastURL


### PR DESCRIPTION
[GPodder v4](https://github.com/gpodder/gpodder-core)'s ability to operate on single episodes would be really handy for a project of mine ([DashPodder](https://github.com/nmaggioni/DashPodder)), but as @thp [hinted](https://github.com/gpodder/gpodder-core/issues/22) it would be better if I proposed such capability on the V3 branch - so here it is! :)

This is a (somewhat rudimentary) approach to downloading single episodes basing on their GUID URL which is already known to the internal data storage; **suggestions on how to improve the commands' syntax or GUIDs display are welcome**.

On the podcasts I've tested GUIDs are either the link to the episode's MP3 file or a shorthand to its page on the podcast's website - the only relevant thing about this is the length of the value: it could get large and cause troubles when being displayed.

---

### Commands changes

+ `download [URL]` :arrow_right: `download [URL] [GUID]` - If a _GUID_ is given, only corresponding episode(s) are downloaded.
+ `episodes [URL]` :arrow_right: `episodes [URL] [SHOWGUID]` - If _SHOWGUID_ is specified **(can be any value)**, episodes' GUIDs are shown alongside the episode's number in the listing.