### PR TITLE
Avoid async keyword for Python 3.6

### DIFF
--- a/src/gpodder/gtkui/services.py
+++ b/src/gpodder/gtkui/services.py
@@ -101,7 +101,7 @@ class CoverDownloader(ObservableService):
         """
         self.request_cover(channel, custom_url)
 
-    def __get_cover(self, channel, url, async=False, avoid_downloading=False):
+    def __get_cover(self, channel, url, async_mode=False, avoid_downloading=False):
         def get_filename():
             return self.downloader.get_cover(channel.cover_file,
                     url or channel.cover_url, channel.url, channel.title,
@@ -131,7 +131,7 @@ class CoverDownloader(ObservableService):
                 logger.warn('Corrupt cover art on server, deleting', exc_info=True)
                 util.delete_file(filename)
 
-        if async:
+        if async_mode:
             self.notify('cover-available', channel, pixbuf)
         else:
             return (channel.url, pixbuf)


### PR DESCRIPTION
Patch adapted from Debian's packaging. Original patch author: @tmancill

https://sources.debian.org/patches/gpodder/3.10.3-2/async-is-a-keyword.patch/

Related Debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=902794