### PR TITLE
Gtk UI: Add support for GtkHeaderBar / GNOME3 CSDs

### DIFF
--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -218,6 +218,7 @@
                           <object class="GtkGrid" id="vbox42">
                             <property name="visible">True</property>
                             <property name="orientation">vertical</property>
+                            <property name="hexpand">True</property>
                             <child>
                               <object class="GtkButton" id="btnUpdateFeeds">
                                 <property name="label" translatable="yes">Check for new episodes</property>

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -134,12 +134,17 @@ class gPodderApplication(Gtk.Application):
             # when the last one is closed the application shuts down
             self.window = gPodder(self, self.bus_name, core.Core(UIConfig, model_class=Model), self.options)
 
+            # If $XDG_CURRENT_DESKTOP is set then it contains a colon-separated list of strings.
+            # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
+            # See https://askubuntu.com/a/227669 for a list of values in different environments
+            xdg_current_desktops = os.environ.get('XDG_CURRENT_DESKTOP', '').split(':')
+
             if gpodder.ui.osx:
                 from . import macosx
 
                 # Handle "subscribe to podcast" events from firefox
                 macosx.register_handlers(self.window)
-            else:
+            elif 'GNOME' in xdg_current_desktops:
                 # Use GtkHeaderBar for client-side decorations on recent GNOME 3 versions
                 self.header_bar_menu_button = Gtk.Button.new_from_icon_name('open-menu-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
                 self.header_bar_menu_button.set_action_name('app.menu')
@@ -159,6 +164,7 @@ class gPodderApplication(Gtk.Application):
 
                 # Tweaks to the UI since we moved the refresh button into the header bar
                 self.window.btnUpdateFeeds.hide()
+                self.window.default_btn_update_feeds_visible = False
                 self.window.vboxChannelNavigator.set_row_spacing(0)
 
                 self.window.main_window.set_titlebar(self.header_bar)

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -110,8 +110,11 @@ class gPodderApplication(Gtk.Application):
         # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
         # See https://askubuntu.com/a/227669 for a list of values in different environments
         xdg_current_desktops = os.environ.get('XDG_CURRENT_DESKTOP', '').split(':')
+        # See https://developer.gnome.org/gtk3/stable/gtk-running.html
+        # GTK_CSD=0 is used to disable client side decorations
+        csd_disabled = os.environ.get('GTK_CSD') == '0'
 
-        self.want_headerbar = ('GNOME' in xdg_current_desktops) and not gpodder.ui.osx
+        self.want_headerbar = ('GNOME' in xdg_current_desktops) and not gpodder.ui.osx and not csd_disabled
 
         self.app_menu = builder.get_object('app-menu')
         if self.want_headerbar:

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -106,8 +106,16 @@ class gPodderApplication(Gtk.Application):
         self.menu_view_columns = builder.get_object('menuViewColumns')
         self.set_menubar(menubar)
 
+        # If $XDG_CURRENT_DESKTOP is set then it contains a colon-separated list of strings.
+        # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
+        # See https://askubuntu.com/a/227669 for a list of values in different environments
+        xdg_current_desktops = os.environ.get('XDG_CURRENT_DESKTOP', '').split(':')
+
+        self.want_headerbar = ('GNOME' in xdg_current_desktops) and not gpodder.ui.osx
+
         self.app_menu = builder.get_object('app-menu')
-        self.set_app_menu(self.app_menu)
+        if not self.want_headerbar:
+            self.set_app_menu(self.app_menu)
 
         Gtk.Window.set_default_icon_name('gpodder')
 
@@ -134,17 +142,13 @@ class gPodderApplication(Gtk.Application):
             # when the last one is closed the application shuts down
             self.window = gPodder(self, self.bus_name, core.Core(UIConfig, model_class=Model), self.options)
 
-            # If $XDG_CURRENT_DESKTOP is set then it contains a colon-separated list of strings.
-            # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
-            # See https://askubuntu.com/a/227669 for a list of values in different environments
-            xdg_current_desktops = os.environ.get('XDG_CURRENT_DESKTOP', '').split(':')
-
             if gpodder.ui.osx:
                 from . import macosx
 
                 # Handle "subscribe to podcast" events from firefox
                 macosx.register_handlers(self.window)
-            elif 'GNOME' in xdg_current_desktops:
+
+            if self.want_headerbar:
                 # Use GtkHeaderBar for client-side decorations on recent GNOME 3 versions
                 self.header_bar_menu_button = Gtk.Button.new_from_icon_name('open-menu-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
                 self.header_bar_menu_button.set_action_name('app.menu')

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -114,7 +114,17 @@ class gPodderApplication(Gtk.Application):
         self.want_headerbar = ('GNOME' in xdg_current_desktops) and not gpodder.ui.osx
 
         self.app_menu = builder.get_object('app-menu')
-        if not self.want_headerbar:
+        if self.want_headerbar:
+            # Use GtkHeaderBar for client-side decorations on recent GNOME 3 versions
+            self.header_bar_menu_button = Gtk.Button.new_from_icon_name('open-menu-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
+            self.header_bar_menu_button.set_action_name('app.menu')
+
+            self.header_bar_refresh_button = Gtk.Button.new_from_icon_name('view-refresh-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
+            self.header_bar_refresh_button.set_action_name('win.updateChannel')
+
+            self.menu_popover = Gtk.Popover.new_from_model(self.header_bar_menu_button, self.app_menu)
+            self.menu_popover.set_position(Gtk.PositionType.BOTTOM)
+        else:
             self.set_app_menu(self.app_menu)
 
         Gtk.Window.set_default_icon_name('gpodder')
@@ -147,31 +157,6 @@ class gPodderApplication(Gtk.Application):
 
                 # Handle "subscribe to podcast" events from firefox
                 macosx.register_handlers(self.window)
-
-            if self.want_headerbar:
-                # Use GtkHeaderBar for client-side decorations on recent GNOME 3 versions
-                self.header_bar_menu_button = Gtk.Button.new_from_icon_name('open-menu-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
-                self.header_bar_menu_button.set_action_name('app.menu')
-
-                self.header_bar_refresh_button = Gtk.Button.new_from_icon_name('view-refresh-symbolic', Gtk.IconSize.SMALL_TOOLBAR)
-                self.header_bar_refresh_button.set_action_name('win.updateChannel')
-
-                self.header_bar = Gtk.HeaderBar()
-                self.header_bar.pack_end(self.header_bar_menu_button)
-                self.header_bar.pack_start(self.header_bar_refresh_button)
-                self.header_bar.set_show_close_button(True)
-                self.header_bar.set_title(self.window.main_window.get_title())
-                self.header_bar.show_all()
-
-                self.menu_popover = Gtk.Popover.new_from_model(self.header_bar_menu_button, self.app_menu)
-                self.menu_popover.set_position(Gtk.PositionType.BOTTOM)
-
-                # Tweaks to the UI since we moved the refresh button into the header bar
-                self.window.btnUpdateFeeds.hide()
-                self.window.default_btn_update_feeds_visible = False
-                self.window.vboxChannelNavigator.set_row_spacing(0)
-
-                self.window.main_window.set_titlebar(self.header_bar)
 
         self.window.gPodder.present()
 

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -197,8 +197,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         util.run_in_background(self.user_apps_reader.read)
 
         # Now, update the feed cache, when everything's in place
-        if getattr(self, 'last_btn_update_feeds_visible', False):
-            self.btnUpdateFeeds.show()
+        self.default_btn_update_feeds_visible = True
+        self.btnUpdateFeeds.show()
         self.feed_cache_update_cancelled = False
         self.update_podcast_list_model()
 
@@ -2524,7 +2524,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Make sure that the buttons for updating feeds
         # appear - this should happen after a feed update
         self.hboxUpdateFeeds.hide()
-        if getattr(self, 'last_btn_update_feeds_visible', False):
+        if self.default_btn_update_feeds_visible:
             self.btnUpdateFeeds.show()
         self.update_action.set_enabled(True)
         self.update_channel_action.set_enabled(True)
@@ -2559,7 +2559,6 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.btnCancelFeedUpdate.set_sensitive(True)
         self.btnCancelFeedUpdate.set_image(Gtk.Image.new_from_icon_name('process-stop', Gtk.IconSize.BUTTON))
         self.hboxUpdateFeeds.show_all()
-        self.last_btn_update_feeds_visible = self.btnUpdateFeeds.get_visible()
         self.btnUpdateFeeds.hide()
 
         count = len(channels)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -197,7 +197,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         util.run_in_background(self.user_apps_reader.read)
 
         # Now, update the feed cache, when everything's in place
-        self.btnUpdateFeeds.show()
+        if getattr(self, 'last_btn_update_feeds_visible', False):
+            self.btnUpdateFeeds.show()
         self.feed_cache_update_cancelled = False
         self.update_podcast_list_model()
 
@@ -2523,7 +2524,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Make sure that the buttons for updating feeds
         # appear - this should happen after a feed update
         self.hboxUpdateFeeds.hide()
-        self.btnUpdateFeeds.show()
+        if getattr(self, 'last_btn_update_feeds_visible', False):
+            self.btnUpdateFeeds.show()
         self.update_action.set_enabled(True)
         self.update_channel_action.set_enabled(True)
 
@@ -2557,6 +2559,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.btnCancelFeedUpdate.set_sensitive(True)
         self.btnCancelFeedUpdate.set_image(Gtk.Image.new_from_icon_name('process-stop', Gtk.IconSize.BUTTON))
         self.hboxUpdateFeeds.show_all()
+        self.last_btn_update_feeds_visible = self.btnUpdateFeeds.get_visible()
         self.btnUpdateFeeds.hide()
 
         count = len(channels)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -89,6 +89,18 @@ class gPodder(BuilderWidget, dbus.service.Object):
         BuilderWidget.__init__(self, None, _builder_expose={'app': app})
 
     def new(self):
+        if self.application.want_headerbar:
+            self.header_bar = Gtk.HeaderBar()
+            self.header_bar.pack_end(self.application.header_bar_menu_button)
+            self.header_bar.pack_start(self.application.header_bar_refresh_button)
+            self.header_bar.set_show_close_button(True)
+            self.header_bar.show_all()
+
+            # Tweaks to the UI since we moved the refresh button into the header bar
+            self.vboxChannelNavigator.set_row_spacing(0)
+
+            self.main_window.set_titlebar(self.header_bar)
+
         gpodder.user_extensions.on_ui_object_available('gpodder-gtk', self)
         self.toolbar.set_property('visible', self.config.show_toolbar)
 
@@ -197,8 +209,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         util.run_in_background(self.user_apps_reader.read)
 
         # Now, update the feed cache, when everything's in place
-        self.default_btn_update_feeds_visible = True
-        self.btnUpdateFeeds.show()
+        if not self.application.want_headerbar:
+            self.btnUpdateFeeds.show()
         self.feed_cache_update_cancelled = False
         self.update_podcast_list_model()
 
@@ -2524,7 +2536,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Make sure that the buttons for updating feeds
         # appear - this should happen after a feed update
         self.hboxUpdateFeeds.hide()
-        if self.default_btn_update_feeds_visible:
+        if not self.application.want_headerbar:
             self.btnUpdateFeeds.show()
         self.update_action.set_enabled(True)
         self.update_channel_action.set_enabled(True)


### PR DESCRIPTION
It seems like on recent GNOME 3 versions, there's no more app menu (at least on the Ubuntu 19.10 I have here), it has been replaced with GtkHeaderBar + client-side decorations.

This creates a header bar and adds a refresh and menu button, similar to what other GNOME3 apps do.