### PR TITLE
fix incorrectly sorted imports shown by make lint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ select = W1, W2, W3, E11, E121, E122, E123, E124, E125, E127, E129, E13, E2, E3,
 max-line-length = 142
 
 [isort]
-known_third_party=dbus,gi,mutagen,cairo,requests,github3,jinja2,magic,youtube_dl
+known_third_party=dbus,gi,mutagen,cairo,requests,github3,jinja2,magic,youtube_dl,podcastparser,mygpoclient
 known_first_party=gpodder,soco

--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -28,6 +28,7 @@ from html.parser import HTMLParser
 from urllib.error import HTTPError
 
 import podcastparser
+
 from gpodder import util
 
 logger = logging.getLogger(__name__)

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -35,8 +35,9 @@ import shutil
 import string
 import time
 
-import gpodder
 import podcastparser
+
+import gpodder
 from gpodder import (coverart, escapist_videos, feedcore, registry, schema,
                      util, vimeo, youtube)
 

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -32,12 +32,13 @@ import os
 import sys
 import time
 
-import gpodder
 # Append gPodder's user agent to mygpoclient's user agent
 import mygpoclient
-from gpodder import minidb, util
 from mygpoclient import api, public
 from mygpoclient import util as mygpoutil
+
+import gpodder
+from gpodder import minidb, util
 
 _ = gpodder.gettext
 


### PR DESCRIPTION
Travis CI doesn't appear to fail for these but my local isort 4.2.5 with python 3.6 does.