### PR TITLE
Update ubuntu_appindicator.py to use AppIndicator3

### DIFF
--- a/share/gpodder/extensions/ubuntu_appindicator.py
+++ b/share/gpodder/extensions/ubuntu_appindicator.py
@@ -3,11 +3,6 @@
 # Ubuntu AppIndicator Icon
 # Thomas Perl <thp@gpodder.org>; 2012-02-24
 
-import logging
-
-from gi.repository import Gtk
-
-import appindicator
 import gpodder
 
 _ = gpodder.gettext
@@ -19,6 +14,12 @@ __category__ = 'desktop-integration'
 __only_for__ = 'gtk'
 __mandatory_in__ = 'unity'
 __disable_in__ = 'win32'
+
+
+from gi.repository import AppIndicator3 as appindicator
+from gi.repository import Gtk
+
+import logging
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +38,9 @@ class gPodderExtension:
 
     def on_load(self):
         if self.config.visible:
-            self.indicator = appindicator.Indicator('gpodder', 'gpodder',
-                    appindicator.CATEGORY_APPLICATION_STATUS)
-            self.indicator.set_status(appindicator.STATUS_ACTIVE)
+            self.indicator = appindicator.Indicator.new('gpodder', 'gpodder',
+                    appindicator.IndicatorCategory.APPLICATION_STATUS)
+            self.indicator.set_status(appindicator.IndicatorStatus.ACTIVE)
 
     def _rebuild_menu(self):
         menu = Gtk.Menu()

--- a/share/gpodder/extensions/ubuntu_appindicator.py
+++ b/share/gpodder/extensions/ubuntu_appindicator.py
@@ -3,6 +3,11 @@
 # Ubuntu AppIndicator Icon
 # Thomas Perl <thp@gpodder.org>; 2012-02-24
 
+import logging
+
+from gi.repository import AppIndicator3 as appindicator
+from gi.repository import Gtk
+
 import gpodder
 
 _ = gpodder.gettext
@@ -16,10 +21,7 @@ __mandatory_in__ = 'unity'
 __disable_in__ = 'win32'
 
 
-from gi.repository import AppIndicator3 as appindicator
-from gi.repository import Gtk
 
-import logging
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
ubuntu_appindicator.py was using the old appindicator module. Updated to use the
AppIndicator3 module as provided by the PyGObject library.