### PR TITLE
Fix unable to drag and drop from episode list

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1019,8 +1019,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             uris = ['file://' + e.local_filename(create=False) \
                     for e in self.get_selected_episodes() \
                     if e.was_downloaded(and_exists=True)]
-            uris.append('') # for the trailing '\r\n'
-            selection_data.set(selection_data.target, 8, '\r\n'.join(uris))
+            selection_data.set_uris(uris)
         self.treeAvailable.connect('drag-data-get', drag_data_get)
 
         selection = self.treeAvailable.get_selection()


### PR DESCRIPTION
Attempting to drag and drop an episode to the playlist of an external media player is no longer working in 3.10.x and causes:

```
Traceback (most recent call last):
  File "/home/jawbkr/github/gpodder/src/gpodder/gtkui/main.py", line 1023, in drag_data_get
    selection_data.set(selection_data.target, 8, '\r\n'.join(uris))
AttributeError: 'SelectionData' object has no attribute 'target'
```
