### PR TITLE
add podcast and section EQL variables for use with SsRr functions

### DIFF
--- a/src/gpodder/query.py
+++ b/src/gpodder/query.py
@@ -117,6 +117,10 @@ class Matcher(object):
             return episode.total_time / 60
         elif k in ('remaining', 'rem'):
             return (episode.total_time - episode.current_position) / 60
+        elif k == 'podcast':
+            return episode.channel.title
+        elif k == 'section':
+            return episode.channel.section
 
         raise KeyError(k)
 


### PR DESCRIPTION
(s('...', podcast))
(s('...', section))

Allows searching based on podcast title or section name. Partially implements #818.