### PR TITLE
Command for single episode deletion

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -48,6 +48,7 @@
   - Episode management -
 
     download [URL] [GUID]      Download new episodes (all or only from URL) or single GUID
+    delete [URL] [GUID]        Delete from feed at URL an episode with given GUID
     pending [URL]              List new episodes (all or only from URL)
     episodes [--guid] [URL]    List episodes with or without GUIDs (all or only from URL)
 
@@ -557,6 +558,29 @@ class gPodderCli(object):
 
         util.delete_empty_folders(gpodder.downloads)
         print(len(episodes), 'episodes downloaded.')
+        return True
+
+    @FirstArgumentIsPodcastURL
+    def delete(self, url, guid):
+        podcast = self.get_podcast(url)
+        episode_to_delete = None
+
+        if podcast is None:
+            self._error(_('You are not subscribed to %s.') % url)
+        else:
+            for episode in podcast.get_all_episodes():
+                if (episode.guid == guid):
+                    episode_to_delete = episode
+
+            if not episode_to_delete:
+                self._error(_('No episode with the specified GUID found.'))
+            else:
+                if episode_to_delete.state != gpodder.STATE_DELETED:
+                    episode_to_delete.delete_from_disk()
+                    self._info(_('Deleted episode "%s".') % episode_to_delete.title)
+                else:
+                    self._error(_('Episode has already been deleted.'))
+
         return True
 
     @FirstArgumentIsPodcastURL


### PR DESCRIPTION
Pretty much a followup to #442, this brings in a new command for deleting single episodes given their feed's URL and their GUID's.

In order to avoid possible GUID duplicates _(two feeds could theoretically have equal values somewhere between their episodes list)_ the feed URL is mandatory.

---

### New commands

+ `delete [URL] [GUID]` - Delete from feed at URL an episode with given GUID.