### PR TITLE
Add extension storage to channels and episodes

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -108,6 +108,7 @@ class PodcastModelObject(object):
     __slots__ = ('id', 'parent', 'children', '_parsed_ext_data', '_ext_data_dirty')
 
     def __init__(self):
+        self._parsed_ext_data = None
         self._ext_data_dirty = False
 
     @classmethod

--- a/src/gpodder/schema.py
+++ b/src/gpodder/schema.py
@@ -50,6 +50,7 @@ EpisodeColumns = (
     'last_playback',
     'payment_url',
     'description_html',
+    'ext_data',
 )
 
 PodcastColumns = (
@@ -70,9 +71,10 @@ PodcastColumns = (
     'download_strategy',
     'sync_to_mp3_player',
     'cover_thumb',
+    'ext_data',
 )
 
-CURRENT_VERSION = 7
+CURRENT_VERSION = 8
 
 
 # SQL commands to upgrade old database versions to new ones
@@ -114,6 +116,12 @@ UPGRADE_SQL = [
         UPDATE episode SET description=remove_html_tags(description_html) WHERE is_html(description)
         UPDATE podcast SET http_last_modified=NULL, http_etag=NULL
         """),
+
+        # Version 8: Add extension storage
+        (7, 8, """
+        ALTER TABLE podcast ADD COLUMN ext_data TEXT NULL DEFAULT NULL
+        ALTER TABLE episode ADD COLUMN ext_data TEXT NULL DEFAULT NULL
+        """),
 ]
 
 
@@ -138,7 +146,8 @@ def initialize_database(db):
         payment_url TEXT NULL DEFAULT NULL,
         download_strategy INTEGER NOT NULL DEFAULT 0,
         sync_to_mp3_player INTEGER NOT NULL DEFAULT 1,
-        cover_thumb BLOB NULL DEFAULT NULL
+        cover_thumb BLOB NULL DEFAULT NULL,
+        ext_data TEXT NULL DEFAULT NULL
     )
     """)
 
@@ -172,7 +181,8 @@ def initialize_database(db):
         current_position_updated INTEGER NOT NULL DEFAULT 0,
         last_playback INTEGER NOT NULL DEFAULT 0,
         payment_url TEXT NULL DEFAULT NULL,
-        description_html TEXT NOT NULL DEFAULT ''
+        description_html TEXT NOT NULL DEFAULT '',
+        ext_data TEXT NULL DEFAULT NULL
     )
     """)
 
@@ -267,6 +277,7 @@ def convert_gpodder2_db(old_db, new_db):
                 0,
                 row['sync_to_devices'],
                 None,
+                None,
         )
         new_db.execute("""
         INSERT INTO podcast VALUES (%s)
@@ -299,6 +310,7 @@ def convert_gpodder2_db(old_db, new_db):
                 0,
                 None,
                 '',
+                None,
         )
         new_db.execute("""
         INSERT INTO episode VALUES (%s)


### PR DESCRIPTION
Original use case: I'm writing a custom feed handler for OPDS (special kind of atom to distribute books). The way custom feed handlers work is each one is called until one returns not None. So my OPDS custom feed handler is called on every podcast. I can't find out if the feed is opds or not until I parse the feed. Too bad to have essentially done everything (download, parse) to throw it away because it's not OPDS. So I want to remember that a feed is or isn't opds.

This PR:
 - adds an *ext_data* column to podcast and episode, converted to a JsonConfig object when needed.
 - adds `get_ext_data(ext_name)` to podcast and episode, returning the relevant subtree of the JsonConfig
 - hooks into `save()` to serialize back the JsonConfig in the database when needed.

Alternatives: 
 - let extensions store this info in their configuration.  
  **pros**: don't have to extend the schema   
  **cons**: data is not really attached to the podcast. It needs to be cleaned when the user unsubscribes
 - go one step further and allow arbitrary tables per extensions, where my OPDS extension would declare a foreign key to podcasts and a bool column for *ignored*  
  **pros**: more efficient than a common json column for all extensions (compact, less parsing)  
  **cons**: harder to implement.