### PR TITLE
Fix Win32 Powershell Notifications

### DIFF
--- a/share/gpodder/extensions/notification-win32.py
+++ b/share/gpodder/extensions/notification-win32.py
@@ -103,6 +103,7 @@ try {{
         $xml.LoadXml($template)
         $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
         [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($APP_ID).Show($toast)
+        Remove-Item -LiteralPath $MyInvocation.MyCommand.Path -Force    # Delete this script temp file.
     }} else {{
         # use older Baloon notification when not on Windows 10
         [System.Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms")
@@ -118,7 +119,11 @@ try {{
 "@
 
     $o.Visible = $True
-    $o.ShowBalloonTip(10000)
+    $Delay = 10    # Delay value in seconds.
+    $o.ShowBalloonTip($Delay*1000)
+    Start-Sleep -s $Delay 
+    $o.Dispose()
+    Remove-Item -LiteralPath $MyInvocation.MyCommand.Path -Force    # Delete this script temp file.
     }}
 }} catch {{
     write-host "Caught an exception:"
@@ -140,11 +145,11 @@ try {{
             powershell = r"{}\sysnative\WindowsPowerShell\v1.0\powershell.exe".format(os.environ["SystemRoot"])
             if not os.path.exists(powershell):
                 powershell = "powershell.exe"
-            subprocess.run([powershell,
-                           "-ExecutionPolicy", "Bypass", "-File", path], check=True,
+            subprocess.Popen([powershell,
+                           "-ExecutionPolicy", "Bypass", "-File", path],
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                            startupinfo=startupinfo)
-            os.remove(path)  # XXX: otherwise keep it for debugging
+            #os.remove(path)  # XXX: otherwise keep it for debugging
         except subprocess.CalledProcessError as e:
             logger.error("Error in on_notification_show(title=%r, message=%r):\n"
                          "\t%r exit code %i\n\tstdout=%s\n\tstderr=%s",

--- a/share/gpodder/extensions/notification-win32.py
+++ b/share/gpodder/extensions/notification-win32.py
@@ -149,7 +149,6 @@ try {{
                            "-ExecutionPolicy", "Bypass", "-File", path],
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                            startupinfo=startupinfo)
-            #os.remove(path)  # XXX: otherwise keep it for debugging
         except subprocess.CalledProcessError as e:
             logger.error("Error in on_notification_show(title=%r, message=%r):\n"
                          "\t%r exit code %i\n\tstdout=%s\n\tstderr=%s",

--- a/share/gpodder/extensions/notification-win32.py
+++ b/share/gpodder/extensions/notification-win32.py
@@ -121,7 +121,7 @@ try {{
     $o.Visible = $True
     $Delay = 10    # Delay value in seconds.
     $o.ShowBalloonTip($Delay*1000)
-    Start-Sleep -s $Delay 
+    Start-Sleep -s $Delay
     $o.Dispose()
     Remove-Item -LiteralPath $MyInvocation.MyCommand.Path -Force    # Delete this script temp file.
     }}


### PR DESCRIPTION
On Windows 7, the Powershell notifications that gPodder  3.x is using are never deleted from the desktop.  The notification icons permanently stay visible in the taskbar system tray, untill your manually roll over them with the mouse cursor.

Changing the subprocess  from "run" to "Popen" so the fuction is non-blocking.

Non Win 10 Windows script will create it's own time delay, after which it removes the taskbar system tray icon, and then deletes it's own script file.

Removing the Python delete file, and have the Powershell script delete itself when it's done, because we want the script to be non-blocking and be removed from the temp folder after use.

I have not tested on Win 10 as I use Win 7, so I don't know if Win 10 has the same issues with Powershell permant  taskbar system tray icons.  So this fix is just for <Win10 script notifications.