### PR TITLE
allow extensions to add tabs to preferences and channel settings dialogs

### DIFF
--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -630,3 +630,34 @@ class ExtensionManager(object):
         It is called after on_application_started.
         """
         pass
+
+    @call_extensions
+    def on_preferences(self):
+        """Called when the preferences dialog is opened
+
+        You can add additional tabs to the preferences dialog here. You have to
+        return a list of tuples, where the first item is a label and the second
+        item is a callable with no parameters and returns a Gtk widget.
+
+        Example return value:
+
+        [('Tab name', lambda: ...)]
+        """
+        pass
+
+    @call_extensions
+    def on_channel_settings(self, channel):
+        """Called when a channel settings dialog is opened
+
+        You can add additional tabs to the channel settings dialog here. You
+        have to return a list of tuples, where the first item is a label and the
+        second item is a callable that will get the channel as its first and
+        only parameter and returns a Gtk widget.
+
+        Example return value:
+
+        [('Tab name', lambda channel: ...)]
+
+        @param channel: A gpodder.model.PodcastChannel instance
+        """
+        pass

--- a/src/gpodder/gtkui/desktop/channel.py
+++ b/src/gpodder/gtkui/desktop/channel.py
@@ -94,6 +94,13 @@ class gPodderChannel(BuilderWidget):
         self.imgCoverEventBox.connect('button-press-event',
                 self.on_cover_popup_menu)
 
+        gpodder.user_extensions.on_ui_object_available('channel-gtk', self)
+
+        result = gpodder.user_extensions.on_channel_settings(self.channel)
+        if result:
+            for label, callback in result:
+                self.notebookChannelEditor.append_page(callback(self.channel), Gtk.Label(label))
+
     def on_button_add_section_clicked(self, widget):
         text = self.show_text_edit_dialog(_('Add section'), _('New section:'),
             affirmative_text=Gtk.STOCK_ADD)

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -290,6 +290,13 @@ class gPodderPreferences(BuilderWidget):
 
         self._config.connect_gtk_window(self.main_window, 'preferences', True)
 
+        gpodder.user_extensions.on_ui_object_available('preferences-gtk', self)
+
+        result = gpodder.user_extensions.on_preferences()
+        if result:
+            for label, callback in result:
+                self.notebook.append_page(callback(), Gtk.Label(label))
+
     def _extensions_select_function(self, selection, model, path, path_currently_selected):
         return model.get_value(model.get_iter(path), self.C_SHOW_TOGGLE)
 


### PR DESCRIPTION
Needed by #701 for extensions to add additional channel settings. Adds two callbacks for extensions to add notebook tabs in preferences and channel settings dialogs. Also adds two on_ui_object_available signals ('preferences-gtk' and 'channel-gtk') for extensions to get raw access to the preferences and channel settings dialog windows.