### PR TITLE
better indicate optional imports (gpod and eyed3.mp3)

### DIFF
--- a/src/gpodder/syncui.py
+++ b/src/gpodder/syncui.py
@@ -88,7 +88,7 @@ class gPodderSyncUI(object):
 
     def _show_message_cannot_open(self):
         title = _('Cannot open device')
-        message = _('Please check the settings in the preferences dialog.')
+        message = _('Please check logs and the settings in the preferences dialog.')
         self.notification(message, title, important=True)
 
     def on_synchronize_episodes(self, channels, episodes=None, force_played=True, done_callback=None):


### PR DESCRIPTION
Move optional import errors to time of use to avoid spamming all users with sync-only warnings. And better indicate why the modules are needed.

This fixes #799 and partially fixes #756 because it doesn't fix the 'Flush requested, but sync disabled.' warning.

I have this patch installed in my gpodder, but **I do not own any mp3/ipod devices to test this.**