### PR TITLE
Extend `tagging` extension to modify the id3 version

### DIFF
--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -32,7 +32,7 @@ import os
 from mutagen import File
 from mutagen.flac import Picture
 from mutagen.id3 import APIC, ID3
-from mutagen.mp3 import MP3
+from mutagen.mp3 import MP3, EasyMP3
 from mutagen.mp4 import MP4Cover, MP4Tags
 
 import gpodder
@@ -103,8 +103,11 @@ class AudioFile(object):
             if set_artist_to_album:
                 audio.tags['artist'] = self.album
 
-        logger.warn(audio.tags)
-        audio.save(v2_version=set_version)
+        if type(audio) is EasyMP3:
+            audio.save(v2_version=set_version)
+        else:
+            # Not actually audio
+            audio.save()
 
     def insert_coverart(self):
         """ implement the cover art logic in the subclass

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -87,8 +87,6 @@ class AudioFile(object):
         if audio.tags is None:
             audio.add_tags()
 
-        
-
         if modify_tags:
             if self.album is not None:
                 audio.tags['album'] = self.album
@@ -106,7 +104,7 @@ class AudioFile(object):
                 audio.tags['artist'] = self.album
 
         logger.warn(audio.tags)
-        audio.save(v2_version = set_version)
+        audio.save(v2_version=set_version)
 
     def insert_coverart(self):
         """ implement the cover art logic in the subclass

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -182,7 +182,6 @@ class Mp3File(AudioFile):
 
 class gPodderExtension:
     def __init__(self, container):
-        logger.info(container)
         self.container = container
 
     def on_episode_downloaded(self, episode):


### PR DESCRIPTION
This PR enables users to modify the `id3` tag version of their podcasts. 

I added support for the `tagging` extension to force the `id3` version (and optionally not change any of the tags). I did this because my car does not support `id3` version `2.4`. 