### PR TITLE
Fix file descriptor leaks into child processes

### DIFF
--- a/share/gpodder/examples/hello_world.py
+++ b/share/gpodder/examples/hello_world.py
@@ -1,9 +1,9 @@
 
-# Use a logger for debug output - this will be managed by gPodder
+# Use a logger for debug output - this will be managed by gPodder.
 import logging
 logger = logging.getLogger(__name__)
 
-# Provide some metadata that will be displayed in the gPodder GUI
+# Provide some metadata that will be displayed in the gPodder GUI.
 __title__ = 'Hello World Extension'
 __description__ = 'Explain in one sentence what this extension does.'
 __only_for__ = 'gtk, cli'
@@ -11,9 +11,9 @@ __authors__ = 'Thomas Perl <m@thp.io>'
 
 
 class gPodderExtension:
-    # The extension will be instantiated the first time it's used
+    # The extension will be instantiated the first time it's used.
     # You can do some sanity checks here and raise an Exception if
-    # you want to prevent the extension from being loaded..
+    # you want to prevent the extension from being loaded.
     def __init__(self, container):
         self.container = container
 
@@ -40,7 +40,7 @@ class gPodderExtension:
 
     def on_ui_object_available(self, name, ui_object):
         """
-        Called by gPodder when ui is ready
+        Called by gPodder when ui is ready.
         """
         if name == 'gpodder-gtk':
             self.gpodder = ui_object
@@ -50,3 +50,24 @@ class gPodderExtension:
 
     def say_hello_cb(self):
         self.gpodder.notification("Hello Extension", "Message", widget=self.gpodder.main_window)
+
+
+# Concurrency Warning
+#
+# When using subprocess.Popen() to spawn a long-lived external command,
+# such as ffmpeg, be sure to include the "close_fds=True" argument.
+#
+# https://docs.python.org/3/library/subprocess.html#subprocess.Popen
+#
+# This is expecially important for extensions responding to
+# on_episode_downloaded(), which runs whenever a download finishes.
+#
+# Otherwise that process will inherit ALL file descriptors gPodder
+# happens to have open at the moment (like other active downloads).
+# Those files will remain 'in-use' until that process exits, a race
+# condition which prevents gPodder from renaming or deleting them.
+#
+# Caveat: On Windows, you cannot set close_fds to true and also
+# redirect the standard handles (stdin, stdout or stderr). To collect
+# output/errors from long-lived external commands, it may be necessary
+# to create a (temp) log file and read it afterward.

--- a/share/gpodder/extensions/command_on_download.py
+++ b/share/gpodder/extensions/command_on_download.py
@@ -64,7 +64,7 @@ class gPodderExtension:
         env = os.environ.copy()
         env.update(info)
 
-        proc = subprocess.Popen(command, shell=True, env=env)
+        proc = subprocess.Popen(command, shell=True, env=env, close_fds=True)
         proc.wait()
         if proc.returncode == 0:
             logger.info("%s succeeded", command)

--- a/share/gpodder/extensions/concatenate_videos.py
+++ b/share/gpodder/extensions/concatenate_videos.py
@@ -71,7 +71,7 @@ class gPodderExtension:
 
         def convert():
             ffmpeg = subprocess.Popen(['ffmpeg', '-f', 'concat', '-nostdin', '-y',
-                '-i', list_filename, '-c', 'copy', out_filename])
+                '-i', list_filename, '-c', 'copy', out_filename], close_fds=True)
             result = ffmpeg.wait()
             util.delete_file(list_filename)
             util.idle_add(lambda: indicator.on_finished())

--- a/share/gpodder/extensions/enqueue_in_mediaplayer.py
+++ b/share/gpodder/extensions/enqueue_in_mediaplayer.py
@@ -78,7 +78,7 @@ class Win32Player(Player):
 
     def open_files(self, filenames):
         for cmd in util.format_desktop_command(self.command, filenames):
-            subprocess.Popen(cmd)
+            subprocess.Popen(cmd, close_fds=True)
 
 
 class MPRISResumer(FreeDesktopPlayer):

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2051,7 +2051,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                         for command in util.format_desktop_command('panucci', \
                                 [filename]):
                             logger.info('Executing: %s', repr(command))
-                            subprocess.Popen(command)
+                            subprocess.Popen(command, close_fds=True)
 
                     on_error = lambda err: error_handler(filename, err)
 
@@ -2076,7 +2076,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         for group in groups:
             for command in util.format_desktop_command(group, groups[group], resume_position):
                 logger.debug('Executing: %s', repr(command))
-                subprocess.Popen(command)
+                subprocess.Popen(command, close_fds=True)
 
         # Persist episode status changes to the database
         self.db.commit()

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1290,7 +1290,7 @@ def bluetooth_send_file(filename):
 
     if command_line is not None:
         command_line.append(filename)
-        return (subprocess.Popen(command_line).wait() == 0)
+        return (subprocess.Popen(command_line, close_fds=True).wait() == 0)
     else:
         logger.error('Cannot send file. Please install "bluetooth-sendto" or "gnome-obex-send".')
         return False
@@ -1419,9 +1419,9 @@ def gui_open(filename):
         if gpodder.ui.win32:
             os.startfile(filename)
         elif gpodder.ui.osx:
-            subprocess.Popen(['open', filename])
+            subprocess.Popen(['open', filename], close_fds=True)
         else:
-            subprocess.Popen(['xdg-open', filename])
+            subprocess.Popen(['xdg-open', filename], close_fds=True)
         return True
     except:
         logger.error('Cannot open file/folder: "%s"', filename, exc_info=True)


### PR DESCRIPTION
This pull request modifies Popen() calls in spawning panucci, spawning other players, util.gui_open(), and util.bluetooth_send_file().

Without this edit (an extra arg to Popen() calls), file handles leak into child processes. Those handles then remain in use, even after gPodder is done with them.

As discovered in issue #420 , this is problematic when gPodder spawns a player while a download is in progress. The partial file will stay locked after gPodder completes the transfer, causing an "in use" error when renaming the file from ".partial" to ".mp3". That happens even if the player was spawned to play some other file - the handle was inherited, not an arg.

.
Notes:

* On Windows, util.gui_open() relies on os.startfile(). I have not touched that and do not know if file descriptor (handle) inheritance is an issue there.
* On Windows, disabling inheritance **also** disables standard in/out/err redirection. Child processes that need to redirect streams cannot be fixed this way and will continue to have lock issues. However, short-lived requests for info from external commands should be tolerable.
* On Unix, standard streams are exempted and will function normally. So this fix could be applied in redirect-dependent code intended only to run on Unix.
* **Warning:** The following extensions have redirection. This fix was not applied to them. An alternate means of logging errors from long-lived external commands may be needed.
    * enqueue_in_mediaplayer.py
    * normalize_audio.py
    * rockbox_convert2mp4.py
    * ubuntu_unity.py
    * video_converter.py
* I recommend a notice about Popen() be included in documentation/examples for extenson developers.
* I hadn't set up a dev environment to test this commit, but it was a trivial edit (based on tests I did with a v3.9.6 PortableApps build for Windows).

.
[Article](https://docs.python.org/2/library/subprocess.html#subprocess.Popen): Python API: Subprocess.popen()

> If close_fds is true, all file descriptors except 0, 1 and 2 will be closed before the child process is executed. (Unix only). Or, on Windows, if close_fds is true then no handles will be inherited by the child process. Note that on Windows, you cannot set close_fds to true and also redirect the standard handles by setting stdin, stdout or stderr.