### PR TITLE
add quiet flag to eliminate warnings from console

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -25,7 +25,7 @@
 
 
 """
-  Usage: gpo [--verbose|-v] [COMMAND] [params...]
+  Usage: gpo [--verbose|-v|--quiet|-q] [COMMAND] [params...]
 
   - Subscription management -
 
@@ -111,6 +111,12 @@ for flag in ('-v', '--verbose'):
         sys.argv.remove(flag)
         verbose = True
         break
+quiet = False
+for flag in ('-q', '--quiet'):
+    if flag in sys.argv:
+        sys.argv.remove(flag)
+        quiet = True
+        break
 
 gpodder_script = sys.argv[0]
 gpodder_script = os.path.realpath(gpodder_script)
@@ -126,7 +132,11 @@ if os.path.exists(os.path.join(src_dir, 'gpodder', '__init__.py')):
     sys.path.insert(0, src_dir)
 
 import gpodder  # isort:skip
-from gpodder import common, core, download, feedcore, log, model, my, opml, sync, util, youtube  # isort:skip
+
+from gpodder import log  # isort:skip
+log.setup(verbose, quiet)
+
+from gpodder import common, core, download, feedcore, model, my, opml, sync, util, youtube  # isort:skip
 from gpodder.config import config_value_to_string  # isort:skip
 from gpodder.syncui import gPodderSyncUI  # isort:skip
 
@@ -139,13 +149,9 @@ gpodder.prefix = prefix
 # This is the command-line UI variant
 gpodder.ui.cli = True
 
-gpodder.verbose = verbose
-
 have_ansi = sys.stdout.isatty() and not gpodder.ui.win32
 interactive_console = sys.stdin.isatty() and sys.stdout.isatty()
 is_single_command = False
-
-log.setup(verbose)
 
 
 def noop(*args, **kwargs):

--- a/bin/gpodder
+++ b/bin/gpodder
@@ -99,6 +99,10 @@ def main():
                       action="store_true", dest="verbose", default=False,
                       help=_("print logging output on the console"))
 
+    parser.add_option("-q", "--quiet",
+                      action="store_true", dest="quiet", default=False,
+                      help=_("reduce warnings on the console"))
+
     parser.add_option('-s', '--subscribe', dest='subscribe', metavar='URL',
                       help=_('subscribe to the feed at URL'))
 
@@ -118,7 +122,7 @@ def main():
                         and xdg_current_desktop in ('unity', 'unity:unity7:ubuntu'))
 
     from gpodder import log
-    log.setup(options.verbose)
+    log.setup(options.verbose, options.quiet)
 
     if have_dbus:
         # Try to find an already-running instance of gPodder

--- a/share/man/man1/gpo.1
+++ b/share/man/man1/gpo.1
@@ -3,7 +3,7 @@
 gpo \- Text mode interface of gPodder
 .SH SYNOPSIS
 .B gpo
-[\fI--verbose|-v\fR]
+[\fI--verbose|-v|--quiet|-q\fR]
 [\fICOMMAND\fR] [\fIparams...\fR]
 
 .SH DESCRIPTION

--- a/share/man/man1/gpodder.1
+++ b/share/man/man1/gpodder.1
@@ -21,5 +21,8 @@ show this help message and exit
 \fB\-v\fR, \fB\-\-verbose\fR
 print logging output on the console
 .TP
+\fB\-q\fR, \fB\-\-quiet\fR
+reduce warnings on the console
+.TP
 \fB\-s\fR URL, \fB\-\-subscribe\fR=\fI\,URL\/\fR
 subscribe to the feed at URL

--- a/src/gpodder/__init__.py
+++ b/src/gpodder/__init__.py
@@ -84,6 +84,8 @@ del sqlite3
 
 # Is gpodder running in verbose mode?
 verbose = False
+# Is gpodder running in quiet mode?
+quiet = False
 
 
 # The User-Agent string for downloads

--- a/src/gpodder/log.py
+++ b/src/gpodder/log.py
@@ -34,14 +34,15 @@ import gpodder
 logger = logging.getLogger(__name__)
 
 
-def setup(verbose=True):
+def setup(verbose=True, quiet=False):
     # mark verbose mode
     gpodder.verbose = verbose
+    gpodder.quiet = quiet and not verbose
 
     # Configure basic stdout logging
     STDOUT_FMT = '%(created)f [%(name)s] %(levelname)s: %(message)s'
     logging.basicConfig(format=STDOUT_FMT,
-            level=logging.DEBUG if verbose else logging.WARNING)
+            level=logging.DEBUG if verbose else logging.ERROR if quiet else logging.WARNING)
 
     # Replace except hook with a custom one that logs it as an error
     original_excepthook = sys.excepthook


### PR DESCRIPTION
Adds a quiet flag (-q or --quiet) to gpo and gpodder to eliminate all warnings on console. Errors are still be displayed, and verbose mode overrides quiet mode. This closes #800.