### PR TITLE
Gtk UI: Force-resize icons in player list

### DIFF
--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -101,7 +101,7 @@ class UserApplication(object):
             (icon_name, extension) = os.path.splitext(os.path.basename(self.icon))
             theme = Gtk.IconTheme()
             if theme.has_icon(icon_name):
-                return theme.load_icon(icon_name, 24, 0)
+                return theme.load_icon(icon_name, 24, Gtk.IconLookupFlags.FORCE_SIZE)
 
     def is_mime(self, mimetype):
         return self.mime.find(mimetype + '/') != -1


### PR DESCRIPTION
Ran into this issue on Ubuntu with the package `milkytracker` installed. The `.desktop` file contains `MimeType=audio/x-xm` (this is why it shows up in the list of players -- starts with `audio/`), and the only icon it installs is a 128x128 icon. This messes up the layout (even when the item is not selected).

Ideally we'd somehow blacklist items there or restrict items a little more (e.g. I also see Mp3splt-gtk, TiMidity++ and HandBrake in there, apps which probably nobody is going to use as "player" for podcast downloads), but not sure how to do that without blacklisting those items manually or potentially excluding valid choices.

![Screenshot from 2020-04-27 18-23-46](https://user-images.githubusercontent.com/135241/80396144-83814780-88b4-11ea-9ced-17ccab12f28f.png)
