### PR TITLE
Embed previous msgids of changed/fuzzied messages

### DIFF
--- a/makefile
+++ b/makefile
@@ -119,7 +119,7 @@ share/man/man1/gpo.1: src/gpodder/__init__.py
 messages: $(MOFILES)
 
 %.po: $(MESSAGES)
-	msgmerge --silent $@ $< --output-file=$@
+	msgmerge --previous --silent $@ $< --output-file=$@
 	msgattrib --set-obsolete --ignore-file=$< -o $@ $@
 	msgattrib --no-obsolete -o $@ $@
 


### PR DESCRIPTION
When a string is changed (marking the translation for the old string
as ‘fuzzy’), the original string is now kept for comparison. This
makes life much easier for the translators, as they can easily see what
has changed in the string, and adjust their translation accordingly.
(Modern PO editors show the changes as a coloured (word) diff.)