### PR TITLE
iterkeys no longer exists in Python 3

### DIFF
--- a/share/gpodder/extensions/sonos.py
+++ b/share/gpodder/extensions/sonos.py
@@ -72,7 +72,7 @@ class gPodderExtension:
             return []
 
         menu_entries = []
-        for uid in self.speakers.iterkeys():
+        for uid in list(self.speakers.keys()):
             callback = partial(self._stream_to_speaker, uid)
 
             controller = self.speakers[uid]


### PR DESCRIPTION
Was getting the error `AttributeError: 'dict' object has no attribute 'iterkeys'`.

This is the result of a `2to3`.
