### PR TITLE
fix exception from locale.setlocale

### DIFF
--- a/src/gpodder/utilwin32locale.py
+++ b/src/gpodder/utilwin32locale.py
@@ -339,7 +339,14 @@ def install(domain, localedir):
     :param localedir: locale directory
     '''
     # prep locale system
-    locale.setlocale(locale.LC_ALL, '')
+    try:
+        # An empty string specifies the user’s default settings.
+        #  If the modification of the locale fails, the exception Error is raised. If successful, the new locale
+        #  setting is returned.
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error:
+        # If locale is omitted or None, the current setting for category is returned.
+        locale.setlocale(locale.LC_ALL, None)
 
     # on windows systems, set the LANGUAGE environment variable
     if sys.platform == 'win32' or sys.platform == 'nt':


### PR DESCRIPTION
Hi there,
- first thanks for your efforts providing gpodder.

I got an issue on Windows related to setting the locale.
Maybe someone also experiences the same issue...

**locale.setlocale(locale.LC_ALL, '') threw an exception**
I can only guess that my particular setup is the cause - when read the locale I got the following mixture:

py.exe -3 -c "import locale; print(locale.setlocale(locale.LC_CTYPE, ''))"
English_Germany.1252

I am catching the exception and make a second call with parameter "locale" being None
locale.setlocale(locale.LC_ALL, **None**)


Python 3.7 documentation says:

> locale.setlocale(category, locale=None)
> If locale is given and not None, setlocale() modifies the locale setting for the category. The available categories are listed in the data description below. locale may be a string, or an iterable of two strings (language code and encoding). If it’s an iterable, it’s converted to a locale name using the locale aliasing engine. An empty string specifies the user’s default settings. If the modification of the locale fails, the exception Error is raised. If successful, the new locale setting is returned.
> 
> If locale is omitted or None, the current setting for category is returned.

Kind regards

P.S. Should I open an issue?


