### PR TITLE
Format number of episodes using (locale-aware) thousands separator

### DIFF
--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -706,7 +706,7 @@ class PodcastListModel(Gtk.ListStore):
 
     def _get_pill_image(self, channel, count_downloaded, count_unplayed):
         if count_unplayed > 0 or count_downloaded > 0:
-            return draw.draw_pill_pixbuf(str(count_unplayed), str(count_downloaded), widget=self.widget)
+            return draw.draw_pill_pixbuf('{:n}'.format(count_unplayed), '{:n}'.format(count_downloaded), widget=self.widget)
         else:
             return None
 


### PR DESCRIPTION
The number of episodes shown in the ‘pill boxes’ in the podcast list
are now formatted like ‘12,345’ or ‘12 345’ (depending on the locale),
instead of ‘12345’.