### PR TITLE
show url when get_channel_desc() fails

### DIFF
--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -362,7 +362,7 @@ def get_channel_desc(url):
                 return _('No description available')
 
         except Exception:
-            logger.warning('Could not retrieve YouTube channel description.', exc_info=True)
+            logger.warning('Could not retrieve YouTube channel description for %s.' % url, exc_info=True)
 
 
 def parse_youtube_url(url):


### PR DESCRIPTION
Showing a (usually) cryptic youtube feed url isn't much but it is better than showing nothing.