### PR TITLE
Revert "Update tagging.py"

### DIFF
--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -67,11 +67,10 @@ DefaultConfig = {
 
 
 class AudioFile(object):
-    def __init__(self, filename, album, title, subtitle, genre, pubDate, cover):
+    def __init__(self, filename, album, title, genre, pubDate, cover):
         self.filename = filename
         self.album = album
         self.title = title
-        self.subtitle = subtitle
         self.genre = genre
         self.pubDate = pubDate
         self.cover = cover
@@ -94,12 +93,6 @@ class AudioFile(object):
 
             if self.title is not None:
                 audio.tags['title'] = self.title
-
-            if self.subtitle is not None:
-                audio.tags['subtitle'] = self.subtitle
-
-            if self.subtitle is not None:
-                audio.tags['comments'] = self.subtitle
 
             if self.genre is not None:
                 audio.tags['genre'] = self.genre
@@ -139,8 +132,8 @@ class AudioFile(object):
 
 
 class OggFile(AudioFile):
-    def __init__(self, filename, album, title, subtitle, genre, pubDate, cover):
-        super(OggFile, self).__init__(filename, album, title, subtitle, genre, pubDate, cover)
+    def __init__(self, filename, album, title, genre, pubDate, cover):
+        super(OggFile, self).__init__(filename, album, title, genre, pubDate, cover)
 
     def insert_coverart(self):
         audio = File(self.filename, easy=True)
@@ -150,8 +143,8 @@ class OggFile(AudioFile):
 
 
 class Mp4File(AudioFile):
-    def __init__(self, filename, album, title, subtitle, genre, pubDate, cover):
-        super(Mp4File, self).__init__(filename, album, title, subtitle, genre, pubDate, cover)
+    def __init__(self, filename, album, title, genre, pubDate, cover):
+        super(Mp4File, self).__init__(filename, album, title, genre, pubDate, cover)
 
     def insert_coverart(self):
         audio = File(self.filename)
@@ -167,8 +160,8 @@ class Mp4File(AudioFile):
 
 
 class Mp3File(AudioFile):
-    def __init__(self, filename, album, title, subtitle, genre, pubDate, cover):
-        super(Mp3File, self).__init__(filename, album, title, subtitle, genre, pubDate, cover)
+    def __init__(self, filename, album, title, genre, pubDate, cover):
+        super(Mp3File, self).__init__(filename, album, title, genre, pubDate, cover)
 
     def insert_coverart(self):
         audio = MP3(self.filename, ID3=ID3)
@@ -221,7 +214,6 @@ class gPodderExtension:
             audio = audioClass(info['filename'],
                 info['album'],
                 info['title'],
-                info['subtitle'],
                 info['genre'],
                 info['pubDate'],
                 cover)
@@ -232,7 +224,6 @@ class gPodderExtension:
             'filename': None,
             'album': None,
             'title': None,
-            'subtitle': None,
             'genre': None,
             'pubDate': None
         }
@@ -249,8 +240,6 @@ class gPodderExtension:
             info['title'] = title[len(info['album']):].lstrip()
         else:
             info['title'] = title
-
-        info['subtitle'] = episode.description
 
         if self.container.config.genre_tag is not None:
             info['genre'] = self.container.config.genre_tag


### PR DESCRIPTION
Reverts gpodder/gpodder#684

@AntonelloA  adding subtitle or comment tags doesn't work. See #737 for the stacktrace.
I've reproduced the bug with http://www.radio.rai.it/radio2/podcast/rssradio2.jsp?id=80 given in the pull request.
I'm reverting it and re-releasing gPodder without it.