### PR TITLE
shownotes: don't use blue hyperlinks on dark themes

### DIFF
--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -459,7 +459,7 @@ def investigate_widget_colors(type_classes_and_widgets):
             # Create an empty style context
             style_ctx = Gtk.StyleContext()
             # Create an empty widget path
-            widget_path =  Gtk.WidgetPath()
+            widget_path = Gtk.WidgetPath()
             # Specify the widget class type you want to get colors from
             for t, c, r in type_and_class:
                 widget_path.append_type(t)

--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -405,3 +405,77 @@ def get_foreground_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
         color = style_context.get_color(state)
         p = p.get_parent()
     return color
+
+
+def investigate_widget_colors(type_classes_and_widgets):
+    """
+    investigate using Gtk.StyleContext to get widget style properties
+    I tried to compare gettings values from static and live widgets.
+    To sum up, better use the live widget, because you'll get the correct path, classes, regions automatically.
+    See "CSS Nodes" in widget documentation for classes and sub-nodes (=regions).
+    WidgetPath and Region are replaced by CSSNodes in gtk4.
+    Not sure it's legitimate usage, though: I got different results from one run to another.
+    Run `GTK_DEBUG=interactive ./bin/gpodder` for gtk widget inspection
+    """
+    def investigate_stylecontext(style_ctx, label):
+        style_ctx.save()
+        for statename, state in [
+                ('normal', Gtk.StateFlags.NORMAL),
+                ('active', Gtk.StateFlags.ACTIVE),
+                ('link', Gtk.StateFlags.LINK),
+                ('visited', Gtk.StateFlags.VISITED)]:
+            f.write("<dt>%s %s</dt><dd>\n" % (label, statename))
+            colors = {
+                'get_color': style_ctx.get_color(state),
+                'get_background_color': style_ctx.get_background_color(state),
+                'color': style_ctx.get_property('color', state),
+                'background-color': style_ctx.get_property('background-color', state),
+                'outline-color': style_ctx.get_property('outline-color', state),
+            }
+            f.write("<p>PREVIEW: <span style='background-color: %s; color: %s'>get_color + get_background_color</span>"
+                  % (colors['get_background_color'].to_string(),
+                     colors['get_color'].to_string()))
+            f.write("<span style='background-color: %s; color: %s; border solid 2px %s;'>color + background-color properties</span></p>\n"
+                  % (colors['background-color'].to_string(),
+                     colors['color'].to_string(),
+                     colors['outline-color'].to_string()))
+            f.write("<p>VALUES: ")
+            for p, v in colors.items():
+                f.write("%s=<span style='background-color: %s;'>%s</span>" % (p, v.to_string(), v.to_string()))
+            f.write("</p></dd>\n")
+        style_ctx.restore()
+
+    with open('/tmp/colors.html', 'w') as f:
+        f.write("""<html>
+                  <style type='text/css'>
+                  body {color: red; background: yellow;}
+                  span { display: inline-block; margin-right: 1ch; }
+                  dd { margin-bottom: 1em; }
+                  td { vertical-align: top; }
+                  </style>
+                  <table>""")
+        for type_and_class, w in type_classes_and_widgets:
+            f.write("<tr><td><dl>\n")
+            # Create an empty style context
+            style_ctx = Gtk.StyleContext()
+            # Create an empty widget path
+            widget_path =  Gtk.WidgetPath()
+            # Specify the widget class type you want to get colors from
+            for t, c, r in type_and_class:
+                widget_path.append_type(t)
+                if c:
+                    widget_path.iter_add_class(widget_path.length() - 1, c)
+                if r:
+                    widget_path.iter_add_region(widget_path.length() - 1, r, 0)
+            style_ctx.set_path(widget_path)
+
+            investigate_stylecontext(
+                style_ctx,
+                'STATIC {}'.format(' '.join('{}.{}({})'.format(t.__name__, c, r) for t, c, r in type_and_class)))
+
+            f.write("</dl></td><td><dl>\n")
+
+            investigate_stylecontext(w.get_style_context(), 'LIVE {}'.format(type(w).__name__))
+
+        f.write("</dl></td></tr>\n")
+        f.write("</table></html>\n")

--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -384,7 +384,7 @@ def get_background_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
     color = Gdk.RGBA(0, 0, 0, 0)
     while p is not None and color.alpha == 0:
         style_context = p.get_style_context()
-        color = style_context.get_background_color(0)
+        color = style_context.get_background_color(state)
         p = p.get_parent()
     return color
 
@@ -399,9 +399,9 @@ def get_foreground_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
     p = widget
     color = Gdk.RGBA(0, 0, 0, 0)
     style_context = widget.get_style_context()
-    foreground = style_context.get_color(0)
+    foreground = style_context.get_color(state)
     while p is not None and color.alpha == 0:
         style_context = p.get_style_context()
-        color = style_context.get_color(0)
+        color = style_context.get_color(state)
         p = p.get_parent()
     return color

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -62,8 +62,8 @@ class gPodderShownotes:
         self.text_view.set_border_width(10)
         self.text_view.set_editable(False)
         self.text_buffer = Gtk.TextBuffer()
-        self.text_buffer.create_tag('heading', scale=1.6, weight=Pango.Weight.BOLD)
-        self.text_buffer.create_tag('subheading', scale=1.3)
+        self.text_buffer.create_tag('heading', scale=1.2, weight=Pango.Weight.BOLD)
+        self.text_buffer.create_tag('subheading', scale=1.0)
         self.text_view.set_buffer(self.text_buffer)
 
         self.status = Gtk.Label.new()

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -55,6 +55,8 @@ class gPodderShownotes:
     def __init__(self, shownotes_pane):
         self.shownotes_pane = shownotes_pane
 
+        self.dark_theme = Gtk.Settings.get_default().get_property('gtk-application-prefer-dark-theme')
+
         self.text_view = Gtk.TextView()
         self.text_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         self.text_view.set_border_width(10)
@@ -137,7 +139,9 @@ class gPodderShownotesText(gPodderShownotes):
         self.text_view.set_property('expand', True)
         self.text_view.connect('button-release-event', self.on_button_release)
         self.text_view.connect('key-press-event', self.on_key_press)
-        self.text_buffer.create_tag('hyperlink', foreground="#0000FF", underline=Pango.Underline.SINGLE)
+        self.text_buffer.create_tag('hyperlink',
+            foreground=None if self.dark_theme else "#0000FF",
+            underline=Pango.Underline.SINGLE)
         self.text_view.connect('motion-notify-event', self.on_hover_hyperlink)
         self.overlay = Gtk.Overlay()
         self.overlay.add(self.scrolled_window)
@@ -380,8 +384,13 @@ class gPodderShownotesHTML(gPodderShownotes):
         if self.stylesheet is None:
             foreground = get_foreground_color()
             background = get_background_color(Gtk.StateFlags.ACTIVE)
+            style = ''
             if background is not None:
-                style = "html { background: %s; color: %s;}" % \
+                style += "html { background: %s; color: %s;}" % \
                             (background.to_string(), foreground.to_string())
+            if self.dark_theme:
+                style += "a { color: %s;}" % \
+                            (foreground.to_string() if foreground else '#000000')
+            if style:
                 self.stylesheet = WebKit2.UserStyleSheet(style, 0, 1, None, None)
         return self.stylesheet

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -56,8 +56,6 @@ class gPodderShownotes:
     def __init__(self, shownotes_pane):
         self.shownotes_pane = shownotes_pane
 
-        self.dark_theme = Gtk.Settings.get_default().get_property('gtk-application-prefer-dark-theme')
-
         self.text_view = Gtk.TextView()
         self.text_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         self.text_view.set_border_width(10)

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -24,6 +24,7 @@ import gpodder
 from gpodder import util
 from gpodder.gtkui.draw import (draw_text_box_centered, get_background_color,
                                 get_foreground_color)
+
 # from gpodder.gtkui.draw import investigate_widget_colors
 
 import gi  # isort:skip
@@ -408,6 +409,7 @@ class gPodderShownotesHTML(gPodderShownotes):
             style = ("html { background: %s; color: %s;}"
                      " a { color: %s; }"
                      " a:visited { color: %s; }") % \
-                     (self.background_color.to_string(), self.foreground_color.to_string(), self.link_color.to_string(), self.visited_color.to_string())
+                     (self.background_color.to_string(), self.foreground_color.to_string(),
+                      self.link_color.to_string(), self.visited_color.to_string())
             self.stylesheet = WebKit2.UserStyleSheet(style, 0, 1, None, None)
         return self.stylesheet


### PR DESCRIPTION
As seen when setting to the dark variant of themes, blue hyperlinks on black don't provide enough contrast.
This fixes it by checking the GSettings property and setting the color accordingly. It doesn't detect a theme with a dark background but not listed as a dark variant, but it was also the case before.

To check, add this line to your `~/.config/gtk-3.0/settings.ini`:
`gtk-application-prefer-dark-theme = true`
