### PR TITLE
Update Norwegian Nynorsk translation

### DIFF
--- a/po/nn.po
+++ b/po/nn.po
@@ -1,100 +1,41 @@
-# SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
 # Translators:
 # Thomas Perl <thp@perli.net>, 2006.
-# Torstein Adolf Winterseth <kvikende@fsfe.org>, 2010.
-# Torstein Adolf Winterseth <kvikende@yahoo.no>, 2009, 2010.
+# Torstein Adolf Winterseth <kvikende@fsfe.org>, 2009, 2010.
+# Karl Ove Hufthammer <karl@huftis.org>, 2019.
 msgid ""
 msgstr ""
 "Project-Id-Version: gPodder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-10 21:26+0200\n"
-"PO-Revision-Date: 2013-01-19 12:30+0000\n"
-"Last-Translator: Thomas Perl <m@thp.io>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2019-09-11 21:33+0200\n"
+"PO-Revision-Date: 2019-09-11 21:23+0200\n"
+"Last-Translator: Karl Ove Hufthammer <karl@huftis.org>\n"
+"Language-Team: Norwegian Nynorsk <i18n-nn@lister.ping.uio.no>\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: src/gpodder/config.py:54
-#, python-format
-msgid "gPodder on %s"
-msgstr "gPodder på %s"
-
-#: src/gpodder/syncui.py:84
-msgid "No device configured"
-msgstr "Inga eining er sett opp"
-
-#: src/gpodder/syncui.py:85
-msgid "Please set up your device in the preferences dialog."
-msgstr "Set opp eininga di i innstillingsdialogen."
-
-#: src/gpodder/syncui.py:90
-msgid "Cannot open device"
-msgstr "Klarte ikkje opna eining"
-
-#: src/gpodder/syncui.py:91
-msgid "Please check the settings in the preferences dialog."
-msgstr "Sjekk innstillingane i innstillingsdialogen."
-
-#: src/gpodder/syncui.py:138
-msgid "Not enough space left on device"
-msgstr "Ikkje nok plass att på eininga"
-
-#: src/gpodder/syncui.py:139
-#, fuzzy, python-format
-msgid ""
-"Additional free space required: %(required_space)s\n"
-"Do you want to continue?"
-msgstr ""
-"Du må frigjera %s.\n"
-"Vil du fortsetja?"
-
-#: src/gpodder/syncui.py:201
-#, fuzzy
-msgid "Update successful"
-msgstr "Opplastinga av liste var vellykka."
-
-#: src/gpodder/syncui.py:202
-msgid "The playlist on your MP3 player has been updated."
-msgstr ""
-
-#: src/gpodder/syncui.py:270 src/gpodder/gtkui/main.py:847
-#: src/gpodder/gtkui/main.py:973 src/gpodder/gtkui/main.py:2791
-#: src/gpodder/gtkui/main.py:2994
-#: src/gpodder/gtkui/desktop/episodeselector.py:127
-msgid "Episode"
-msgstr "Episode"
-
-#: src/gpodder/syncui.py:275
-msgid "Episodes have been deleted on device"
-msgstr ""
-
-#: src/gpodder/syncui.py:287
-#, fuzzy
-msgid "Error writing playlist files"
-msgstr "Klarte ikkje konvertera fil."
+"X-Generator: Lokalize 19.11.70\n"
 
 #: src/gpodder/youtube.py:336 src/gpodder/model.py:468
 #: src/gpodder/plugins/soundcloud.py:174
 #: share/gpodder/extensions/youtube-dl.py:165
 msgid "No description available"
-msgstr "Ingen detaljar tilgjengeleg"
+msgstr "Inga skildring tilgjengeleg"
 
 #: src/gpodder/util.py:443
 #, python-format
 msgid "%(count)d day ago"
 msgid_plural "%(count)d days ago"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d dag sidan"
+msgstr[1] "%(count)d dagar sidan"
 
 #: src/gpodder/util.py:522
 msgid "Today"
-msgstr "Idag"
+msgstr "I dag"
 
 #: src/gpodder/util.py:524
 msgid "Yesterday"
@@ -108,168 +49,82 @@ msgstr "(ukjend)"
 #, python-format
 msgid "%(count)d second"
 msgid_plural "%(count)d seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d sekund"
+msgstr[1] "%(count)d sekund"
 
 #: src/gpodder/util.py:1389
 #, python-format
 msgid "%(count)d hour"
 msgid_plural "%(count)d hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d time"
+msgstr[1] "%(count)d timar"
 
 #: src/gpodder/util.py:1393
 #, python-format
 msgid "%(count)d minute"
 msgid_plural "%(count)d minutes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d minutt"
+msgstr[1] "%(count)d minutt"
 
 #: src/gpodder/util.py:1401
 msgid "and"
 msgstr "og"
 
-#: src/gpodder/deviceplaylist.py:98
-#, fuzzy, python-format
-msgid "Folder %s could not be created."
-msgstr "Klarte ikkje oppdatera kjelda med adressa %(url)s"
+#: src/gpodder/syncui.py:84
+msgid "No device configured"
+msgstr "Inga eining er sett opp"
 
-#: src/gpodder/deviceplaylist.py:98
-#, fuzzy
-msgid "Error writing playlist"
-msgstr "Klarte ikkje opna spelar"
+#: src/gpodder/syncui.py:85
+msgid "Please set up your device in the preferences dialog."
+msgstr "Set opp eininga i innstillingane."
 
-#: src/gpodder/download.py:370 bin/gpo:319
-msgid "Wrong username/password"
-msgstr "Feil brukarnamn/passord"
+#: src/gpodder/syncui.py:90
+msgid "Cannot open device"
+msgstr "Klarte ikkje opna eining"
 
-#: src/gpodder/download.py:550 src/gpodder/sync.py:958
-msgid "Added"
-msgstr "Lagt til"
+#: src/gpodder/syncui.py:91
+msgid "Please check the settings in the preferences dialog."
+msgstr "Sjå til at innstillingane er rette."
 
-#: src/gpodder/download.py:550 src/gpodder/sync.py:958
-msgid "Queued"
-msgstr "I kø"
+#: src/gpodder/syncui.py:138
+msgid "Not enough space left on device"
+msgstr "Ikkje nok plass att på eininga"
 
-#: src/gpodder/download.py:550 src/gpodder/gtkui/model.py:372
-msgid "Downloading"
-msgstr "Lastar ned"
-
-#: src/gpodder/download.py:551 src/gpodder/model.py:744 src/gpodder/sync.py:959
-msgid "Finished"
-msgstr "Ferdig"
-
-#: src/gpodder/download.py:551 src/gpodder/sync.py:959
-msgid "Failed"
-msgstr "Feila"
-
-#: src/gpodder/download.py:551 src/gpodder/sync.py:959
-msgid "Cancelled"
-msgstr "Avbrote"
-
-#: src/gpodder/download.py:551 src/gpodder/sync.py:959
-msgid "Paused"
-msgstr "Pausa"
-
-#: src/gpodder/download.py:898
-msgid "Missing content from server"
-msgstr "Manglande innhald frå tenaren"
-
-#: src/gpodder/download.py:904
-#, python-format
-msgid "I/O Error: %(error)s: %(filename)s"
-msgstr "I/O-feil: %(error)s: %(filename)s"
-
-#: src/gpodder/download.py:911
-#, python-format
-msgid "HTTP Error %(code)s: %(message)s"
-msgstr "HTTP-feil %(code)s: %(message)s"
-
-#: src/gpodder/download.py:915 src/gpodder/sync.py:1114
-#, python-format
-msgid "Error: %s"
-msgstr "Feil: %s"
-
-#: src/gpodder/directory.py:97
-#, fuzzy
-msgid "gpodder.net search"
-msgstr "gpodder.net"
-
-#: src/gpodder/directory.py:107
-#, fuzzy
-msgid "OPML from web"
-msgstr "OMPL-filer"
-
-#: src/gpodder/directory.py:117
-#, fuzzy
-msgid "OPML file"
-msgstr "OMPL-filer"
-
-#: src/gpodder/directory.py:127 share/gpodder/ui/gtk/gpodderwelcome.ui.h:1
-#, fuzzy
-msgid "Getting started"
-msgstr "Innstillingar"
-
-#: src/gpodder/directory.py:137
-#, fuzzy
-msgid "gpodder.net Top 50"
-msgstr "gpodder.net"
-
-#: src/gpodder/directory.py:147
-#, fuzzy
-msgid "gpodder.net Tags"
-msgstr "gpodder.net"
-
-#: src/gpodder/directory.py:160
-#, fuzzy
-msgid "Soundcloud search"
-msgstr "%s på Soundcloud"
-
-#: src/gpodder/directory.py:174
-#, fuzzy
-msgid "Imported OPML file"
-msgstr "Importer frå OPML-fil"
-
-#: src/gpodder/model.py:702
-msgid "unknown"
-msgstr "ukjend"
-
-#: src/gpodder/model.py:773
-msgid "Default"
-msgstr ""
-
-#: src/gpodder/model.py:774
-msgid "Only keep latest"
-msgstr ""
-
-#: src/gpodder/model.py:808 src/gpodder/model.py:1216
-#: src/gpodder/extensions.py:59
-msgid "Other"
-msgstr "Andre"
-
-#: src/gpodder/model.py:1199 src/gpodder/model.py:1214
-#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:10
-msgid "Video"
-msgstr ""
-
-#: src/gpodder/model.py:1212
-msgid "Audio"
-msgstr ""
-
-#: src/gpodder/model.py:1391
+#: src/gpodder/syncui.py:139
 #, python-format
 msgid ""
-"Warning: path to gPodder home (%(root)s) is very long and can result in "
-"failure to download files.\n"
+"Additional free space required: %(required_space)s\n"
+"Do you want to continue?"
 msgstr ""
+"Du må frigjera %(required_space)s.\n"
+"Vil du halda fram?"
 
-#: src/gpodder/model.py:1393
-msgid "You're advised to set it to a shorter path."
-msgstr ""
+#: src/gpodder/syncui.py:201
+msgid "Update successful"
+msgstr "Oppdatering fullført"
+
+#: src/gpodder/syncui.py:202
+msgid "The playlist on your MP3 player has been updated."
+msgstr "Spelelista på MP3-spelaren er no oppdatert."
+
+#: src/gpodder/syncui.py:270 src/gpodder/gtkui/main.py:847
+#: src/gpodder/gtkui/main.py:973 src/gpodder/gtkui/main.py:2791
+#: src/gpodder/gtkui/main.py:2994
+#: src/gpodder/gtkui/desktop/episodeselector.py:127
+msgid "Episode"
+msgstr "Episode"
+
+#: src/gpodder/syncui.py:275
+msgid "Episodes have been deleted on device"
+msgstr "Episodar vart sletta frå eininga"
+
+#: src/gpodder/syncui.py:287
+msgid "Error writing playlist files"
+msgstr "Feil ved lagring av spelelistefiler"
 
 #: src/gpodder/sync.py:238
 msgid "Cancelled by user"
-msgstr "Avbroten av brukar."
+msgstr "Avbroten av brukar"
 
 #: src/gpodder/sync.py:241
 msgid "Writing data to disk"
@@ -320,6 +175,8 @@ msgstr "MP3-spelar opna"
 msgid ""
 "Not enough space in %(path)s: %(free)s available, but need at least %(need)s"
 msgstr ""
+"Ikkje nok ledig plass på %(path)s: %(free)s tilgjengeleg, men treng minst "
+"%(need)s"
 
 #: src/gpodder/sync.py:626 src/gpodder/sync.py:634
 #, python-format
@@ -352,12 +209,40 @@ msgstr "%s lukka"
 #: src/gpodder/sync.py:847 bin/gpo:802
 #, python-format
 msgid "Adding %s..."
-msgstr "Legg til %s ..."
+msgstr "Legg til %s …"
+
+#: src/gpodder/sync.py:958 src/gpodder/download.py:550
+msgid "Added"
+msgstr "Lagd til"
+
+#: src/gpodder/sync.py:958 src/gpodder/download.py:550
+msgid "Queued"
+msgstr "Lagd i kø"
 
 #: src/gpodder/sync.py:958
-#, fuzzy
 msgid "Synchronizing"
-msgstr "Synkronisering"
+msgstr "Synkroniserer"
+
+#: src/gpodder/sync.py:959 src/gpodder/model.py:744 src/gpodder/download.py:551
+msgid "Finished"
+msgstr "Fullført"
+
+#: src/gpodder/sync.py:959 src/gpodder/download.py:551
+msgid "Failed"
+msgstr "Mislukka"
+
+#: src/gpodder/sync.py:959 src/gpodder/download.py:551
+msgid "Cancelled"
+msgstr "Avbroten"
+
+#: src/gpodder/sync.py:959 src/gpodder/download.py:551
+msgid "Paused"
+msgstr "Sett på pause"
+
+#: src/gpodder/sync.py:1114 src/gpodder/download.py:915
+#, python-format
+msgid "Error: %s"
+msgstr "Feil: %s"
 
 #: src/gpodder/my.py:178
 #, python-format
@@ -369,897 +254,169 @@ msgstr "Legg til %s"
 msgid "Remove %s"
 msgstr "Fjern %s"
 
+#: src/gpodder/model.py:702
+msgid "unknown"
+msgstr "ukjend"
+
+#: src/gpodder/model.py:773
+msgid "Default"
+msgstr "Standard"
+
+#: src/gpodder/model.py:774
+msgid "Only keep latest"
+msgstr "Behald berre nyaste episodar"
+
+# Noko anna enn video eller lyd.
+#: src/gpodder/model.py:808 src/gpodder/model.py:1219
+#: src/gpodder/extensions.py:59
+msgid "Other"
+msgstr "Anna"
+
+#: src/gpodder/model.py:1202 src/gpodder/model.py:1217
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:10
+msgid "Video"
+msgstr "Video"
+
+#: src/gpodder/model.py:1215
+msgid "Audio"
+msgstr "Lyd"
+
+#: src/gpodder/model.py:1394
+#, python-format
+msgid ""
+"Warning: path to gPodder home (%(root)s) is very long and can result in "
+"failure to download files.\n"
+msgstr ""
+"Åtvaring: Adressa til gPodder-mappa (%(root)s) er veldig lang, noko som kan "
+"føra til feil ved nedlasting av filer.\n"
+
+#: src/gpodder/model.py:1396
+msgid "You're advised to set it to a shorter path."
+msgstr "Du bør flytta mappa for å gjera adressa kortare."
+
 #: src/gpodder/extensions.py:55
 msgid "Desktop Integration"
-msgstr ""
+msgstr "Skrivebordsintegrering"
 
 #: src/gpodder/extensions.py:56
-#, fuzzy
 msgid "Interface"
-msgstr "Heiltal"
+msgstr "Brukargrensesnitt"
 
+# Kategorinamn for programtillegg som gjer handlingar *etter* nedlasting av einskildepisodar.
 #: src/gpodder/extensions.py:57
-#, fuzzy
 msgid "Post download"
-msgstr "Pause nedlasting"
+msgstr "Etter nedlasting"
 
 #: src/gpodder/extensions.py:100
-#, fuzzy
 msgid "No description for this extension."
-msgstr "Inga skildring tilgjengeleg."
+msgstr "Manglar skildring for utvidinga."
 
 #: src/gpodder/extensions.py:220
 #, python-format
 msgid "Command not found: %(command)s"
-msgstr ""
+msgstr "Fann ikkje kommandoen: %(command)s"
 
 #: src/gpodder/extensions.py:236
 #, python-format
 msgid "Need at least one of the following commands: %(list_of_commands)s"
-msgstr ""
+msgstr "Treng minst éin av desse kommandoane: %(list_of_commands)s"
 
 #: src/gpodder/extensions.py:273
-#, fuzzy, python-format
+#, python-format
 msgid "Python module not found: %(module)s"
-msgstr "Python-modulen «%s» er ikkje installert"
+msgstr "Fann ikkje Python-modul: %(module)s"
 
-#: src/gpodder/gtkui/app.py:117
-msgid "Cannot start gPodder"
-msgstr "Klarte ikkje starta gPodder"
+#: src/gpodder/download.py:370 bin/gpo:319
+msgid "Wrong username/password"
+msgstr "Feil brukarnamn/passord"
 
-#: src/gpodder/gtkui/app.py:118
+#: src/gpodder/download.py:550 src/gpodder/gtkui/model.py:372
+msgid "Downloading"
+msgstr "Lastar ned"
+
+#: src/gpodder/download.py:898
+msgid "Missing content from server"
+msgstr "Manglar innhald frå tenaren"
+
+#: src/gpodder/download.py:904
 #, python-format
-msgid "D-Bus error: %s"
-msgstr "D-Bus-feil: %s"
+msgid "I/O Error: %(error)s: %(filename)s"
+msgstr "I/U-feil: %(error)s: %(filename)s"
 
-#: src/gpodder/gtkui/app.py:141
-#, fuzzy
-msgid "About gPodder"
-msgstr "Avslutt gPodder"
-
-#: src/gpodder/gtkui/app.py:165
-#, fuzzy
-msgid "Website"
-msgstr "Nettstad:"
-
-#: src/gpodder/gtkui/app.py:166
-msgid "Bug Tracker"
-msgstr ""
-
-#: src/gpodder/gtkui/app.py:217
-msgid "Path to gPodder home is too long"
-msgstr ""
-
-#: src/gpodder/gtkui/desktopfile.py:70
+#: src/gpodder/download.py:911
 #, python-format
-msgid "Command: %s"
-msgstr "Kommando: %s"
+msgid "HTTP Error %(code)s: %(message)s"
+msgstr "HTTP-feil %(code)s: %(message)s"
 
-#: src/gpodder/gtkui/desktopfile.py:156
-msgid "Default application"
-msgstr "Standardprogram"
+#: src/gpodder/directory.py:97
+msgid "gpodder.net search"
+msgstr "Søk på gpodder.net"
 
-#: src/gpodder/gtkui/main.py:149 share/applications/gpodder.desktop.in.h:1
-msgid "gPodder"
-msgstr "gPodder"
+#: src/gpodder/directory.py:107
+msgid "OPML from web"
+msgstr "OPML frå nettet"
 
-#: src/gpodder/gtkui/main.py:318 share/gpodder/ui/gtk/menus.ui.h:28
-msgid "E_xtras"
-msgstr ""
+#: src/gpodder/directory.py:117
+msgid "OPML file"
+msgstr "OPML-fil"
 
-#: src/gpodder/gtkui/main.py:319
-#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:11
-msgid "Extensions"
-msgstr ""
+#: src/gpodder/directory.py:127 share/gpodder/ui/gtk/gpodderwelcome.ui.h:1
+msgid "Getting started"
+msgstr "Kom i gang"
 
-#: src/gpodder/gtkui/main.py:338
-msgid "Loading incomplete downloads"
-msgstr "Lastar ufullstendige nedlastingar"
+#: src/gpodder/directory.py:137
+msgid "gpodder.net Top 50"
+msgstr "Topp 50 på gpodder.net"
 
-#: src/gpodder/gtkui/main.py:339
-msgid "Some episodes have not finished downloading in a previous session."
-msgstr "Somme episodar har ikkje vorte lasta ned ferdig i ei tidlegare økt."
+#: src/gpodder/directory.py:147
+msgid "gpodder.net Tags"
+msgstr "gpodder.net-merkelappar"
 
-#: src/gpodder/gtkui/main.py:342 bin/gpo:586
+#: src/gpodder/directory.py:160
+msgid "Soundcloud search"
+msgstr "SoundCloud-søk"
+
+#: src/gpodder/directory.py:174
+msgid "Imported OPML file"
+msgstr "Importert OPML-fil"
+
+#: src/gpodder/deviceplaylist.py:98
 #, python-format
-msgid "%(count)d partial file"
-msgid_plural "%(count)d partial files"
-msgstr[0] ""
-msgstr[1] ""
+msgid "Folder %s could not be created."
+msgstr "Klarte ikkje oppretta mappa %s."
 
-#: src/gpodder/gtkui/main.py:358
-msgid "Resume all"
-msgstr "Fortset alle"
+#: src/gpodder/deviceplaylist.py:98
+msgid "Error writing playlist"
+msgstr "Feil ved lagring av speleliste"
 
-#: src/gpodder/gtkui/main.py:370
-msgid "Incomplete downloads from a previous session were found."
-msgstr "Ufullstendige nedlastingar frå ei tidlegare økt vart funne."
-
-#: src/gpodder/gtkui/main.py:475
-msgid "Action"
-msgstr "Handling"
-
-#: src/gpodder/gtkui/main.py:522
-msgid "Confirm changes from gpodder.net"
-msgstr "Stadfest endringar frå gpodder.net"
-
-#: src/gpodder/gtkui/main.py:523
-msgid "Select the actions you want to carry out."
-msgstr "Vel handlingane du vil utføra"
-
-#: src/gpodder/gtkui/main.py:563
-msgid "Uploading subscriptions"
-msgstr "Lastar opp abonnement"
-
-#: src/gpodder/gtkui/main.py:564
-msgid "Your subscriptions are being uploaded to the server."
-msgstr "Dine abonnement vert lasta opp til tenaren."
-
-#: src/gpodder/gtkui/main.py:569
-msgid "List uploaded successfully."
-msgstr "Opplastinga av liste var vellykka."
-
-#: src/gpodder/gtkui/main.py:576
-msgid "Error while uploading"
-msgstr "Feil under opplasting"
-
-#: src/gpodder/gtkui/main.py:866
-msgid "Size"
-msgstr "Storleik"
-
-#: src/gpodder/gtkui/main.py:871
-msgid "Duration"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:875
-msgid "Released"
-msgstr "Utgjeven"
-
-#: src/gpodder/gtkui/main.py:993 src/gpodder/gtkui/main.py:1142
-#: share/gpodder/ui/gtk/gpodder.ui.h:11
-msgid "Progress"
-msgstr "Framdrift"
-
-#: src/gpodder/gtkui/main.py:1021
-msgid "No episodes in current view"
-msgstr "Ingen episodar her"
-
-#: src/gpodder/gtkui/main.py:1023
-msgid "No episodes available"
-msgstr "Ingen episodar tilgjengeleg"
-
-#: src/gpodder/gtkui/main.py:1029
-msgid "No podcasts in this view"
-msgstr "Ingen podkastar her"
-
-#: src/gpodder/gtkui/main.py:1031
-msgid "No subscriptions"
-msgstr "Ingen abonnement"
-
-#: src/gpodder/gtkui/main.py:1033
-#, fuzzy
-msgid "No active tasks"
-msgstr "Ingen aktive nedlastingar"
-
-#: src/gpodder/gtkui/main.py:1146 src/gpodder/gtkui/main.py:1148
+#: src/gpodder/config.py:54
 #, python-format
-msgid "%(count)d active"
-msgid_plural "%(count)d active"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:1150
-#, python-format
-msgid "%(count)d failed"
-msgid_plural "%(count)d failed"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:1152
-#, python-format
-msgid "%(count)d queued"
-msgid_plural "%(count)d queued"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:1165
-#, python-format
-msgid "downloading %(count)d file"
-msgid_plural "downloading %(count)d files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:1177
-#, python-format
-msgid "synchronizing %(count)d file"
-msgid_plural "synchronizing %(count)d files"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:1181
-#, python-format
-msgid "%(queued)d task queued"
-msgid_plural "%(queued)d tasks queued"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:1208
-msgid "Please report this problem and restart gPodder:"
-msgstr "Ver god og rapporter dette problemet og start gPodder på nytt:"
-
-#: src/gpodder/gtkui/main.py:1209
-msgid "Unhandled exception"
-msgstr "Ikkje-handtert unntak"
-
-#: src/gpodder/gtkui/main.py:1276
-#, python-format
-msgid "Feedparser error: %s"
-msgstr "Kjeldetolkarfeil: %s"
-
-#: src/gpodder/gtkui/main.py:1409
-#, fuzzy
-msgid "Could not download some episodes:"
-msgstr "Klarte ikkje leggja til somme podkastar"
-
-#: src/gpodder/gtkui/main.py:1411 src/gpodder/gtkui/main.py:1414
-msgid "Downloads finished"
-msgstr "Nedlastingar er fullførte"
-
-#: src/gpodder/gtkui/main.py:1417
-msgid "Downloads failed"
-msgstr "Nedlastingar feila"
-
-#: src/gpodder/gtkui/main.py:1422
-#, fuzzy
-msgid "Could not sync some episodes:"
-msgstr "Klarte ikkje leggja til somme podkastar"
-
-#: src/gpodder/gtkui/main.py:1425 src/gpodder/gtkui/main.py:1429
-#, fuzzy
-msgid "Device synchronization finished"
-msgstr "Eining synkronisert"
-
-#: src/gpodder/gtkui/main.py:1433
-#, fuzzy
-msgid "Device synchronization failed"
-msgstr "Eining synkronisert"
-
-#: src/gpodder/gtkui/main.py:1476
-#, python-format
-msgid "%(count)d more episode"
-msgid_plural "%(count)d more episodes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:1584
-msgid "Start download now"
-msgstr "Start nedlasting no"
-
-#: src/gpodder/gtkui/main.py:1589 src/gpodder/gtkui/main.py:1868
-#: src/gpodder/gtkui/desktop/podcastdirectory.py:192
-#: src/gpodder/gtkui/desktop/episodeselector.py:139
-#: share/gpodder/ui/gtk/gpodder.ui.h:1 share/gpodder/ui/gtk/menus.ui.h:22
-msgid "Download"
-msgstr "Last ned"
-
-#: src/gpodder/gtkui/main.py:1594 share/gpodder/ui/gtk/gpodder.ui.h:2
-#: share/gpodder/ui/gtk/menus.ui.h:23
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: src/gpodder/gtkui/main.py:1598
-msgid "Pause"
-msgstr "Pause"
-
-#: src/gpodder/gtkui/main.py:1602
-msgid "Move up"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1604
-msgid "Move down"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1607
-msgid "Remove from list"
-msgstr "Fjern frå lista"
-
-#: src/gpodder/gtkui/main.py:1648 share/gpodder/ui/gtk/menus.ui.h:15
-msgid "Update podcast"
-msgstr "Oppdater podkast"
-
-#: src/gpodder/gtkui/main.py:1655
-msgid "Open download folder"
-msgstr "Opna nedlastingsmappe"
-
-#: src/gpodder/gtkui/main.py:1661
-#, fuzzy
-msgid "Mark episodes as old"
-msgstr "Merk episode som avspelt"
-
-#: src/gpodder/gtkui/main.py:1665 src/gpodder/gtkui/main.py:1926
-msgid "Archive"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1670
-#, fuzzy
-msgid "Delete podcast"
-msgstr "Slett episodar"
-
-#: src/gpodder/gtkui/main.py:1685 share/gpodder/ui/gtk/menus.ui.h:16
-msgid "Podcast settings"
-msgstr "Podkastinnstillingar"
-
-#: src/gpodder/gtkui/main.py:1730
-msgid "File already exist"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1732
-#, python-format
-msgid "A file named \"%(filename)s\" already exist. Do you want to replace it?"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1774
-#, python-format
-msgid ""
-"Error saving to local folder: %(error)r.\n"
-"Would you like to continue?"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1776 src/gpodder/gtkui/main.py:1781
-#, fuzzy
-msgid "Error saving to local folder"
-msgstr "Klarte ikkje konvertera fil."
-
-#: src/gpodder/gtkui/main.py:1780
-#, python-format
-msgid "Error saving to local folder: %(error)r"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1801
-msgid "Error converting file."
-msgstr "Klarte ikkje konvertera fil."
-
-#: src/gpodder/gtkui/main.py:1801
-msgid "Bluetooth file transfer"
-msgstr "Filoverføring via Blåtann"
-
-#: src/gpodder/gtkui/main.py:1854 share/gpodder/ui/gtk/menus.ui.h:20
-msgid "Play"
-msgstr "Spel"
-
-#: src/gpodder/gtkui/main.py:1858
-msgid "Preview"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:1860
-msgid "Stream"
-msgstr "Straum"
-
-#: src/gpodder/gtkui/main.py:1873
-#, fuzzy
-msgid "_Cancel"
-msgstr "Avbryt"
-
-#: src/gpodder/gtkui/main.py:1877
-#, fuzzy
-msgid "_Delete"
-msgstr "Slett"
-
-#: src/gpodder/gtkui/main.py:1903
-msgid "Send to"
-msgstr "Send til"
-
-#: src/gpodder/gtkui/main.py:1905
-msgid "Local folder"
-msgstr "Lokal mappe"
-
-#: src/gpodder/gtkui/main.py:1910
-msgid "Bluetooth device"
-msgstr "Blåtanneining"
-
-#: src/gpodder/gtkui/main.py:1917
-msgid "New"
-msgstr "Ny"
-
-#: src/gpodder/gtkui/main.py:1935 share/gpodder/ui/gtk/menus.ui.h:27
-msgid "Episode details"
-msgstr "Episodedetaljar"
-
-#: src/gpodder/gtkui/main.py:2088
-msgid "Please check your media player settings in the preferences dialog."
-msgstr "Sjekk mediaspelarinnstillingane dine i innstillingsdialogen."
-
-#: src/gpodder/gtkui/main.py:2089
-msgid "Error opening player"
-msgstr "Klarte ikkje opna spelar"
-
-#: src/gpodder/gtkui/main.py:2331
-msgid "Adding podcasts"
-msgstr "Legg til podkast"
-
-#: src/gpodder/gtkui/main.py:2332
-msgid "Please wait while episode information is downloaded."
-msgstr "Vent medan episodeinformasjon vert lasta ned."
-
-#: src/gpodder/gtkui/main.py:2339
-msgid "Existing subscriptions skipped"
-msgstr "Eksisterande abonnement er hoppa over"
-
-#: src/gpodder/gtkui/main.py:2340
-msgid "You are already subscribed to these podcasts:"
-msgstr "Du abonnerer alt på desse podkastane:"
-
-#: src/gpodder/gtkui/main.py:2348 bin/gpo:322
-msgid "Podcast requires authentication"
-msgstr "Podkast krev autentisering"
-
-#: src/gpodder/gtkui/main.py:2349 bin/gpo:323
-#, python-format
-msgid "Please login to %s:"
-msgstr "Logg inn til %s:"
-
-#: src/gpodder/gtkui/main.py:2357 src/gpodder/gtkui/main.py:2453
-msgid "Authentication failed"
-msgstr "Autentisering feila"
-
-#: src/gpodder/gtkui/main.py:2363
-msgid "Website redirection detected"
-msgstr "Nettstadsomadressering oppdaga"
-
-#: src/gpodder/gtkui/main.py:2364
-#, python-format
-msgid "The URL %(url)s redirects to %(target)s."
-msgstr "Adressa %(url)s vert omadressert til %(target)s."
-
-#: src/gpodder/gtkui/main.py:2365
-msgid "Do you want to visit the website now?"
-msgstr "Vil du vitje nettstaden no?"
-
-#: src/gpodder/gtkui/main.py:2374
-msgid "Could not add some podcasts"
-msgstr "Klarte ikkje leggja til somme podkastar"
-
-#: src/gpodder/gtkui/main.py:2375
-msgid "Some podcasts could not be added to your list:"
-msgstr "Klarte ikkje leggja til somme podkastar til lista di:"
-
-#: src/gpodder/gtkui/main.py:2378
-msgid "Unknown"
-msgstr "Ukjend"
-
-#: src/gpodder/gtkui/main.py:2462
-msgid "Redirection detected"
-msgstr "Omadressering oppdaga"
-
-#: src/gpodder/gtkui/main.py:2496
-msgid "Merging episode actions"
-msgstr "Flett saman episodehandlingar"
-
-#: src/gpodder/gtkui/main.py:2497
-msgid "Episode actions from gpodder.net are merged."
-msgstr "Episodehandlingar frå gpodder.net er fletta saman."
-
-#: src/gpodder/gtkui/main.py:2521
-msgid "Cancelling..."
-msgstr "Avbryt …"
-
-#: src/gpodder/gtkui/main.py:2530
-msgid "Please connect to a network, then try again."
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:2531
-#, fuzzy
-msgid "No network connection"
-msgstr "Nytt namn:"
-
-#: src/gpodder/gtkui/main.py:2552
-#, python-format
-msgid "Updating %(count)d feed..."
-msgid_plural "Updating %(count)d feeds..."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:2567
-#, fuzzy, python-format
-msgid "Updating %(podcast)s (%(position)d/%(total)d)"
-msgstr "Oppdatert %(podcast)s (%(position)d / %(total)d)"
-
-#: src/gpodder/gtkui/main.py:2578
-#, fuzzy, python-format
-msgid "Error while updating %(title)s at %(url)s: %(message)s"
-msgstr "Feil under oppdatering av %(url)s: %(message)s"
-
-#: src/gpodder/gtkui/main.py:2580
-#, fuzzy, python-format
-msgid "The %(title)s feed at %(url)s could not be updated."
-msgstr "Klarte ikkje oppdatera kjelda med adressa %(url)s"
-
-#: src/gpodder/gtkui/main.py:2581
-msgid "Error while updating feed"
-msgstr "Klarte ikkje oppdatera kjelde"
-
-#: src/gpodder/gtkui/main.py:2623
-msgid "No new episodes"
-msgstr "Ingen nye episodar"
-
-#: src/gpodder/gtkui/main.py:2636
-#, python-format
-msgid "Downloading %(count)d new episode."
-msgid_plural "Downloading %(count)d new episodes."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:2639 src/gpodder/gtkui/main.py:2646
-#: src/gpodder/gtkui/main.py:3012
-msgid "New episodes available"
-msgstr "Nye episodar tilgjengeleg"
-
-#: src/gpodder/gtkui/main.py:2643
-#, python-format
-msgid "%(count)d new episode added to download list."
-msgid_plural "%(count)d new episodes added to download list."
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:2652
-#, python-format
-msgid "%(count)d new episode available"
-msgid_plural "%(count)d new episodes available"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:2683
-msgid "Quit gPodder"
-msgstr "Avslutt gPodder"
-
-#: src/gpodder/gtkui/main.py:2684
-msgid ""
-"You are downloading episodes. You can resume downloads the next time you "
-"start gPodder. Do you want to quit now?"
-msgstr ""
-"Du lastar ned episodar. Du kan fortsetja nedlastingane neste gong du startar "
-"gPodder. Vil du avslutta no?"
-
-#: src/gpodder/gtkui/main.py:2724 bin/gpo:857
-msgid "Episodes are locked"
-msgstr "Episodane er låst"
-
-#: src/gpodder/gtkui/main.py:2726 bin/gpo:859
-msgid ""
-"The selected episodes are locked. Please unlock the episodes that you want "
-"to delete before trying to delete them."
-msgstr ""
-"Dei valde episodane er låst. Lås opp dei episodane du vil sletta og prøv om "
-"att."
-
-#: src/gpodder/gtkui/main.py:2733 bin/gpo:866
-#, python-format
-msgid "Delete %(count)d episode?"
-msgid_plural "Delete %(count)d episodes?"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:2735 bin/gpo:868
-msgid "Deleting episodes removes downloaded files."
-msgstr "Sletting av episodar fjernar nedlasta filer."
-
-#: src/gpodder/gtkui/main.py:2740
-msgid "Deleting episodes"
-msgstr "Slettar episodar"
-
-#: src/gpodder/gtkui/main.py:2741 bin/gpo:873
-msgid "Please wait while episodes are deleted"
-msgstr "Vent medan episodane vert sletta"
-
-#: src/gpodder/gtkui/main.py:2794
-#, python-format
-msgid "Select older than %(count)d day"
-msgid_plural "Select older than %(count)d days"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:2796
-msgid "Select played"
-msgstr "Vel avspela"
-
-#: src/gpodder/gtkui/main.py:2797
-#, fuzzy
-msgid "Select finished"
-msgstr "Vel ingen"
-
-#: src/gpodder/gtkui/main.py:2801
-msgid "Select the episodes you want to delete:"
-msgstr "Vel episodane du vil sletta:"
-
-#: src/gpodder/gtkui/main.py:2818 share/gpodder/ui/gtk/menus.ui.h:10
-msgid "Delete episodes"
-msgstr "Slett episodar"
-
-#: src/gpodder/gtkui/main.py:2871 src/gpodder/gtkui/main.py:3106
-#: src/gpodder/gtkui/main.py:3206
-msgid "No podcast selected"
-msgstr "Ingen podkastar valde"
-
-#: src/gpodder/gtkui/main.py:2872
-msgid "Please select a podcast in the podcasts list to update."
-msgstr "Vel ein podkast i lista som du vil oppdatera."
-
-#: src/gpodder/gtkui/main.py:2962
-#, python-format
-msgid "Download error while downloading %(episode)s: %(message)s"
-msgstr "Det oppstod ein feil under nedlasting av %(episode)s: %(message)s"
-
-#: src/gpodder/gtkui/main.py:2963
-msgid "Download error"
-msgstr "Nedlastingsfeil"
-
-#: src/gpodder/gtkui/main.py:2997
-msgid "Select the episodes you want to download:"
-msgstr "Vel episodane du vil lasta ned:"
-
-#: src/gpodder/gtkui/main.py:3020
-msgid "Mark as old"
-msgstr "Merk som gammal"
-
-#: src/gpodder/gtkui/main.py:3027
-msgid "Please check for new episodes later."
-msgstr "Sjekk etter nye episodar seinare."
-
-#: src/gpodder/gtkui/main.py:3028
-msgid "No new episodes available"
-msgstr "Ingen nye episodar tilgjengeleg."
-
-#: src/gpodder/gtkui/main.py:3069
-#, fuzzy, python-format
-msgid "Subscriptions on %(server)s"
-msgstr "Abonnent på gpodder.net"
-
-#: src/gpodder/gtkui/main.py:3080
-msgid "Login to gpodder.net"
-msgstr "Logg inn til gpodder.net"
-
-#: src/gpodder/gtkui/main.py:3081
-msgid "Please login to download your subscriptions."
-msgstr "Logg inn for å lasta ned abonnementa dine."
-
-#: src/gpodder/gtkui/main.py:3107
-msgid "Please select a podcast in the podcasts list to edit."
-msgstr "Vel ein podkast i lista for å redigera"
-
-#: src/gpodder/gtkui/main.py:3121
-msgid "Podcast"
-msgstr "Podkast"
-
-#: src/gpodder/gtkui/main.py:3127 share/gpodder/ui/gtk/menus.ui.h:14
-#, fuzzy
-msgid "Delete podcasts"
-msgstr "Fjern podkastar"
-
-#: src/gpodder/gtkui/main.py:3128
-#, fuzzy
-msgid "Select the podcast you want to delete."
-msgstr "Vel podkastane du vil sletta."
-
-#: src/gpodder/gtkui/main.py:3132 share/gpodder/ui/gtk/menus.ui.h:24
-msgid "Delete"
-msgstr "Slett"
-
-#: src/gpodder/gtkui/main.py:3141
-#, fuzzy
-msgid "Deleting podcast"
-msgstr "Slettar episodar"
-
-#: src/gpodder/gtkui/main.py:3142
-#, fuzzy
-msgid "Please wait while the podcast is deleted"
-msgstr "Vent medan podkasten vert fjerna"
-
-#: src/gpodder/gtkui/main.py:3143
-msgid ""
-"This podcast and all its episodes will be PERMANENTLY DELETED.\r\n"
-"Are you sure you want to continue?"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3145
-#, fuzzy
-msgid "Deleting podcasts"
-msgstr "Fjernar podkastar"
-
-#: src/gpodder/gtkui/main.py:3146
-#, fuzzy
-msgid "Please wait while the podcasts are deleted"
-msgstr "Vent medan podkastane vert fjerna"
-
-#: src/gpodder/gtkui/main.py:3147
-msgid ""
-"These podcasts and all their episodes will be PERMANENTLY DELETED.\r\n"
-"Are you sure you want to continue?"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3207
-msgid "Please select a podcast in the podcasts list to remove."
-msgstr "Vel ein podkast i lista for å fjerna."
-
-#: src/gpodder/gtkui/main.py:3217
-msgid "OPML files"
-msgstr "OMPL-filer"
-
-#: src/gpodder/gtkui/main.py:3222
-msgid "Import from OPML"
-msgstr "Importer frå OPML"
-
-#: src/gpodder/gtkui/main.py:3236
-msgid "Import podcasts from OPML file"
-msgstr "Importer podkastar frå OPML-fil"
-
-#: src/gpodder/gtkui/main.py:3243
-msgid "Nothing to export"
-msgstr "Ingenting å eksportera"
-
-#: src/gpodder/gtkui/main.py:3244
-msgid ""
-"Your list of podcast subscriptions is empty. Please subscribe to some "
-"podcasts first before trying to export your subscription list."
-msgstr ""
-"Lista di over podkastabonnement er tom. Abonner på nokre podkastar før du "
-"prøver å eksportera abonnementslista di."
-
-#: src/gpodder/gtkui/main.py:3250
-msgid "Export to OPML"
-msgstr "Eksporter til OPML"
-
-#: src/gpodder/gtkui/main.py:3263
-#, python-format
-msgid "%(count)d subscription exported"
-msgid_plural "%(count)d subscriptions exported"
-msgstr[0] ""
-msgstr[1] ""
-
-#: src/gpodder/gtkui/main.py:3266
-msgid "Your podcast list has been successfully exported."
-msgstr "Podkastlista di er eksportert."
-
-#: src/gpodder/gtkui/main.py:3270
-msgid "Could not export OPML to file. Please check your permissions."
-msgstr "Klarte ikkje eksportera til OPML-fil. Sjekk rettane dine."
-
-#: src/gpodder/gtkui/main.py:3272
-msgid "OPML export failed"
-msgstr "Klarte ikkje eksportera OPML"
-
-#: src/gpodder/gtkui/main.py:3296
-#, fuzzy
-msgid "Could not check for updates"
-msgstr "Klarte ikkje leggja til somme podkastar"
-
-#: src/gpodder/gtkui/main.py:3297
-msgid "Please try again later."
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3302
-#, fuzzy
-msgid "No updates available"
-msgstr "Ingen episodar tilgjengeleg"
-
-#: src/gpodder/gtkui/main.py:3303
-msgid "You have the latest version of gPodder."
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3307
-#, fuzzy
-msgid "New version available"
-msgstr "Nye episodar tilgjengeleg"
-
-#: src/gpodder/gtkui/main.py:3309
-#, python-format
-msgid "Installed version: %s"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3310
-#, fuzzy, python-format
-msgid "Newest version: %s"
-msgstr "Slettar: %s"
-
-#: src/gpodder/gtkui/main.py:3311
-#, fuzzy, python-format
-msgid "Release date: %s"
-msgstr "Utgjeven: %s"
-
-#: src/gpodder/gtkui/main.py:3313
-#, fuzzy
-msgid "Download the latest version from gpodder.org?"
-msgstr "Last ned mine abonnement frå gpodder.net"
-
-#: src/gpodder/gtkui/main.py:3563
-#, fuzzy
-msgid "Please register a YouTube API key and set it in the preferences."
-msgstr "Set opp eininga di i innstillingsdialogen."
-
-#: src/gpodder/gtkui/main.py:3564
-msgid "Would you like to set up an API key now?"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3564
-msgid "API key required"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3583 bin/gpo:725
-#, fuzzy
-msgid "No unique URL found"
-msgstr "Ingen kanalar funne"
-
-#: src/gpodder/gtkui/main.py:3588 bin/gpo:731
-#, fuzzy
-msgid "Already subscribed"
-msgstr "Klarte ikkje synkronisera til iPod"
-
-#: src/gpodder/gtkui/main.py:3598 bin/gpo:743
-#, python-format
-msgid "Make sure the API key is correct. Error: %(message)s"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3599
-#, fuzzy
-msgid "Error getting YouTube channels"
-msgstr "Klarte ikkje stilla innstilling."
-
-#: src/gpodder/gtkui/main.py:3602
-msgid "Successfully migrated subscriptions"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3604
-#, fuzzy
-msgid "Subscriptions are up to date"
-msgstr "_Abonnement"
-
-#: src/gpodder/gtkui/main.py:3607
-msgid "These URLs failed:"
-msgstr ""
-
-#: src/gpodder/gtkui/main.py:3609
-#, fuzzy
-msgid "Could not migrate some subscriptions"
-msgstr "Klarte ikkje leggja til somme podkastar"
+msgid "gPodder on %s"
+msgstr "gPodder på %s"
 
 #: src/gpodder/gtkui/shownotes.py:99 src/gpodder/gtkui/model.py:67
 #: src/gpodder/gtkui/model.py:85 src/gpodder/gtkui/model.py:285
 #, python-format
 msgid "from %s"
-msgstr "Frå %s"
+msgstr "frå %s"
 
 #: src/gpodder/gtkui/shownotes.py:130
-#, fuzzy
 msgid "Please select an episode"
-msgstr "Vel episodar"
+msgstr "Vel episode"
 
 #: src/gpodder/gtkui/shownotes.py:312
 msgid "Open shownotes in web browser"
-msgstr ""
+msgstr "Opna programnotat i nettlesar"
 
 #: src/gpodder/gtkui/shownotes.py:318
 msgid "Open link in web browser"
-msgstr ""
+msgstr "Opna lenkje i nettlesar"
 
-#: src/gpodder/gtkui/config.py:50
-msgid "Integer"
-msgstr "Heiltal"
-
-#: src/gpodder/gtkui/config.py:52
-msgid "Float"
-msgstr "Flyttal"
-
-#: src/gpodder/gtkui/config.py:54
-msgid "Boolean"
-msgstr "Boolsk"
-
-#: src/gpodder/gtkui/config.py:56
-msgid "String"
-msgstr "Streng"
-
+# Dato for publisering av podkastepisode.
 #: src/gpodder/gtkui/model.py:66
 #, python-format
 msgid "released %s"
-msgstr "Utgjeven %s"
+msgstr "publisert %s"
 
 #: src/gpodder/gtkui/model.py:78 src/gpodder/gtkui/model.py:439
 msgid "played"
@@ -1267,11 +424,11 @@ msgstr "avspela"
 
 #: src/gpodder/gtkui/model.py:80
 msgid "unplayed"
-msgstr "ikkje spela"
+msgstr "ikkje avspela"
 
 #: src/gpodder/gtkui/model.py:83
 msgid "today"
-msgstr "idag"
+msgstr "i dag"
 
 #: src/gpodder/gtkui/model.py:84
 #, python-format
@@ -1292,7 +449,7 @@ msgstr "Nedlasta episode"
 
 #: src/gpodder/gtkui/model.py:404
 msgid "Downloaded video episode"
-msgstr "Nedlasta filmepisode"
+msgstr "Nedlasta videoepisode"
 
 #: src/gpodder/gtkui/model.py:407
 msgid "Downloaded image"
@@ -1328,7 +485,7 @@ msgstr "opna"
 
 #: src/gpodder/gtkui/model.py:443
 msgid "deletion prevented"
-msgstr "sletting avverga"
+msgstr "sletting hindra"
 
 #: src/gpodder/gtkui/model.py:485 share/gpodder/ui/gtk/menus.ui.h:34
 msgid "All episodes"
@@ -1339,17 +496,845 @@ msgid "from all podcasts"
 msgstr "frå alle podkastar"
 
 #: src/gpodder/gtkui/model.py:719
-#, fuzzy
 msgid "Subscription paused"
-msgstr "_Abonnement"
+msgstr "Abonnement sett på pause"
 
-#: src/gpodder/gtkui/interface/addpodcast.py:76
-msgid "Nothing to paste."
-msgstr "Ingenting å lima inn."
+#: src/gpodder/gtkui/main.py:149 share/applications/gpodder.desktop.in.h:1
+msgid "gPodder"
+msgstr "gPodder"
 
-#: src/gpodder/gtkui/interface/addpodcast.py:76
-msgid "Clipboard is empty"
-msgstr "Utklippstavle er tom"
+#: src/gpodder/gtkui/main.py:318 share/gpodder/ui/gtk/menus.ui.h:28
+msgid "E_xtras"
+msgstr "E_kstra"
+
+#: src/gpodder/gtkui/main.py:319
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:11
+msgid "Extensions"
+msgstr "Utvidingar"
+
+#: src/gpodder/gtkui/main.py:338
+msgid "Loading incomplete downloads"
+msgstr "Lastar ufullstendige nedlastingar"
+
+# skip-rule: passiv
+#: src/gpodder/gtkui/main.py:339
+msgid "Some episodes have not finished downloading in a previous session."
+msgstr "Nokre episodar vart ikkje ferdig lasta ned i ei tidlegare økt."
+
+#: src/gpodder/gtkui/main.py:342 bin/gpo:586
+#, python-format
+msgid "%(count)d partial file"
+msgid_plural "%(count)d partial files"
+msgstr[0] "%(count)d delvis nedlasta fil"
+msgstr[1] "%(count)d delvis nedlasta filer"
+
+#: src/gpodder/gtkui/main.py:358
+msgid "Resume all"
+msgstr "Hald fram med alle"
+
+#: src/gpodder/gtkui/main.py:370
+msgid "Incomplete downloads from a previous session were found."
+msgstr "Fann ufullstendige nedlastingar frå ei tidlegare økt."
+
+#: src/gpodder/gtkui/main.py:475
+msgid "Action"
+msgstr "Handling"
+
+#: src/gpodder/gtkui/main.py:522
+msgid "Confirm changes from gpodder.net"
+msgstr "Stadfest endringar frå gpodder.net"
+
+#: src/gpodder/gtkui/main.py:523
+msgid "Select the actions you want to carry out."
+msgstr "Vel handlingane du vil utføra."
+
+#: src/gpodder/gtkui/main.py:563
+msgid "Uploading subscriptions"
+msgstr "Lastar opp abonnement"
+
+#: src/gpodder/gtkui/main.py:564
+msgid "Your subscriptions are being uploaded to the server."
+msgstr "Abonnementa dine vert lasta opp til tenaren."
+
+#: src/gpodder/gtkui/main.py:569
+msgid "List uploaded successfully."
+msgstr "Podkastlista vart lasta opp."
+
+#: src/gpodder/gtkui/main.py:576
+msgid "Error while uploading"
+msgstr "Feil ved opplasting"
+
+#: src/gpodder/gtkui/main.py:866
+msgid "Size"
+msgstr "Storleik"
+
+# Tidslengd, altså kor lenge ein episode varer.
+#: src/gpodder/gtkui/main.py:871
+msgid "Duration"
+msgstr "Lengd"
+
+#: src/gpodder/gtkui/main.py:875
+msgid "Released"
+msgstr "Publisert"
+
+#: src/gpodder/gtkui/main.py:993 src/gpodder/gtkui/main.py:1142
+#: share/gpodder/ui/gtk/gpodder.ui.h:11
+msgid "Progress"
+msgstr "Framdrift"
+
+#: src/gpodder/gtkui/main.py:1021
+msgid "No episodes in current view"
+msgstr "Ingen episodar i gjeldande vising"
+
+#: src/gpodder/gtkui/main.py:1023
+msgid "No episodes available"
+msgstr "Ingen tilgjengelege episodar"
+
+#: src/gpodder/gtkui/main.py:1029
+msgid "No podcasts in this view"
+msgstr "Ingen podkastar i gjeldande vising"
+
+#: src/gpodder/gtkui/main.py:1031
+msgid "No subscriptions"
+msgstr "Ingen abonnement"
+
+#: src/gpodder/gtkui/main.py:1033
+msgid "No active tasks"
+msgstr "Ingen oppgåver køyrer"
+
+#: src/gpodder/gtkui/main.py:1146 src/gpodder/gtkui/main.py:1148
+#, python-format
+msgid "%(count)d active"
+msgid_plural "%(count)d active"
+msgstr[0] "%(count)d køyrer"
+msgstr[1] "%(count)d køyrer"
+
+#: src/gpodder/gtkui/main.py:1150
+#, python-format
+msgid "%(count)d failed"
+msgid_plural "%(count)d failed"
+msgstr[0] "%(count)d mislukka"
+msgstr[1] "%(count)d mislukka"
+
+#: src/gpodder/gtkui/main.py:1152
+#, python-format
+msgid "%(count)d queued"
+msgid_plural "%(count)d queued"
+msgstr[0] "%(count)d i kø"
+msgstr[1] "%(count)d i kø"
+
+#: src/gpodder/gtkui/main.py:1165
+#, python-format
+msgid "downloading %(count)d file"
+msgid_plural "downloading %(count)d files"
+msgstr[0] "lastar ned %(count)d fil"
+msgstr[1] "lastar ned %(count)d filer"
+
+#: src/gpodder/gtkui/main.py:1177
+#, python-format
+msgid "synchronizing %(count)d file"
+msgid_plural "synchronizing %(count)d files"
+msgstr[0] "synkroniserer %(count)d fil"
+msgstr[1] "synkroniserer %(count)d filer"
+
+#: src/gpodder/gtkui/main.py:1181
+#, python-format
+msgid "%(queued)d task queued"
+msgid_plural "%(queued)d tasks queued"
+msgstr[0] "%(queued)d oppgåve lagd i kø"
+msgstr[1] "%(queued)d oppgåver lagde i kø"
+
+#: src/gpodder/gtkui/main.py:1208
+msgid "Please report this problem and restart gPodder:"
+msgstr "Meld frå om problemet, og start så gPodder på nytt:"
+
+#: src/gpodder/gtkui/main.py:1209
+msgid "Unhandled exception"
+msgstr "Ikkje-handtert unntak"
+
+#: src/gpodder/gtkui/main.py:1276
+#, python-format
+msgid "Feedparser error: %s"
+msgstr "Feil ved innlesing av kjelde: %s"
+
+#: src/gpodder/gtkui/main.py:1409
+msgid "Could not download some episodes:"
+msgstr "Feil ved nedlasting av nokre episodar:"
+
+# Unødvendig med fleirtalsform her.
+#: src/gpodder/gtkui/main.py:1411 src/gpodder/gtkui/main.py:1414
+msgid "Downloads finished"
+msgstr "Nedlasting fullført"
+
+#: src/gpodder/gtkui/main.py:1417
+msgid "Downloads failed"
+msgstr "Mislukka nedlasting"
+
+#: src/gpodder/gtkui/main.py:1422
+msgid "Could not sync some episodes:"
+msgstr "Feil ved synkronisering av nokre episodar:"
+
+#: src/gpodder/gtkui/main.py:1425 src/gpodder/gtkui/main.py:1429
+msgid "Device synchronization finished"
+msgstr "Eining synkronisert"
+
+#: src/gpodder/gtkui/main.py:1433
+msgid "Device synchronization failed"
+msgstr "Feil ved synkronisering av eining"
+
+#: src/gpodder/gtkui/main.py:1476
+#, python-format
+msgid "%(count)d more episode"
+msgid_plural "%(count)d more episodes"
+msgstr[0] "%(count)d episode til"
+msgstr[1] "%(count)d episodar til"
+
+#: src/gpodder/gtkui/main.py:1584
+msgid "Start download now"
+msgstr "Start nedlasting no"
+
+#: src/gpodder/gtkui/main.py:1589 src/gpodder/gtkui/main.py:1868
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:192
+#: src/gpodder/gtkui/desktop/episodeselector.py:139
+#: share/gpodder/ui/gtk/menus.ui.h:22 share/gpodder/ui/gtk/gpodder.ui.h:1
+msgid "Download"
+msgstr "Last ned"
+
+#: src/gpodder/gtkui/main.py:1594 share/gpodder/ui/gtk/menus.ui.h:23
+#: share/gpodder/ui/gtk/gpodder.ui.h:2
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: src/gpodder/gtkui/main.py:1598
+msgid "Pause"
+msgstr "Pause"
+
+#: src/gpodder/gtkui/main.py:1602
+msgid "Move up"
+msgstr "Flytt opp"
+
+#: src/gpodder/gtkui/main.py:1604
+msgid "Move down"
+msgstr "Flytt ned"
+
+#: src/gpodder/gtkui/main.py:1607
+msgid "Remove from list"
+msgstr "Fjern frå lista"
+
+#: src/gpodder/gtkui/main.py:1648 share/gpodder/ui/gtk/menus.ui.h:15
+msgid "Update podcast"
+msgstr "Oppdater podkast"
+
+#: src/gpodder/gtkui/main.py:1655
+msgid "Open download folder"
+msgstr "Opna nedlastingsmappa"
+
+#: src/gpodder/gtkui/main.py:1661
+msgid "Mark episodes as old"
+msgstr "Merk episodar som gamle"
+
+# Avkryssingstekst på menyen for om ein episode skal reknast som arkivert eller ikkje.
+#: src/gpodder/gtkui/main.py:1665 src/gpodder/gtkui/main.py:1926
+msgid "Archive"
+msgstr "Arkivert"
+
+#: src/gpodder/gtkui/main.py:1670
+msgid "Delete podcast"
+msgstr "Slett podkast"
+
+#: src/gpodder/gtkui/main.py:1685 share/gpodder/ui/gtk/menus.ui.h:16
+msgid "Podcast settings"
+msgstr "Podkastinnstillingar"
+
+#: src/gpodder/gtkui/main.py:1730
+msgid "File already exist"
+msgstr "Fila finst frå før"
+
+#: src/gpodder/gtkui/main.py:1732
+#, python-format
+msgid "A file named \"%(filename)s\" already exist. Do you want to replace it?"
+msgstr "Det finst alt ei fil med namnet «%(filename)s». Vil du overskriva ho?"
+
+#: src/gpodder/gtkui/main.py:1774
+#, python-format
+msgid ""
+"Error saving to local folder: %(error)r.\n"
+"Would you like to continue?"
+msgstr ""
+"Feil ved lagring til lokal mappe: %(error)r.\n"
+"Vil du halda fram?"
+
+#: src/gpodder/gtkui/main.py:1776 src/gpodder/gtkui/main.py:1781
+msgid "Error saving to local folder"
+msgstr "Feil ved lagring til lokal mappe"
+
+#: src/gpodder/gtkui/main.py:1780
+#, python-format
+msgid "Error saving to local folder: %(error)r"
+msgstr "Feil ved lagring til lokal mappe: %(error)r"
+
+#: src/gpodder/gtkui/main.py:1801
+msgid "Error converting file."
+msgstr "Feil ved konvertering av fil."
+
+#: src/gpodder/gtkui/main.py:1801
+msgid "Bluetooth file transfer"
+msgstr "Filoverføring via Bluetooth"
+
+#: src/gpodder/gtkui/main.py:1854 share/gpodder/ui/gtk/menus.ui.h:20
+msgid "Play"
+msgstr "Spel av"
+
+#: src/gpodder/gtkui/main.py:1858
+msgid "Preview"
+msgstr "Førehandsvis"
+
+# Spel av utan å lasta ned. (Dette er noko anna enn «Stream to Sonos»-funksjonaliteten.)
+#: src/gpodder/gtkui/main.py:1860
+msgid "Stream"
+msgstr "Direkteavspel"
+
+#: src/gpodder/gtkui/main.py:1873
+msgid "_Cancel"
+msgstr "_Avbryt"
+
+#: src/gpodder/gtkui/main.py:1877
+msgid "_Delete"
+msgstr "_Slett"
+
+#: src/gpodder/gtkui/main.py:1903
+msgid "Send to"
+msgstr "Send til"
+
+#: src/gpodder/gtkui/main.py:1905
+msgid "Local folder"
+msgstr "Lokal mappe"
+
+#: src/gpodder/gtkui/main.py:1910
+msgid "Bluetooth device"
+msgstr "Bluetooth-eining"
+
+#: src/gpodder/gtkui/main.py:1917
+msgid "New"
+msgstr "Ny"
+
+#: src/gpodder/gtkui/main.py:1935 share/gpodder/ui/gtk/menus.ui.h:27
+msgid "Episode details"
+msgstr "Episodedetaljar"
+
+#: src/gpodder/gtkui/main.py:2088
+msgid "Please check your media player settings in the preferences dialog."
+msgstr "Sjå til at innstillingane for val av mediespelar er i orden."
+
+#: src/gpodder/gtkui/main.py:2089
+msgid "Error opening player"
+msgstr "Klarte ikkje opna avspelingsprogram"
+
+#: src/gpodder/gtkui/main.py:2331
+msgid "Adding podcasts"
+msgstr "Legg til podkast"
+
+#: src/gpodder/gtkui/main.py:2332
+msgid "Please wait while episode information is downloaded."
+msgstr "Vent mens informasjon om episoden vert lasta ned."
+
+#: src/gpodder/gtkui/main.py:2339
+msgid "Existing subscriptions skipped"
+msgstr "Hoppa over gamle abonnement"
+
+#: src/gpodder/gtkui/main.py:2340
+msgid "You are already subscribed to these podcasts:"
+msgstr "Du abonnerer alt på desse podkastane:"
+
+#: src/gpodder/gtkui/main.py:2348 bin/gpo:322
+msgid "Podcast requires authentication"
+msgstr "Podkasten krev autentisering"
+
+#: src/gpodder/gtkui/main.py:2349 bin/gpo:323
+#, python-format
+msgid "Please login to %s:"
+msgstr "Logg inn på %s:"
+
+#: src/gpodder/gtkui/main.py:2357 src/gpodder/gtkui/main.py:2453
+msgid "Authentication failed"
+msgstr "Feil ved autentisering"
+
+#: src/gpodder/gtkui/main.py:2363
+msgid "Website redirection detected"
+msgstr "Fekk melding om omadressering"
+
+#: src/gpodder/gtkui/main.py:2364
+#, python-format
+msgid "The URL %(url)s redirects to %(target)s."
+msgstr "Adressa %(url)s vert omadressert til %(target)s."
+
+#: src/gpodder/gtkui/main.py:2365
+msgid "Do you want to visit the website now?"
+msgstr "Vil du gå til nettstaden no?"
+
+#: src/gpodder/gtkui/main.py:2374
+msgid "Could not add some podcasts"
+msgstr "Feil ved forsøk på å leggja til nokre podkastar"
+
+#: src/gpodder/gtkui/main.py:2375
+msgid "Some podcasts could not be added to your list:"
+msgstr "Nokre podkastar kunne ikkje leggjast til i lista:"
+
+#: src/gpodder/gtkui/main.py:2378
+msgid "Unknown"
+msgstr "Ukjend"
+
+#: src/gpodder/gtkui/main.py:2462
+msgid "Redirection detected"
+msgstr "Omadressering oppdaga"
+
+#: src/gpodder/gtkui/main.py:2496
+msgid "Merging episode actions"
+msgstr "Flettar saman episodehandlingar"
+
+#: src/gpodder/gtkui/main.py:2497
+msgid "Episode actions from gpodder.net are merged."
+msgstr "Episodehandlingar frå gpodder.net vart fletta saman."
+
+#: src/gpodder/gtkui/main.py:2521
+msgid "Cancelling..."
+msgstr "Avbryt …"
+
+#: src/gpodder/gtkui/main.py:2530
+msgid "Please connect to a network, then try again."
+msgstr "Kopla til eit nettverk, og prøv så på nytt."
+
+#: src/gpodder/gtkui/main.py:2531
+msgid "No network connection"
+msgstr "Manglar nettverkstilkopling"
+
+#: src/gpodder/gtkui/main.py:2552
+#, python-format
+msgid "Updating %(count)d feed..."
+msgid_plural "Updating %(count)d feeds..."
+msgstr[0] "Oppdaterer %(count)d kjelde …"
+msgstr[1] "Oppdaterer %(count)d kjelder …"
+
+#: src/gpodder/gtkui/main.py:2567
+#, python-format
+msgid "Updating %(podcast)s (%(position)d/%(total)d)"
+msgstr "Oppdaterer %(podcast)s (%(position)d/%(total)d)"
+
+#: src/gpodder/gtkui/main.py:2578
+#, python-format
+msgid "Error while updating %(title)s at %(url)s: %(message)s"
+msgstr "Feil ved oppdatering av %(title)s på %(url)s: %(message)s"
+
+#: src/gpodder/gtkui/main.py:2580
+#, python-format
+msgid "The %(title)s feed at %(url)s could not be updated."
+msgstr "Klarte ikkje oppdatera kjelda %(title)s på %(url)s."
+
+#: src/gpodder/gtkui/main.py:2581
+msgid "Error while updating feed"
+msgstr "Feil ved kjeldeoppdatering"
+
+#: src/gpodder/gtkui/main.py:2623
+msgid "No new episodes"
+msgstr "Ingen nye episodar"
+
+#: src/gpodder/gtkui/main.py:2636
+#, python-format
+msgid "Downloading %(count)d new episode."
+msgid_plural "Downloading %(count)d new episodes."
+msgstr[0] "Lastar ned %(count)d ny episode."
+msgstr[1] "Lastar ned %(count)d nye episodar."
+
+#: src/gpodder/gtkui/main.py:2639 src/gpodder/gtkui/main.py:2646
+#: src/gpodder/gtkui/main.py:3012
+msgid "New episodes available"
+msgstr "Nye episodar er tilgjengelege"
+
+#: src/gpodder/gtkui/main.py:2643
+#, python-format
+msgid "%(count)d new episode added to download list."
+msgid_plural "%(count)d new episodes added to download list."
+msgstr[0] "%(count)d ny episode er lagd til i nedlastingskøen."
+msgstr[1] "%(count)d nye episodar er lagde til i nedlastingskøen."
+
+#: src/gpodder/gtkui/main.py:2652
+#, python-format
+msgid "%(count)d new episode available"
+msgid_plural "%(count)d new episodes available"
+msgstr[0] "%(count)d ny episode er tilgjengeleg"
+msgstr[1] "%(count)d nye episodar er tilgjengelege"
+
+#: src/gpodder/gtkui/main.py:2683
+msgid "Quit gPodder"
+msgstr "Avslutt gPodder"
+
+#: src/gpodder/gtkui/main.py:2684
+msgid ""
+"You are downloading episodes. You can resume downloads the next time you "
+"start gPodder. Do you want to quit now?"
+msgstr ""
+"Du lastar ned episodar. Du kan halda fram nedlastingane neste gong du "
+"startar gPodder. Vil du avslutta no?"
+
+#: src/gpodder/gtkui/main.py:2724 bin/gpo:857
+msgid "Episodes are locked"
+msgstr "Episodane er låste"
+
+#: src/gpodder/gtkui/main.py:2726 bin/gpo:859
+msgid ""
+"The selected episodes are locked. Please unlock the episodes that you want "
+"to delete before trying to delete them."
+msgstr ""
+"Dei valde episodane er låste. Lås opp episodane du vil sletta og prøv på "
+"nytt."
+
+#: src/gpodder/gtkui/main.py:2733 bin/gpo:866
+#, python-format
+msgid "Delete %(count)d episode?"
+msgid_plural "Delete %(count)d episodes?"
+msgstr[0] "Vil du sletta %(count)d episode?"
+msgstr[1] "Vil du sletta %(count)d episodar?"
+
+#: src/gpodder/gtkui/main.py:2735 bin/gpo:868
+msgid "Deleting episodes removes downloaded files."
+msgstr "Viss du slettar ein episode, vert òg tilhøyrande fil sletta."
+
+#: src/gpodder/gtkui/main.py:2740
+msgid "Deleting episodes"
+msgstr "Slettar episodar"
+
+#: src/gpodder/gtkui/main.py:2741 bin/gpo:873
+msgid "Please wait while episodes are deleted"
+msgstr "Vent mens episodane vert sletta"
+
+#: src/gpodder/gtkui/main.py:2794
+#, python-format
+msgid "Select older than %(count)d day"
+msgid_plural "Select older than %(count)d days"
+msgstr[0] "Vel episodar eldre enn %(count)d dag"
+msgstr[1] "Vel episodar eldre enn %(count)d dagar"
+
+#: src/gpodder/gtkui/main.py:2796
+msgid "Select played"
+msgstr "Vel avspela"
+
+#: src/gpodder/gtkui/main.py:2797
+msgid "Select finished"
+msgstr "Vel ferdigavspela"
+
+#: src/gpodder/gtkui/main.py:2801
+msgid "Select the episodes you want to delete:"
+msgstr "Vel episodane du vil sletta:"
+
+#: src/gpodder/gtkui/main.py:2818 share/gpodder/ui/gtk/menus.ui.h:10
+msgid "Delete episodes"
+msgstr "Slett episodar"
+
+#: src/gpodder/gtkui/main.py:2871 src/gpodder/gtkui/main.py:3106
+#: src/gpodder/gtkui/main.py:3206
+msgid "No podcast selected"
+msgstr "Ingen podkastar valde"
+
+#: src/gpodder/gtkui/main.py:2872
+msgid "Please select a podcast in the podcasts list to update."
+msgstr "Vel podkasten du vil oppdatera."
+
+#: src/gpodder/gtkui/main.py:2962
+#, python-format
+msgid "Download error while downloading %(episode)s: %(message)s"
+msgstr "Feil ved nedlasting av %(episode)s: %(message)s"
+
+#: src/gpodder/gtkui/main.py:2963
+msgid "Download error"
+msgstr "Nedlastingsfeil"
+
+#: src/gpodder/gtkui/main.py:2997
+msgid "Select the episodes you want to download:"
+msgstr "Vel episodane du vil lasta ned:"
+
+# Knapp som merker valde episodar som gamle, derfor fleirtal.
+#: src/gpodder/gtkui/main.py:3020
+msgid "Mark as old"
+msgstr "Merk som gamle"
+
+#: src/gpodder/gtkui/main.py:3027
+msgid "Please check for new episodes later."
+msgstr "Sjå etter nye episodar seinare."
+
+#: src/gpodder/gtkui/main.py:3028
+msgid "No new episodes available"
+msgstr "Ingen nye episodar er tilgjengelege"
+
+#: src/gpodder/gtkui/main.py:3069
+#, python-format
+msgid "Subscriptions on %(server)s"
+msgstr "Abonnement på %(server)s"
+
+#: src/gpodder/gtkui/main.py:3080
+msgid "Login to gpodder.net"
+msgstr "Logg på gpodder.net"
+
+#: src/gpodder/gtkui/main.py:3081
+msgid "Please login to download your subscriptions."
+msgstr "Logg inn for å lasta ned abonnementa dine."
+
+#: src/gpodder/gtkui/main.py:3107
+msgid "Please select a podcast in the podcasts list to edit."
+msgstr "Vel podkasten du vil redigera."
+
+#: src/gpodder/gtkui/main.py:3121
+msgid "Podcast"
+msgstr "Podkast"
+
+#: src/gpodder/gtkui/main.py:3127 share/gpodder/ui/gtk/menus.ui.h:14
+msgid "Delete podcasts"
+msgstr "Slett podkastar"
+
+#: src/gpodder/gtkui/main.py:3128
+msgid "Select the podcast you want to delete."
+msgstr "Vel podkastane du vil sletta."
+
+#: src/gpodder/gtkui/main.py:3132 share/gpodder/ui/gtk/menus.ui.h:24
+msgid "Delete"
+msgstr "Slett"
+
+#: src/gpodder/gtkui/main.py:3141
+msgid "Deleting podcast"
+msgstr "Slettar podkast"
+
+#: src/gpodder/gtkui/main.py:3142
+msgid "Please wait while the podcast is deleted"
+msgstr "Vent mens podkasten vert sletta"
+
+#: src/gpodder/gtkui/main.py:3143
+msgid ""
+"This podcast and all its episodes will be PERMANENTLY DELETED.\r\n"
+"Are you sure you want to continue?"
+msgstr ""
+"Podkasten og alle tilhøyrande episodar vert SLETTA FOR ALLTID.\r\n"
+"Er du sikker på at du vil halda fram?"
+
+#: src/gpodder/gtkui/main.py:3145
+msgid "Deleting podcasts"
+msgstr "Slettar podkastar"
+
+#: src/gpodder/gtkui/main.py:3146
+msgid "Please wait while the podcasts are deleted"
+msgstr "Vent mens podkastane vert sletta"
+
+#: src/gpodder/gtkui/main.py:3147
+msgid ""
+"These podcasts and all their episodes will be PERMANENTLY DELETED.\r\n"
+"Are you sure you want to continue?"
+msgstr ""
+"Podkastane og alle tilhøyrande episodar vert SLETTA FOR ALLTID.\r\n"
+"Er du sikker på at du vil halda fram?"
+
+#: src/gpodder/gtkui/main.py:3207
+msgid "Please select a podcast in the podcasts list to remove."
+msgstr "Vel podkasten du vil sletta."
+
+#: src/gpodder/gtkui/main.py:3217
+msgid "OPML files"
+msgstr "OMPL-filer"
+
+#: src/gpodder/gtkui/main.py:3222
+msgid "Import from OPML"
+msgstr "Importer frå OPML"
+
+#: src/gpodder/gtkui/main.py:3236
+msgid "Import podcasts from OPML file"
+msgstr "Importer podkastar frå OPML-fil"
+
+#: src/gpodder/gtkui/main.py:3243
+msgid "Nothing to export"
+msgstr "Ingenting å eksportera"
+
+#: src/gpodder/gtkui/main.py:3244
+msgid ""
+"Your list of podcast subscriptions is empty. Please subscribe to some "
+"podcasts first before trying to export your subscription list."
+msgstr ""
+"Du har ingen podkastabonnement. Abonner på nokre podkastar før du prøver å "
+"eksportera abonnementslista di."
+
+#: src/gpodder/gtkui/main.py:3250
+msgid "Export to OPML"
+msgstr "Eksporter til OPML"
+
+#: src/gpodder/gtkui/main.py:3263
+#, python-format
+msgid "%(count)d subscription exported"
+msgid_plural "%(count)d subscriptions exported"
+msgstr[0] "%(count)d abonnement eksportert"
+msgstr[1] "%(count)d abonnement eksporterte"
+
+#: src/gpodder/gtkui/main.py:3266
+msgid "Your podcast list has been successfully exported."
+msgstr "Podkastlista di er no eksportert."
+
+#: src/gpodder/gtkui/main.py:3270
+msgid "Could not export OPML to file. Please check your permissions."
+msgstr "Klarte ikkje eksportera til OPML-fil. Kontroller filløyva."
+
+#: src/gpodder/gtkui/main.py:3272
+msgid "OPML export failed"
+msgstr "Klarte ikkje eksportera til OPML-fil"
+
+#: src/gpodder/gtkui/main.py:3296
+msgid "Could not check for updates"
+msgstr "Feil ved søk etter oppdateringar"
+
+#: src/gpodder/gtkui/main.py:3297
+msgid "Please try again later."
+msgstr "Prøv på nytt seinare."
+
+# Overskrift som vert vist når ein sjekkar om det har kommen ein ny versjon av programmet.
+#: src/gpodder/gtkui/main.py:3302
+msgid "No updates available"
+msgstr "Ingen programoppdateringar"
+
+#: src/gpodder/gtkui/main.py:3303
+msgid "You have the latest version of gPodder."
+msgstr "Du har nyaste versjon av gPodder."
+
+#: src/gpodder/gtkui/main.py:3307
+msgid "New version available"
+msgstr "Nye versjon tilgjengeleg"
+
+#: src/gpodder/gtkui/main.py:3309
+#, python-format
+msgid "Installed version: %s"
+msgstr "Installert versjon: %s"
+
+#: src/gpodder/gtkui/main.py:3310
+#, python-format
+msgid "Newest version: %s"
+msgstr "Nyaste versjon: %s"
+
+#: src/gpodder/gtkui/main.py:3311
+#, python-format
+msgid "Release date: %s"
+msgstr "Utgjeven: %s"
+
+#: src/gpodder/gtkui/main.py:3313
+msgid "Download the latest version from gpodder.org?"
+msgstr "Vil du lasta ned den nyaste versjonen frå gpodder.org?"
+
+#: src/gpodder/gtkui/main.py:3563
+msgid "Please register a YouTube API key and set it in the preferences."
+msgstr ""
+"Registrer deg for å få ein YouTube-API-nøkkel, og oppgje han i "
+"innstillingane."
+
+#: src/gpodder/gtkui/main.py:3564
+msgid "Would you like to set up an API key now?"
+msgstr "Vil du setja opp ein API-nøkkel no?"
+
+#: src/gpodder/gtkui/main.py:3564
+msgid "API key required"
+msgstr "Treng API-nøkkel"
+
+#: src/gpodder/gtkui/main.py:3583 bin/gpo:725
+msgid "No unique URL found"
+msgstr "Fann ikkje ei unik nettadresse"
+
+#: src/gpodder/gtkui/main.py:3588 bin/gpo:731
+msgid "Already subscribed"
+msgstr "Allereie abonnent"
+
+#: src/gpodder/gtkui/main.py:3598 bin/gpo:743
+#, python-format
+msgid "Make sure the API key is correct. Error: %(message)s"
+msgstr "Sjå til at API-nøkkelen er rett. Feilmelding: %(message)s"
+
+#: src/gpodder/gtkui/main.py:3599
+msgid "Error getting YouTube channels"
+msgstr "Feil ved henting av oversikt over YouTube-kanalar"
+
+#: src/gpodder/gtkui/main.py:3602
+msgid "Successfully migrated subscriptions"
+msgstr "Abonnementa vart overførte"
+
+#: src/gpodder/gtkui/main.py:3604
+msgid "Subscriptions are up to date"
+msgstr "Abonnementa er à jour"
+
+#: src/gpodder/gtkui/main.py:3607
+msgid "These URLs failed:"
+msgstr "Desse adressene gav feil:"
+
+#: src/gpodder/gtkui/main.py:3609
+msgid "Could not migrate some subscriptions"
+msgstr "Feil ved overføring av nokre abonnement"
+
+#: src/gpodder/gtkui/desktopfile.py:70
+#, python-format
+msgid "Command: %s"
+msgstr "Kommando: %s"
+
+#: src/gpodder/gtkui/desktopfile.py:156
+msgid "Default application"
+msgstr "Standardprogram"
+
+#: src/gpodder/gtkui/config.py:50
+msgid "Integer"
+msgstr "Heiltal"
+
+#: src/gpodder/gtkui/config.py:52
+msgid "Float"
+msgstr "Desimaltal"
+
+#: src/gpodder/gtkui/config.py:54
+msgid "Boolean"
+msgstr "Ja/nei-verdi"
+
+#: src/gpodder/gtkui/config.py:56
+msgid "String"
+msgstr "Tekst"
+
+#: src/gpodder/gtkui/app.py:117
+msgid "Cannot start gPodder"
+msgstr "Klarte ikkje starta gPodder"
+
+#: src/gpodder/gtkui/app.py:118
+#, python-format
+msgid "D-Bus error: %s"
+msgstr "D-Bus-feil: %s"
+
+#: src/gpodder/gtkui/app.py:141
+msgid "About gPodder"
+msgstr "Om gPodder"
+
+#: src/gpodder/gtkui/app.py:165
+msgid "Website"
+msgstr "Heimeside"
+
+#: src/gpodder/gtkui/app.py:166
+msgid "Bug Tracker"
+msgstr "Meld frå om feil"
+
+#: src/gpodder/gtkui/app.py:217
+msgid "Path to gPodder home is too long"
+msgstr "Adressa til gPodder-mappa er for lang"
+
+#: src/gpodder/gtkui/interface/configeditor.py:33
+msgid "Setting"
+msgstr "Innstilling"
+
+#: src/gpodder/gtkui/interface/configeditor.py:41
+msgid "Set to"
+msgstr "Set til"
+
+#: src/gpodder/gtkui/interface/configeditor.py:84
+#, python-format
+msgid "Cannot set %(field)s to %(value)s. Needed data type: %(datatype)s"
+msgstr ""
+"Klarte ikkje setja %(field)s til %(value)s. Påkravd datatype: %(datatype)s"
+
+#: src/gpodder/gtkui/interface/configeditor.py:88
+msgid "Error setting option"
+msgstr "Klarte ikkje definera innstilling"
 
 #: src/gpodder/gtkui/interface/common.py:134
 msgid "Username"
@@ -1365,15 +1350,15 @@ msgstr "Logg inn"
 
 #: src/gpodder/gtkui/interface/common.py:146
 msgid "Authentication required"
-msgstr "Autentisering trengst"
+msgstr "Krev autentisering"
 
 #: src/gpodder/gtkui/interface/common.py:155
 msgid "hostname or root URL (e.g. https://gpodder.net)"
-msgstr ""
+msgstr "vertsnamn eller rotadresse (eksempel: https://gpodder.net/)"
 
 #: src/gpodder/gtkui/interface/common.py:176
 msgid "Server"
-msgstr ""
+msgstr "Tenar"
 
 #: src/gpodder/gtkui/interface/common.py:182
 msgid "Password"
@@ -1384,28 +1369,18 @@ msgstr "Passord"
 msgid "Select destination"
 msgstr "Vel mål"
 
-#: src/gpodder/gtkui/interface/configeditor.py:33
-msgid "Setting"
-msgstr "Innstilling"
+#: src/gpodder/gtkui/interface/addpodcast.py:76
+msgid "Nothing to paste."
+msgstr "Ingenting å lima inn."
 
-#: src/gpodder/gtkui/interface/configeditor.py:41
-msgid "Set to"
-msgstr "Set til"
-
-#: src/gpodder/gtkui/interface/configeditor.py:84
-#, python-format
-msgid "Cannot set %(field)s to %(value)s. Needed data type: %(datatype)s"
-msgstr ""
-"Klarte ikkje setja %(field)s til %(value)s. Påkravt datatype: %(datatype)s"
-
-#: src/gpodder/gtkui/interface/configeditor.py:88
-msgid "Error setting option"
-msgstr "Klarte ikkje stilla innstilling."
+#: src/gpodder/gtkui/interface/addpodcast.py:76
+msgid "Clipboard is empty"
+msgstr "Utklippstavla er tom"
 
 #: src/gpodder/gtkui/desktop/preferences.py:46
 #: src/gpodder/gtkui/desktop/preferences.py:89
 msgid "Do nothing"
-msgstr "Gjer ingenting"
+msgstr "Ikkje gjer noko"
 
 #: src/gpodder/gtkui/desktop/preferences.py:47
 msgid "Show episode list"
@@ -1413,11 +1388,11 @@ msgstr "Vis episodeliste"
 
 #: src/gpodder/gtkui/desktop/preferences.py:48
 msgid "Add to download list"
-msgstr "Legg til nedlasting"
+msgstr "Legg til nedlastingskøen"
 
 #: src/gpodder/gtkui/desktop/preferences.py:49
 msgid "Download immediately"
-msgstr "Last ned no"
+msgstr "Last ned med ein gong"
 
 #: src/gpodder/gtkui/desktop/preferences.py:68
 msgid "None"
@@ -1425,54 +1400,52 @@ msgstr "Ingen"
 
 #: src/gpodder/gtkui/desktop/preferences.py:69
 msgid "iPod"
-msgstr ""
+msgstr "iPod"
 
 #: src/gpodder/gtkui/desktop/preferences.py:70
 msgid "Filesystem-based"
 msgstr "Filsystembasert"
 
 #: src/gpodder/gtkui/desktop/preferences.py:90
-#, fuzzy
 msgid "Mark as played"
-msgstr "Merk som uavspelt"
+msgstr "Merk som avspela"
 
 #: src/gpodder/gtkui/desktop/preferences.py:91
-#, fuzzy
 msgid "Delete from gPodder"
-msgstr "Slett han frå gPodder"
+msgstr "Slett frå gPodder"
 
 #: src/gpodder/gtkui/desktop/preferences.py:118
-#, fuzzy, python-format
+#, python-format
 msgid "Custom (%(format_ids)s)"
-msgstr "Tilpassa formatstrengar"
+msgstr "Tilpassa (%(format_ids)s)"
 
 #: src/gpodder/gtkui/desktop/preferences.py:321
 msgid "Name"
-msgstr ""
+msgstr "Namn"
 
 #: src/gpodder/gtkui/desktop/preferences.py:373
 msgid "Documentation"
-msgstr ""
+msgstr "Dokumentasjon"
 
 #: src/gpodder/gtkui/desktop/preferences.py:378
 msgid "Extension info"
-msgstr ""
+msgstr "Utvidingsinformasjon"
 
 #: src/gpodder/gtkui/desktop/preferences.py:383
 msgid "Support the author"
-msgstr ""
+msgstr "Støtt utviklaren"
 
 #: src/gpodder/gtkui/desktop/preferences.py:425
 msgid "Extension cannot be activated"
-msgstr ""
+msgstr "Utvidinga kan ikkje takast i bruk"
 
 #: src/gpodder/gtkui/desktop/preferences.py:438
 msgid "Extension module info"
-msgstr ""
+msgstr "Informasjon om utvidingsmodul"
 
 #: src/gpodder/gtkui/desktop/preferences.py:475
 msgid "Configure audio player"
-msgstr "Set opp lydeining"
+msgstr "Set opp lydavspelar"
 
 #: src/gpodder/gtkui/desktop/preferences.py:476
 #: src/gpodder/gtkui/desktop/preferences.py:486
@@ -1481,7 +1454,7 @@ msgstr "Kommando:"
 
 #: src/gpodder/gtkui/desktop/preferences.py:485
 msgid "Configure video player"
-msgstr "Set opp filmspelar"
+msgstr "Set opp videoavspelar"
 
 #: src/gpodder/gtkui/desktop/preferences.py:498
 #: src/gpodder/gtkui/desktop/preferences.py:522
@@ -1492,39 +1465,36 @@ msgstr "manuelt"
 #, python-format
 msgid "after %(count)d day"
 msgid_plural "after %(count)d days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "etter %(count)d dag"
+msgstr[1] "etter %(count)d dagar"
 
 #: src/gpodder/gtkui/desktop/preferences.py:564
 msgid "Replace subscription list on server"
-msgstr "Byt ut abonnementlista på tenaren"
+msgstr "Byt ut abonnementslista på tenaren"
 
 #: src/gpodder/gtkui/desktop/preferences.py:565
 msgid ""
 "Remote podcasts that have not been added locally will be removed on the "
 "server. Continue?"
 msgstr ""
-"Eksterne podkastar som ikkje har vorte lagt til lokalt vil verta fjerna på "
-"tenaren. Vil du fortsetja?"
+"Eksterne podkastar som ikkje er lagde til lokalt, vert fjerna på tenaren. "
+"Vil du du halda fram?"
 
 #: src/gpodder/gtkui/desktop/preferences.py:644
 msgid "Select folder for mount point"
-msgstr "Vel mappe som monteringspunkt"
+msgstr "Vel mappe for monteringspunkt"
 
 #: src/gpodder/gtkui/desktop/preferences.py:661
-#, fuzzy
 msgid "Select folder for playlists"
-msgstr "Vel mappe som monteringspunkt"
+msgstr "Vel mappe for spelelister"
 
 #: src/gpodder/gtkui/desktop/podcastdirectory.py:188
-#, fuzzy
 msgid "Search:"
-msgstr "Søk etter:"
+msgstr "Søk:"
 
 #: src/gpodder/gtkui/desktop/podcastdirectory.py:189
-#, fuzzy
 msgid "Search"
-msgstr "Søk etter:"
+msgstr "Søk"
 
 #: src/gpodder/gtkui/desktop/podcastdirectory.py:191
 #: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:2
@@ -1532,9 +1502,8 @@ msgid "URL:"
 msgstr "Adresse:"
 
 #: src/gpodder/gtkui/desktop/podcastdirectory.py:194
-#, fuzzy
 msgid "Filename:"
-msgstr "Brukarnamn:"
+msgstr "Filnamn:"
 
 #: src/gpodder/gtkui/desktop/podcastdirectory.py:195
 #: share/gpodder/ui/gtk/menus.ui.h:21
@@ -1542,14 +1511,22 @@ msgid "Open"
 msgstr "Opna"
 
 #: src/gpodder/gtkui/desktop/podcastdirectory.py:236
-#, fuzzy
 msgid "Loading podcasts"
-msgstr "Legg til podkast"
+msgstr "Lastar podkastar"
 
 #: src/gpodder/gtkui/desktop/podcastdirectory.py:237
-#, fuzzy
 msgid "Please wait while the podcast list is downloaded"
-msgstr "Vent medan podkasten vert fjerna"
+msgstr "Vent mens oversikta over podkastar vert lasta ned"
+
+#: src/gpodder/gtkui/desktop/exportlocal.py:57
+#, python-format
+msgid "Export remaining %(count)d episode to this folder with its default name"
+msgid_plural ""
+"Export remaining %(count)d episodes to this folder with their default name"
+msgstr[0] ""
+"Eksporter gjenståande %(count)d episode til denne mappa, med standardnamn"
+msgstr[1] ""
+"Eksporter gjenståande %(count)d episodar til denne mappa, med standardnamn"
 
 #: src/gpodder/gtkui/desktop/episodeselector.py:100
 msgid "Remove"
@@ -1558,7 +1535,7 @@ msgstr "Fjern"
 #: src/gpodder/gtkui/desktop/episodeselector.py:283
 #: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:2
 msgid "Select all"
-msgstr "Vel alt"
+msgstr "Vel alle"
 
 #: src/gpodder/gtkui/desktop/episodeselector.py:287
 #: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:3
@@ -1567,54 +1544,43 @@ msgstr "Vel ingen"
 
 #: src/gpodder/gtkui/desktop/episodeselector.py:319
 msgid "Nothing selected"
-msgstr "Ingen vald"
+msgstr "Ingen er valde"
 
 #: src/gpodder/gtkui/desktop/episodeselector.py:320
 #, python-format
 msgid "%(count)d episode"
 msgid_plural "%(count)d episodes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d episode"
+msgstr[1] "%(count)d episodar"
 
 #: src/gpodder/gtkui/desktop/episodeselector.py:323
 #, python-format
 msgid "size: %s"
 msgstr "storleik: %s"
 
-#: src/gpodder/gtkui/desktop/exportlocal.py:57
-#, python-format
-msgid "Export remaining %(count)d episode to this folder with its default name"
-msgid_plural ""
-"Export remaining %(count)d episodes to this folder with their default name"
-msgstr[0] ""
-msgstr[1] ""
-
 #: src/gpodder/gtkui/desktop/channel.py:98
-#, fuzzy
 msgid "Add section"
-msgstr "Handling"
+msgstr "Legg til kategori"
 
 #: src/gpodder/gtkui/desktop/channel.py:98
-#, fuzzy
 msgid "New section:"
-msgstr "Nytt namn:"
+msgstr "Ny kategori:"
 
 #: src/gpodder/gtkui/desktop/channel.py:116
-#, fuzzy
 msgid "_Open"
-msgstr "Opna"
+msgstr "_Opna"
 
 #: src/gpodder/gtkui/desktop/channel.py:120
 msgid "_Refresh"
-msgstr ""
+msgstr "O_ppdater"
 
 #: src/gpodder/gtkui/desktop/channel.py:133
 msgid "Select new podcast cover artwork"
-msgstr "Vel nytt podkastomslagsbilete"
+msgstr "Vel nytt omslagsbilete for podkast"
 
 #: src/gpodder/gtkui/desktop/channel.py:165
 msgid "You can only drop a single image or URL here."
-msgstr "Du kan berre sleppa eit enkelt bilete eller ei adresse her."
+msgstr "Du kan berre dra eitt bilete eller éi nettadresse hit."
 
 #: src/gpodder/gtkui/desktop/channel.py:166
 #: src/gpodder/gtkui/desktop/channel.py:178
@@ -1623,7 +1589,7 @@ msgstr "Dreg og slepp"
 
 #: src/gpodder/gtkui/desktop/channel.py:177
 msgid "You can only drop local files and http:// URLs here."
-msgstr "Du kan berre sleppa lokale filer og HTTP-adresser her."
+msgstr "Du kan berre dra lokale filer og HTTP-adresser hit."
 
 #: src/gpodder/plugins/soundcloud.py:172
 msgid "Unknown track"
@@ -1632,431 +1598,291 @@ msgstr "Ukjent spor"
 #: src/gpodder/plugins/soundcloud.py:206
 #, python-format
 msgid "%s on Soundcloud"
-msgstr "%s på Soundcloud"
+msgstr "%s på SoundCloud"
 
 #: src/gpodder/plugins/soundcloud.py:215
 #, python-format
 msgid "Tracks published by %s on Soundcloud."
-msgstr "Spor publisert av %s på Soundcloud"
+msgstr "Spor lagde ut av %s på SoundCloud"
 
 #: src/gpodder/plugins/soundcloud.py:249
 #, python-format
 msgid "%s's favorites on Soundcloud"
-msgstr "%ss favorittar på Soundcloud"
+msgstr "%s sine favorittar på SoundCloud"
 
 #: src/gpodder/plugins/soundcloud.py:255
 #, python-format
 msgid "Tracks favorited by %s on Soundcloud."
-msgstr "Spor favorisert av %s på Soundcloud."
-
-#: share/gpodder/extensions/ted_subtitles.py:17
-msgid "Subtitle Downloader for TED Talks"
-msgstr ""
-
-#: share/gpodder/extensions/ted_subtitles.py:18
-msgid "Downloads .srt subtitles for TED Talks Videos"
-msgstr ""
-
-#: share/gpodder/extensions/rockbox_convert2mp4.py:26
-msgid "Convert video files to MP4 for Rockbox"
-msgstr ""
-
-#: share/gpodder/extensions/rockbox_convert2mp4.py:27
-msgid "Converts all videos to a Rockbox-compatible format"
-msgstr ""
-
-#: share/gpodder/extensions/rockbox_convert2mp4.py:65
-#: share/gpodder/extensions/video_converter.py:115
-#: share/gpodder/extensions/audio_converter.py:134
-#, fuzzy
-msgid "File converted"
-msgstr "iPod OGG-konverterer"
-
-#: share/gpodder/extensions/mpris-listener.py:36
-msgid "MPRIS Listener"
-msgstr ""
-
-#: share/gpodder/extensions/mpris-listener.py:37
-msgid "Convert MPRIS notifications to gPodder Media Player D-Bus API"
-msgstr ""
-
-#: share/gpodder/extensions/ubuntu_appindicator.py:15
-msgid "Ubuntu App Indicator"
-msgstr ""
-
-#: share/gpodder/extensions/ubuntu_appindicator.py:16
-msgid "Show a status indicator in the top bar."
-msgstr ""
-
-#: share/gpodder/extensions/ubuntu_appindicator.py:47
-msgid "Show main window"
-msgstr ""
-
-#: share/gpodder/extensions/ubuntu_appindicator.py:58
-#: share/gpodder/ui/gtk/gpodder.ui.h:4 share/gpodder/ui/gtk/menus.ui.h:6
-msgid "Quit"
-msgstr "Avslutt"
-
-#: share/gpodder/extensions/rockbox_coverart.py:18
-msgid "Rockbox Cover Art Sync"
-msgstr ""
-
-#: share/gpodder/extensions/rockbox_coverart.py:19
-msgid "Copy Cover Art To Rockboxed Media Player"
-msgstr ""
-
-#: share/gpodder/extensions/taskbar_progress.py:35
-msgid "Show download progress on the taskbar"
-msgstr ""
-
-#: share/gpodder/extensions/taskbar_progress.py:36
-msgid "Displays the progress on the Windows taskbar."
-msgstr ""
-
-#: share/gpodder/extensions/rename_download.py:17
-#, fuzzy
-msgid "Rename episodes after download"
-msgstr "Éin ny episode er klar for nedlasting"
-
-#: share/gpodder/extensions/rename_download.py:18
-#, fuzzy
-msgid "Rename episodes to \"<Episode Title>.<ext>\" on download"
-msgstr "Éin ny episode er klar for nedlasting"
-
-#: share/gpodder/extensions/command_on_download.py:18
-msgid "Run a Command on Download"
-msgstr ""
-
-#: share/gpodder/extensions/command_on_download.py:19
-msgid "Run a predefined external command upon download completion."
-msgstr ""
+msgstr "Favorittspor til %s på SoundCloud."
 
 #: share/gpodder/extensions/youtube-dl.py:26
 msgid "Manage Youtube subscriptions using youtube-dl (pip install youtube_dl)"
-msgstr ""
+msgstr "Handsam YouTube-abonnement med youtube-dl («pip install youtube_dl»)"
 
 #: share/gpodder/extensions/video_converter.py:20
-#, fuzzy
 msgid "Convert video files"
-msgstr "Klarte ikkje konvertera fil."
+msgstr "Gjer om videofiler"
 
 #: share/gpodder/extensions/video_converter.py:21
 msgid "Transcode video files to avi/mp4/m4v"
-msgstr ""
+msgstr "Transkod videofiler til AVI/MP4/M4V"
 
 #: share/gpodder/extensions/video_converter.py:84
 #: share/gpodder/extensions/audio_converter.py:93
 #, python-format
 msgid "Convert to %(format)s"
-msgstr ""
+msgstr "Gjer om til %(format)s"
+
+#: share/gpodder/extensions/video_converter.py:115
+#: share/gpodder/extensions/rockbox_convert2mp4.py:65
+#: share/gpodder/extensions/audio_converter.py:134
+msgid "File converted"
+msgstr "Fil gjord om"
 
 #: share/gpodder/extensions/video_converter.py:118
 #: share/gpodder/extensions/audio_converter.py:137
-#, fuzzy
 msgid "Conversion failed"
-msgstr "Klarte ikkje konvertera fil."
+msgstr "Feil ved formatomgjering"
+
+#: share/gpodder/extensions/update_feeds_on_startup.py:15
+msgid "Search for new episodes on startup"
+msgstr "Søk etter nye episodar ved oppstart"
+
+#: share/gpodder/extensions/update_feeds_on_startup.py:16
+msgid "Starts the search for new episodes on startup"
+msgstr "Start søk etter nye episodar når programmet vert starta"
+
+#: share/gpodder/extensions/ubuntu_unity.py:16
+msgid "Ubuntu Unity Integration"
+msgstr "Integrasjon med Ubuntu Unity"
+
+#: share/gpodder/extensions/ubuntu_unity.py:17
+msgid "Show download progress in the Unity Launcher icon."
+msgstr "Vis nedlastingsframdrift på Unity Launcher-ikonet"
+
+#: share/gpodder/extensions/ubuntu_appindicator.py:15
+msgid "Ubuntu App Indicator"
+msgstr "Appindikator for Ubuntu"
+
+# Skal ikkje vera avsluttande punktum i utvidingsskildringar.
+#: share/gpodder/extensions/ubuntu_appindicator.py:16
+msgid "Show a status indicator in the top bar."
+msgstr "Vis statusmarkør i topplinja"
+
+#: share/gpodder/extensions/ubuntu_appindicator.py:47
+msgid "Show main window"
+msgstr "Vis hovudvindauget"
+
+#: share/gpodder/extensions/ubuntu_appindicator.py:58
+#: share/gpodder/ui/gtk/menus.ui.h:6 share/gpodder/ui/gtk/gpodder.ui.h:4
+msgid "Quit"
+msgstr "Avslutt"
+
+#: share/gpodder/extensions/ted_subtitles.py:17
+msgid "Subtitle Downloader for TED Talks"
+msgstr "Undertekst-nedlastar for TED-føredrag"
+
+#: share/gpodder/extensions/ted_subtitles.py:18
+msgid "Downloads .srt subtitles for TED Talks Videos"
+msgstr "Last ned .srt-undertekstar for TED-føredrag"
+
+#: share/gpodder/extensions/taskbar_progress.py:35
+msgid "Show download progress on the taskbar"
+msgstr "Vis nedlastingsframdrift på oppgåvelinja"
+
+# Skal ikkje vera avsluttande punktum her.
+#: share/gpodder/extensions/taskbar_progress.py:36
+msgid "Displays the progress on the Windows taskbar."
+msgstr "Vis framdriftslinja på oppgåvelinja i Windows"
+
+#: share/gpodder/extensions/tagging.py:50
+msgid "Tag downloaded files using Mutagen"
+msgstr "Lagra metadata med Mutagen"
+
+#: share/gpodder/extensions/tagging.py:51
+msgid "Add episode and podcast titles to MP3/OGG tags"
+msgstr "Lagra episode- og podkasttitlar som MP3-/OGG-metadata"
+
+#: share/gpodder/extensions/sonos.py:19 share/gpodder/extensions/sonos.py:81
+msgid "Stream to Sonos"
+msgstr "Straum til Sonos"
+
+#: share/gpodder/extensions/sonos.py:20
+msgid "Stream podcasts to Sonos speakers"
+msgstr "Straum podkastar til Sonos-høgtalarar"
+
+#: share/gpodder/extensions/rockbox_coverart.py:18
+msgid "Rockbox Cover Art Sync"
+msgstr "Synkroniser omslagsbilete for Rockbox"
+
+#: share/gpodder/extensions/rockbox_coverart.py:19
+msgid "Copy Cover Art To Rockboxed Media Player"
+msgstr "Kopier omslagsbileta til Rockbox-basert mediespelar"
+
+#: share/gpodder/extensions/rockbox_convert2mp4.py:26
+msgid "Convert video files to MP4 for Rockbox"
+msgstr "Gjer om videofiler til MP4-format for Rockbox"
+
+#: share/gpodder/extensions/rockbox_convert2mp4.py:27
+msgid "Converts all videos to a Rockbox-compatible format"
+msgstr "Gjer om alle videofiler til eit Rockbox-kompatibelt format"
 
 #: share/gpodder/extensions/rm_ogg_cover.py:38
-#, fuzzy
 msgid "Remove cover art from OGG files"
-msgstr "Vel omslag frå fil"
+msgstr "Fjern omslagsbilete frå OGG-filer"
 
 #: share/gpodder/extensions/rm_ogg_cover.py:39
 msgid "removes coverart from all downloaded ogg files"
-msgstr ""
+msgstr "Fjern omslagsbilete frå alle nedlasta OGG-filer"
 
 #: share/gpodder/extensions/rm_ogg_cover.py:68
-#, fuzzy
 msgid "Remove cover art"
-msgstr "Fjern nytt merke"
+msgstr "Fjern omslagsbilete"
+
+#: share/gpodder/extensions/rename_download.py:17
+msgid "Rename episodes after download"
+msgstr "Endra namn på episodar etter nedlasting"
+
+# Blir dobbelt opp om det står «ved nedlasting» både her og i overskrifta.
+#: share/gpodder/extensions/rename_download.py:18
+msgid "Rename episodes to \"<Episode Title>.<ext>\" on download"
+msgstr "Endra namn på episodane til «<episodetittel>.<filetternamn>»"
+
+#: share/gpodder/extensions/notification-win32.py:55
+msgid "Notification Bubbles for Windows"
+msgstr "Varslingsbobler på Windows"
+
+#: share/gpodder/extensions/notification-win32.py:56
+msgid "Display notification bubbles for different events."
+msgstr "Vis varslingsbobler for ulike hendingar."
+
+#: share/gpodder/extensions/normalize_audio.py:21
+msgid "Normalize audio with re-encoding"
+msgstr "Normaliser lydstyrken med omkoding"
+
+#: share/gpodder/extensions/normalize_audio.py:22
+msgid "Normalize the volume of audio files with normalize-audio"
+msgstr "Normaliser lydstyrken på lydfiler med «normalize-audio»"
+
+#: share/gpodder/extensions/normalize_audio.py:105
+msgid "File normalized"
+msgstr "Fil normalisert"
+
+#: share/gpodder/extensions/mpris-listener.py:36
+msgid "MPRIS Listener"
+msgstr "MPRIS-lyttar"
+
+#: share/gpodder/extensions/mpris-listener.py:37
+msgid "Convert MPRIS notifications to gPodder Media Player D-Bus API"
+msgstr "Gjer om MPRIS-varslingar til D-Bus-API for gPodder-mediespelar"
+
+#: share/gpodder/extensions/minimize_on_start.py:11
+msgid "Minimize on start"
+msgstr "Minimer ved oppstart"
+
+# Er ikkje punktum i skildringane av dei andre utvidingane.
+#: share/gpodder/extensions/minimize_on_start.py:12
+msgid "Minimizes the gPodder window on startup."
+msgstr "Minimer gPodder-vindauget ved oppstart"
+
+#: share/gpodder/extensions/gtk_statusicon.py:19
+msgid "Gtk Status Icon"
+msgstr "Gtk-statusikon"
+
+# Skal ikkje vera avsluttande punktum i utvidingsskildringar.
+#: share/gpodder/extensions/gtk_statusicon.py:20
+msgid "Show a status icon for Gtk-based Desktops."
+msgstr "Vis statusikon på Gtk-baserte skrivebord"
+
+#: share/gpodder/extensions/episode_website_context_menu.py:15
+msgid "\"Open website\" episode and podcast context menu"
+msgstr "«Opna nettsida»-kontekstmeny for podkastar og episodar"
+
+#: share/gpodder/extensions/episode_website_context_menu.py:16
+msgid ""
+"Add a context menu item for opening the website of an episode or podcast"
+msgstr "Legg til kontekstmeny for å opna nettsida til podkastar og episodar"
+
+#: share/gpodder/extensions/episode_website_context_menu.py:34
+#: share/gpodder/extensions/episode_website_context_menu.py:37
+msgid "Open website"
+msgstr "Opna nettsida"
 
 #: share/gpodder/extensions/enqueue_in_mediaplayer.py:17
 msgid "Enqueue/Resume in media players"
-msgstr ""
+msgstr "Legg i kø / hald fram avspeling i mediespelarar"
 
 #: share/gpodder/extensions/enqueue_in_mediaplayer.py:18
 msgid ""
 "Add a context menu item for enqueueing/resuming playback of episodes in "
 "installed media players"
 msgstr ""
+"Legg til kontekstmeny for å leggja episodar i kø / halda fram med avspeling "
+"i installerte mediespelarar"
 
 #: share/gpodder/extensions/enqueue_in_mediaplayer.py:36
 msgid "Enqueue in"
-msgstr ""
+msgstr "Legg i kø i"
 
 #: share/gpodder/extensions/enqueue_in_mediaplayer.py:97
-#, fuzzy
 msgid "Resume in"
-msgstr "Fortset alle"
-
-#: share/gpodder/extensions/notification-win32.py:55
-msgid "Notification Bubbles for Windows"
-msgstr ""
-
-#: share/gpodder/extensions/notification-win32.py:56
-msgid "Display notification bubbles for different events."
-msgstr ""
-
-#: share/gpodder/extensions/update_feeds_on_startup.py:15
-#, fuzzy
-msgid "Search for new episodes on startup"
-msgstr "Sjå etter nye episodar under oppstart"
-
-#: share/gpodder/extensions/update_feeds_on_startup.py:16
-#, fuzzy
-msgid "Starts the search for new episodes on startup"
-msgstr "Sjå etter nye episodar under oppstart"
-
-#: share/gpodder/extensions/normalize_audio.py:21
-msgid "Normalize audio with re-encoding"
-msgstr ""
-
-#: share/gpodder/extensions/normalize_audio.py:22
-msgid "Normalize the volume of audio files with normalize-audio"
-msgstr ""
-
-#: share/gpodder/extensions/normalize_audio.py:105
-#, fuzzy
-msgid "File normalized"
-msgstr "Filnamn"
-
-#: share/gpodder/extensions/gtk_statusicon.py:19
-msgid "Gtk Status Icon"
-msgstr ""
-
-#: share/gpodder/extensions/gtk_statusicon.py:20
-msgid "Show a status icon for Gtk-based Desktops."
-msgstr ""
+msgstr "Hald fram avspeling i"
 
 #: share/gpodder/extensions/concatenate_videos.py:20
 #: share/gpodder/extensions/concatenate_videos.py:102
-#, fuzzy
 msgid "Concatenate videos"
-msgstr "Klarte ikkje konvertera fil."
+msgstr "Flett saman videofiler"
 
 #: share/gpodder/extensions/concatenate_videos.py:21
 msgid "Add a context menu item for concatenating multiple videos"
-msgstr ""
+msgstr "Legg til kontekstmeny for å fletta saman fleire videofiler"
 
 #: share/gpodder/extensions/concatenate_videos.py:38
 msgid "Save video"
-msgstr ""
+msgstr "Lagra video"
 
 #: share/gpodder/extensions/concatenate_videos.py:67
-#, fuzzy
 msgid "Concatenating video files"
-msgstr "Klarte ikkje konvertera fil."
+msgstr "Flettar saman videofiler"
 
 #: share/gpodder/extensions/concatenate_videos.py:68
 #, python-format
 msgid "Writing %(filename)s"
-msgstr ""
+msgstr "Lagrar %(filename)s"
 
 #: share/gpodder/extensions/concatenate_videos.py:80
 msgid "Videos successfully converted"
-msgstr ""
+msgstr "Videofilene er no gjorde om"
 
 #: share/gpodder/extensions/concatenate_videos.py:81
-#, fuzzy
 msgid "Error converting videos"
-msgstr "Klarte ikkje konvertera fil."
+msgstr "Feil ved formatomgjering av videofiler"
 
 #: share/gpodder/extensions/concatenate_videos.py:82
 msgid "Concatenation result"
-msgstr ""
+msgstr "Resultat av fletting"
 
-#: share/gpodder/extensions/sonos.py:19 share/gpodder/extensions/sonos.py:81
-msgid "Stream to Sonos"
-msgstr ""
+#: share/gpodder/extensions/command_on_download.py:18
+msgid "Run a Command on Download"
+msgstr "Køyr kommando ved nedlasting"
 
-#: share/gpodder/extensions/sonos.py:20
-msgid "Stream podcasts to Sonos speakers"
-msgstr ""
-
-#: share/gpodder/extensions/minimize_on_start.py:11
-msgid "Minimize on start"
-msgstr ""
-
-#: share/gpodder/extensions/minimize_on_start.py:12
-msgid "Minimizes the gPodder window on startup."
-msgstr ""
+# Skal ikkje vera avsluttande punktum i utvidingsskildringane.
+#: share/gpodder/extensions/command_on_download.py:19
+msgid "Run a predefined external command upon download completion."
+msgstr "Køyr ferdigdefinert ekstern kommando etter nedlasting"
 
 #: share/gpodder/extensions/audio_converter.py:20
-#, fuzzy
 msgid "Convert audio files"
-msgstr "Klarte ikkje konvertera fil."
+msgstr "Gjer om lydfiler"
 
 #: share/gpodder/extensions/audio_converter.py:21
 msgid "Transcode audio files to mp3/ogg"
-msgstr ""
+msgstr "Transkod lydfiler til MP3/Ogg"
 
-#: share/gpodder/extensions/episode_website_context_menu.py:15
-msgid "\"Open website\" episode and podcast context menu"
-msgstr ""
-
-#: share/gpodder/extensions/episode_website_context_menu.py:16
-msgid ""
-"Add a context menu item for opening the website of an episode or podcast"
-msgstr ""
-
-#: share/gpodder/extensions/episode_website_context_menu.py:34
-#: share/gpodder/extensions/episode_website_context_menu.py:37
-#, fuzzy
-msgid "Open website"
-msgstr "Nettstad:"
-
-#: share/gpodder/extensions/tagging.py:50
-msgid "Tag downloaded files using Mutagen"
-msgstr ""
-
-#: share/gpodder/extensions/tagging.py:51
-#, fuzzy
-msgid "Add episode and podcast titles to MP3/OGG tags"
-msgstr "Vis «Alle episodar» i podkastliste"
-
-#: share/gpodder/extensions/ubuntu_unity.py:16
-msgid "Ubuntu Unity Integration"
-msgstr ""
-
-#: share/gpodder/extensions/ubuntu_unity.py:17
-msgid "Show download progress in the Unity Launcher icon."
-msgstr ""
-
-#: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:1
-msgid "Add a new podcast"
-msgstr "Legg til ein ny podkast"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:1
-msgid "gPodder Podcast Editor"
-msgstr "Podkastendrar"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:2
-#, fuzzy
-msgid "Section:"
-msgstr "Handling"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:3
-#, fuzzy
-msgid "Disable feed updates (pause subscription)"
-msgstr "Bruk smart kjeldeoppdatering"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:4
-#, fuzzy
-msgid "Synchronize to MP3 player devices"
-msgstr "Synkroniserer til spelar"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:5
-#, fuzzy
-msgid "Strategy:"
-msgstr "Slettingstrategi"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:6
-#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:6
-msgid "General"
-msgstr "Generelt"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:7
-msgid "<b>HTTP/FTP Authentication</b>"
-msgstr "<b>HTTP/FTP-autentisering</b>"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:8
-#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:14
-msgid "Username:"
-msgstr "Brukarnamn:"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:9
-#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:15 bin/gpo:326
-msgid "Password:"
-msgstr "Passord:"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:10
-msgid "<b>Locations</b>"
-msgstr "<b>Plasseringar</b>"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:11
-msgid "Download to:"
-msgstr "Last ned til:"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:12
-msgid "Website:"
-msgstr "Nettstad:"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:13
-msgid "website label"
-msgstr "nettstadsetikett"
-
-#: share/gpodder/ui/gtk/gpodderchannel.ui.h:14
-msgid "Advanced"
-msgstr "Avansert"
-
-#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:1
-msgid "gPodder Configuration Editor"
-msgstr "Innstillingsendrar"
-
-#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:2
-msgid "Search for:"
-msgstr "Søk etter:"
-
-#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:3
-msgid "Show All"
-msgstr "Vis alt"
-
-#: share/gpodder/ui/gtk/gpodder.ui.h:3 share/gpodder/ui/gtk/menus.ui.h:1
+#: share/gpodder/ui/gtk/menus.ui.h:1 share/gpodder/ui/gtk/gpodder.ui.h:3
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:1
 msgid "Preferences"
 msgstr "Innstillingar"
-
-#: share/gpodder/ui/gtk/gpodder.ui.h:5 share/gpodder/ui/gtk/menus.ui.h:8
-msgid "Check for new episodes"
-msgstr "Sjekk etter nye episodar"
-
-#: share/gpodder/ui/gtk/gpodder.ui.h:6
-msgid "Filter:"
-msgstr "Filter:"
-
-#: share/gpodder/ui/gtk/gpodder.ui.h:7
-msgid "Podcasts"
-msgstr "Podkastar"
-
-#: share/gpodder/ui/gtk/gpodder.ui.h:8
-msgid "Limit rate to"
-msgstr "Avgrens rate til"
-
-#: share/gpodder/ui/gtk/gpodder.ui.h:9
-msgid "KiB/s"
-msgstr "KiB/s"
-
-#: share/gpodder/ui/gtk/gpodder.ui.h:10
-msgid "Limit downloads to"
-msgstr "Avgrens nedlastingar til"
-
-#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:1
-msgid "Select episodes"
-msgstr "Vel episodar"
-
-#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:2
-#, fuzzy
-msgid "<big>Welcome to gPodder</big>"
-msgstr "<b><big>Velkommen til gPodder</big></b>"
-
-#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:3
-#, fuzzy
-msgid "Your podcast list is empty."
-msgstr "Podkastlista di er tom. Kva vil du gjera?"
-
-#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:4
-msgid "Choose from a list of example podcasts"
-msgstr "Vel frå ei liste med dømepodkastar"
-
-#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:5
-#, fuzzy
-msgid "Add a podcast by entering its URL"
-msgstr "Legg til podkast via ei adresse"
-
-#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:6
-#, fuzzy
-msgid "Restore my subscriptions from gpodder.net"
-msgstr "Last ned mine abonnement frå gpodder.net"
 
 #: share/gpodder/ui/gtk/menus.ui.h:2
 msgid "Go to gpodder.net"
@@ -2064,30 +1890,31 @@ msgstr "Gå til gpodder.net"
 
 #: share/gpodder/ui/gtk/menus.ui.h:3
 msgid "Software updates"
-msgstr ""
+msgstr "Programoppdateringar"
 
 #: share/gpodder/ui/gtk/menus.ui.h:4
-#, fuzzy
 msgid "Help"
-msgstr "_Hjelp"
+msgstr "Hjelp"
 
 #: share/gpodder/ui/gtk/menus.ui.h:5
 msgid "About"
-msgstr ""
+msgstr "Om"
 
 #: share/gpodder/ui/gtk/menus.ui.h:7
-#, fuzzy
 msgid "_Podcasts"
-msgstr "Podkastar"
+msgstr "_Podkastar"
+
+#: share/gpodder/ui/gtk/menus.ui.h:8 share/gpodder/ui/gtk/gpodder.ui.h:5
+msgid "Check for new episodes"
+msgstr "Sjå etter nye episodar"
 
 #: share/gpodder/ui/gtk/menus.ui.h:9
 msgid "Download new episodes"
 msgstr "Last ned nye episodar"
 
 #: share/gpodder/ui/gtk/menus.ui.h:11
-#, fuzzy
 msgid "_Subscriptions"
-msgstr "Ingen abonnement"
+msgstr "_Abonnement"
 
 #: share/gpodder/ui/gtk/menus.ui.h:12
 msgid "Discover new podcasts"
@@ -2095,7 +1922,7 @@ msgstr "Finn nye podkastar"
 
 #: share/gpodder/ui/gtk/menus.ui.h:13
 msgid "Add podcast via URL"
-msgstr "Legg til podkast via ei adresse"
+msgstr "Legg til podkast via nettadresse"
 
 #: share/gpodder/ui/gtk/menus.ui.h:17
 msgid "Import from OPML file"
@@ -2106,36 +1933,32 @@ msgid "Export to OPML file"
 msgstr "Eksporter til OPML-fil"
 
 #: share/gpodder/ui/gtk/menus.ui.h:19
-#, fuzzy
 msgid "_Episodes"
-msgstr "Episode"
+msgstr "_Episodar"
 
 #: share/gpodder/ui/gtk/menus.ui.h:25
 msgid "Toggle new status"
-msgstr ""
+msgstr "Merk som ny/ikkje-ny"
 
 #: share/gpodder/ui/gtk/menus.ui.h:26
 msgid "Change delete lock"
-msgstr "Skift slettelås"
+msgstr "Slå på/av slettelås"
 
 #: share/gpodder/ui/gtk/menus.ui.h:29
-#, fuzzy
 msgid "Sync to device"
 msgstr "Synkroniser til eining"
 
 #: share/gpodder/ui/gtk/menus.ui.h:30
-#, fuzzy
 msgid "Update YouTube subscriptions"
-msgstr "Ingen abonnement"
+msgstr "Oppdater YouTube-abonnement"
 
 #: share/gpodder/ui/gtk/menus.ui.h:31
 msgid "_View"
-msgstr ""
+msgstr "_Vis"
 
 #: share/gpodder/ui/gtk/menus.ui.h:32
-#, fuzzy
 msgid "Toolbar"
-msgstr "Vis verktøylinje"
+msgstr "Verktøylinje"
 
 #: share/gpodder/ui/gtk/menus.ui.h:33
 msgid "Episode descriptions"
@@ -2159,49 +1982,103 @@ msgstr "Gøym podkastar utan episodar"
 
 #: share/gpodder/ui/gtk/menus.ui.h:39
 msgid "Visible columns"
-msgstr ""
+msgstr "Synlege kolonnar"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:2
+msgid "<big>Welcome to gPodder</big>"
+msgstr "<big>Velkommen til gPodder</big>"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:3
+msgid "Your podcast list is empty."
+msgstr "Podkastlista er tom."
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:4
+msgid "Choose from a list of example podcasts"
+msgstr "Vel nokre eksempelpodkastar"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:5
+msgid "Add a podcast by entering its URL"
+msgstr "Legg til podkast via nettadresse"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:6
+msgid "Restore my subscriptions from gpodder.net"
+msgstr "Gjenopprett abonnement frå gpodder.net"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:6
+msgid "Filter:"
+msgstr "Filter:"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:7
+msgid "Podcasts"
+msgstr "Podkastar"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:8
+msgid "Limit rate to"
+msgstr "Avgrens nedlastingsfart til"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:9
+msgid "KiB/s"
+msgstr "KiB/s"
+
+# God plass, så går greitt med lang tekst her.
+#: share/gpodder/ui/gtk/gpodder.ui.h:10
+msgid "Limit downloads to"
+msgstr "Avgrens talet på samtidige nedlastingar til"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:2
 msgid "Audio player:"
-msgstr "Lydspelar:"
+msgstr "Lydavspelar:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:3
 msgid "Video player:"
-msgstr "Filmspelar:"
+msgstr "Videoavspelar:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:4
-#, fuzzy
 msgid "\"All episodes\" in podcast list"
-msgstr "Vis «Alle episodar» i podkastliste"
+msgstr "Vis samlekategori med «alle episodar» i podkastlista"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:5
-#, fuzzy
 msgid "Use sections for podcast list"
-msgstr "Klarte ikkje lagra podkastliste"
+msgstr "Grupper podkastlista etter kategoriar"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:6
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:6
+msgid "General"
+msgstr "Generelt"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:7
 msgid "Preferred YouTube format:"
-msgstr ""
+msgstr "Føretrekt YouTube-format:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:8
 msgid "YouTube API key (v3):"
-msgstr ""
+msgstr "YouTube-API-nøkkel (v3):"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:9
 msgid "Preferred Vimeo format:"
-msgstr ""
+msgstr "Føretrekt Vimeo-format:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:12
 msgid "Synchronize subscriptions and episode actions"
-msgstr "Synkroniser abonnementar og episodehandlingar"
+msgstr "Synkroniser abonnement og episodehandlingar"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:13
 msgid "Server:"
-msgstr ""
+msgstr "Tenar:"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:14
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:8
+msgid "Username:"
+msgstr "Brukarnamn:"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:15
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:9 bin/gpo:326
+msgid "Password:"
+msgstr "Passord:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:16
 msgid "Replace list on server with local subscriptions"
-msgstr "Byt ut liste på tenar med lokale abonnement"
+msgstr "Byt ut lista på tenaren med lokale abonnement"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:17
 msgid "Device name:"
@@ -2217,32 +2094,33 @@ msgstr "Oppdateringsintervall:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:20
 msgid "Maximum number of episodes per podcast:"
-msgstr "Maksimultalet på episodar per podkast:"
+msgstr "Øvre grense på episodar per podkast:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:21
 msgid "When new episodes are found:"
-msgstr "Når nye episodar er funne:"
+msgstr "Når det kjem nye episodar:"
 
+# Faneoverskrift i innstillingane.
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:22
 msgid "Updating"
-msgstr "Oppdaterer"
+msgstr "Oppdatering"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:23
 msgid "Delete played episodes:"
-msgstr "Slett spela episodar:"
+msgstr "Slett avspela episodar:"
 
+# Forklaring (frå src/gpodder/model.py): «An episode is considered "finished" when there is a current position mark on the track, and when the current position is greater than 99 percent of the total time or inside the last 10 seconds of a track.»
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:24
-#, fuzzy
 msgid "Remove played episodes even if unfinished"
-msgstr "Fjern spela episodar frå eining"
+msgstr "Fjern påbegynte episodar sjølv om dei ikkje er ferdigavspela"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:25
 msgid "Also remove unplayed episodes"
-msgstr "Fjern òg uspela episodar"
+msgstr "Fjern òg episodar som ikkje er påbegynte"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:26
 msgid "Clean-up"
-msgstr "Rydd opp"
+msgstr "Opprydding"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:27
 msgid "Device type:"
@@ -2254,21 +2132,19 @@ msgstr "Monteringspunkt:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:29
 msgid "After syncing an episode:"
-msgstr "Etter ein episode er synkronisert:"
+msgstr "Etter synkronisering av episode:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:30
-#, fuzzy
 msgid "Create playlists on device"
-msgstr "Byt ut abonnementlista på tenaren"
+msgstr "Lag spelelista på eininga"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:31
-#, fuzzy
 msgid "Playlists Folder:"
-msgstr "Namn på spelelista:"
+msgstr "Spelelistemappe:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:32
 msgid "Remove episodes deleted on device from gPodder"
-msgstr ""
+msgstr "Fjern automatisk episodar i gPodder som er sletta på eininga"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:33
 msgid "Only sync unplayed episodes"
@@ -2280,7 +2156,7 @@ msgstr "Einingar"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:35
 msgid "Edit config"
-msgstr "Rediger innstillingar"
+msgstr "Rediger råoppsett"
 
 #: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:1
 msgid "Find new podcasts"
@@ -2288,7 +2164,7 @@ msgstr "Finn nye podkastar"
 
 #: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:2
 msgid "Select All"
-msgstr "Vel alt"
+msgstr "Vel alle"
 
 #: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:3
 msgid "Select None"
@@ -2296,240 +2172,296 @@ msgstr "Vel ingen"
 
 #: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:4
 msgid "label"
-msgstr ""
+msgstr "merkelapp"
 
 #: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:5
 msgid "..."
-msgstr ""
+msgstr "…"
+
+#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:1
+msgid "Select episodes"
+msgstr "Vel episodar"
+
+#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:1
+msgid "gPodder Configuration Editor"
+msgstr "gPodder oppsett-redigering"
+
+#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:2
+msgid "Search for:"
+msgstr "Søk etter:"
+
+#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:3
+msgid "Show All"
+msgstr "Vis alle"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:1
+msgid "gPodder Podcast Editor"
+msgstr "gPodder podkast-redigering"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:2
+msgid "Section:"
+msgstr "Kategori:"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:3
+msgid "Disable feed updates (pause subscription)"
+msgstr "Slå av kjeldeoppdatering (set abonnementet på pause)"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:4
+msgid "Synchronize to MP3 player devices"
+msgstr "Synkroniser til MP3-spelar"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:5
+msgid "Strategy:"
+msgstr "Strategi:"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:7
+msgid "<b>HTTP/FTP Authentication</b>"
+msgstr "<b>HTTP/FTP-autentisering</b>"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:10
+msgid "<b>Locations</b>"
+msgstr "<b>Mapper</b>"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:11
+msgid "Download to:"
+msgstr "Last ned til:"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:12
+msgid "Website:"
+msgstr "Nettstad:"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:13
+msgid "website label"
+msgstr "nettstad-merkelapp"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:14
+msgid "Advanced"
+msgstr "Avansert"
+
+#: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:1
+msgid "Add a new podcast"
+msgstr "Legg til ny podkast"
+
+#: bin/gpodder:100
+msgid "print logging output on the console"
+msgstr "Skriv loggdata på konsollen"
+
+#: bin/gpodder:103
+msgid "subscribe to the feed at URL"
+msgstr "abonner på kjelda på nettadressa"
+
+#: bin/gpodder:108
+msgid "Mac OS X application process number"
+msgstr "Mac OS X-prosess-ID"
 
 #: bin/gpo:245
-#, fuzzy
 msgid "Podcast update requested by extensions."
-msgstr "Podkast krev autentisering"
+msgstr "Utviding ber om oppdatering av podkast."
 
 #: bin/gpo:249
 msgid "Episode download requested by extensions."
-msgstr ""
+msgstr "Utviding ber om nedlasting av episode."
 
 #: bin/gpo:302
 #, python-format
 msgid "Invalid url: %s"
-msgstr ""
+msgstr "Ugyldig adresse: %s"
 
 #: bin/gpo:324
-#, fuzzy
 msgid "User name:"
 msgstr "Brukarnamn:"
 
 #: bin/gpo:341 bin/gpo:417 bin/gpo:455 bin/gpo:654 bin/gpo:676 bin/gpo:691
 #: bin/gpo:811
-#, fuzzy, python-format
+#, python-format
 msgid "You are not subscribed to %s."
-msgstr "Du abonnerer alt på desse podkastane:"
+msgstr "Du abonnerer ikkje på %s."
 
 #: bin/gpo:347
-#, fuzzy, python-format
+#, python-format
 msgid "Already subscribed to %s."
-msgstr "Klarte ikkje synkronisera til iPod"
+msgstr "Du abonnerer alt på %s."
 
 #: bin/gpo:353
-#, fuzzy, python-format
+#, python-format
 msgid "Cannot subscribe to %s."
-msgstr "Klarte ikkje synkronisera til iPod"
+msgstr "Kan ikkje avslutta abonnementet på %s."
 
 #: bin/gpo:369
 #, python-format
 msgid "Successfully added %s."
-msgstr ""
+msgstr "La til %s."
 
 #: bin/gpo:387
 msgid "This configuration option does not exist."
-msgstr ""
+msgstr "Denne innstillinga finst ikkje."
 
 #: bin/gpo:391
 msgid "Can only set leaf configuration nodes."
-msgstr ""
+msgstr "Kan berre endra bladnodar i oppsettet."
 
 #: bin/gpo:405
 #, python-format
 msgid "Renamed %(old_title)s to %(new_title)s."
-msgstr ""
+msgstr "Endra namn på %(old_title)s til %(new_title)s."
 
 #: bin/gpo:421
-#, fuzzy, python-format
+#, python-format
 msgid "Unsubscribed from %s."
-msgstr "Fjern abonnement"
+msgstr "Avslutta abonnement på %s."
 
 #: bin/gpo:487
 msgid "Invalid command."
-msgstr ""
+msgstr "Ugyldig kommando."
 
 #: bin/gpo:492
 #, python-format
 msgid "Invalid option: %s."
-msgstr ""
+msgstr "Ugyldig val: %s."
 
 #: bin/gpo:517
-#, fuzzy
 msgid "Updates disabled"
-msgstr "Oppdater valde"
+msgstr "Oppdateringar av"
 
 #: bin/gpo:528
 #, python-format
 msgid "%(count)d new episode"
 msgid_plural "%(count)d new episodes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%(count)d ny episode"
+msgstr[1] "%(count)d nye episodar"
 
 #: bin/gpo:534
-#, fuzzy
 msgid "Checking for new episodes"
-msgstr "Sjekkar etter nye episodar …"
+msgstr "Ser etter nye episodar …"
 
 #: bin/gpo:543
-#, fuzzy, python-format
+#, python-format
 msgid "Skipping %(podcast)s"
-msgstr "Legg til podkast"
+msgstr "Hoppar over %(podcast)s"
 
 #: bin/gpo:661
 msgid "No episode with the specified GUID found."
-msgstr ""
+msgstr "Fann ingen episode med den oppgjevne GUID-en."
 
 #: bin/gpo:665
-#, fuzzy, python-format
+#, python-format
 msgid "Deleted episode \"%s\"."
-msgstr "Slett episodar"
+msgstr "Sletta episoden «%s»."
 
 #: bin/gpo:667
-#, fuzzy
 msgid "Episode has already been deleted."
-msgstr "Episodane er låst"
+msgstr "Episoden er alt sletta."
 
 #: bin/gpo:682
 #, python-format
 msgid "Disabling feed update from %s."
-msgstr ""
+msgstr "Slår av oppdatering av kjelda %s."
 
 #: bin/gpo:697
-#, fuzzy, python-format
+#, python-format
 msgid "Enabling feed update from %s."
-msgstr "Leser filer frå %s"
+msgstr "Slår på oppdatering av kjelda %s."
 
 #: bin/gpo:710
 #, python-format
 msgid "Please register a YouTube API key and set it using %(command)s."
 msgstr ""
+"Registrer deg for å få ein YouTube-API-nøkkel, og oppgje han via %(command)s."
 
 #: bin/gpo:737
 #, python-format
 msgid "Changing: %(old_url)s => %(new_url)s"
-msgstr ""
+msgstr "Endrar: %(old_url)s → %(new_url)s"
 
 #: bin/gpo:747
-#, fuzzy
 msgid "Nothing to fix"
-msgstr "Ingenting å eksportera"
+msgstr "Ingenting å retta opp"
 
 #: bin/gpo:766
-#, fuzzy
 msgid "No podcasts found."
-msgstr "Ingen podkastar funne."
+msgstr "Fann ikkje nokon podkastar."
 
 #: bin/gpo:780
 msgid "Enter index to subscribe, ? for list"
-msgstr ""
+msgstr "Vel indeks å abonnera på, eller «?» for ei oversikt"
 
 #: bin/gpo:794 bin/gpo:798 bin/gpo:940 bin/gpo:944
 msgid "Invalid value."
-msgstr ""
+msgstr "Ugyldig verdi."
 
 #: bin/gpo:815
 #, python-format
 msgid "Invalid URL: %s"
-msgstr ""
+msgstr "Ugyldig adresse: %s"
 
 #: bin/gpo:818
 #, python-format
 msgid "Changed URL from %(old_url)s to %(new_url)s."
-msgstr ""
+msgstr "Endra adresse frå %(old_url)s til %(new_url)s."
 
 #: bin/gpo:843
 #, python-format
 msgid "%(title)s: %(msg)s ([yes]/no): "
-msgstr ""
+msgstr "%(title)s: %(msg)s ([ja]/nei): "
 
 #: bin/gpo:847
 msgid "yes"
-msgstr ""
+msgstr "ja"
 
 #: bin/gpo:885
-#, fuzzy, python-format
+#, python-format
 msgid "Deleting episode: %(episode)s"
-msgstr "Slettar episodar"
+msgstr "Slettar episode: %(episode)s"
 
 #: bin/gpo:918
 msgid ""
 "Enter episode index to toggle, ? for list, X to select all, space to select "
 "none, empty when ready"
 msgstr ""
+"Skriv inn episodeindeks for å merkja / fjerna merking, «?» for oversikt, «X» "
+"for å merkja alle, «Mellomrom» for å fjerna all merking og linjeskift når du "
+"er klar"
 
 #: bin/gpo:950
-#, fuzzy, python-format
+#, python-format
 msgid "Will delete %(episode)s"
-msgstr "Gøym sletta episodar"
+msgstr "Skal sletta %(episode)s"
 
 #: bin/gpo:952
-#, fuzzy, python-format
+#, python-format
 msgid "Won't delete %(episode)s"
-msgstr "Slett episodar"
+msgstr "Skal ikkje sletta %(episode)s"
 
 #: bin/gpo:965
-#, fuzzy, python-format
+#, python-format
 msgid "Syncing %s"
-msgstr "Legg til %s"
+msgstr "Synkroniserer %s"
 
 #: bin/gpo:1035
 #, python-format
 msgid "Syntax error: %(error)s"
-msgstr ""
+msgstr "Syntaksfeil: %(error)s"
 
 #: bin/gpo:1129
 msgid "Ambiguous command. Did you mean.."
-msgstr ""
+msgstr "Tvetydig kommando. Meinte du …"
 
 #: bin/gpo:1133
-#, fuzzy
 msgid "The requested function is not available."
-msgstr "Denne funksjonen er ikkje tilgjengeleg for iPod-ar."
-
-#: bin/gpodder:100
-#, fuzzy
-msgid "print logging output on the console"
-msgstr "Skriv avlusningsutdata til «stdout»"
-
-#: bin/gpodder:103
-msgid "subscribe to the feed at URL"
-msgstr ""
-
-#: bin/gpodder:108
-msgid "Mac OS X application process number"
-msgstr ""
+msgstr "Funksjonen er ikkje tilgjengeleg."
 
 #: share/applications/gpodder-url-handler.desktop.in.h:1
-#, fuzzy
 msgid "gPodder (subscribe to feed)"
-msgstr "Klarte ikkje synkronisera til iPod"
+msgstr "gPodder (abonner på kjelde)"
 
 #: share/applications/gpodder.desktop.in.h:2
-#, fuzzy
 msgid "gPodder Podcast Client"
-msgstr "Podkastendrar"
+msgstr "gPodder podkastklient"
 
 #: share/applications/gpodder.desktop.in.h:3
-#, fuzzy
 msgid "Podcast Client"
-msgstr "Podkastliste"
+msgstr "Podkastklient"
 
 #: share/applications/gpodder.desktop.in.h:4
 msgid "Subscribe to audio and video content from the web"
-msgstr ""
+msgstr "Abonner på lyd- og videoinnhald på Internett"


### PR DESCRIPTION
Here’s a complete Norwegian Nynorsk translation of gPodder. (I don’t why the strings are in a different order; the .po file was automatically updated when I did a ‘make install’.)