### PR TITLE
don't clear custom youtube formats

### DIFF
--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -112,37 +112,24 @@ class YouTubeVideoFormatListModel(Gtk.ListStore):
     def __init__(self, config):
         Gtk.ListStore.__init__(self, str, int)
         self._config = config
-        self.custom_fmt_ids = self._config.youtube.preferred_fmt_ids
 
         if self._config.youtube.preferred_fmt_ids:
             caption = _('Custom (%(format_ids)s)') % {
-                'format_ids': ', '.join(str(x) for x in self.custom_fmt_ids),
+                'format_ids': ', '.join(str(x) for x in self._config.youtube.preferred_fmt_ids),
             }
-            self.append((caption, -1))
+            self.append((caption, 0))
 
         for id, (fmt_id, path, description) in youtube.formats:
             self.append((description, id))
 
     def get_index(self):
-        if self._config.youtube.preferred_fmt_ids:
-            return 0
-
         for index, row in enumerate(self):
             if self._config.youtube.preferred_fmt_id == row[self.C_ID]:
                 return index
         return 0
 
     def set_index(self, index):
-        value = self[index][self.C_ID]
-        if value > 0:
-            self._config.youtube.preferred_fmt_id = value
-            # If we set a value, we need to unset the custom one, so that
-            # the single value (preferred_fmt_id) gets used instead
-            self._config.youtube.preferred_fmt_ids = []
-        else:
-            # If the user selects the -1 value, it's our custom one, and
-            # we need to restore the value for preferred_fmt_ids
-            self._config.youtube.preferred_fmt_ids = self.custom_fmt_ids
+        self._config.youtube.preferred_fmt_id = self[index][self.C_ID]
 
 
 class VimeoVideoFormatListModel(Gtk.ListStore):

--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -138,14 +138,13 @@ class YouTubeError(Exception):
 
 
 def get_fmt_ids(youtube_config):
-    fmt_ids = youtube_config.preferred_fmt_ids
-    if not fmt_ids:
-        format = formats_dict.get(youtube_config.preferred_fmt_id)
-        if format is None:
-            fmt_ids = []
-        else:
-            fmt_ids, path, description = format
+    if youtube_config.preferred_fmt_id == 0:
+        return (youtube_config.preferred_fmt_ids if youtube_config.preferred_fmt_ids else [])
 
+    format = formats_dict.get(youtube_config.preferred_fmt_id)
+    if format is None:
+        return []
+    fmt_ids, path, description = format
     return fmt_ids
 
 


### PR DESCRIPTION
When a youtube format is selected from video preferences, it temporarily saves custom IDs. The custom IDs are lost if gpodder is restarted and might also be lost when preferences is closed. This patch uses a permanent ID value of zero to represent custom IDs and prevents losing them when testing. It might also be useful if someone wants to select a format that isn't in their custom IDs to download a single video, without worrying about losing the custom IDs.
