### PR TITLE
Fix #796 MKV Files Not Properly Renamed

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -95,9 +95,6 @@ class YoutubeCustomDownload(download.CustomDownload):
         # youtube-dl doesn't return a content-type but an extension
         if 'ext' in res:
             dot_ext = '.{}'.format(res['ext'])
-            ext_filetype = mimetype_from_extension(dot_ext)
-            if ext_filetype:
-                headers['content-type'] = ext_filetype
             # See #673 when merging multiple formats, the extension is appended to the tempname
             # by YoutubeDL resulting in empty .partial file + .partial.mp4 exists
             # and #796 .mkv is chosen by ytdl sometimes
@@ -111,7 +108,11 @@ class YoutubeCustomDownload(download.CustomDownload):
                                      os.path.basename(tempname))
                         os.remove(tempname)
                         os.rename(tempname_with_ext, tempname)
+                        dot_ext = try_ext
                         break
+            ext_filetype = mimetype_from_extension(dot_ext)
+            if ext_filetype:
+                headers['content-type'] = ext_filetype
         return headers, res.get('url', self._url)
 
     def _my_hook(self, d):

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -100,15 +100,18 @@ class YoutubeCustomDownload(download.CustomDownload):
                 headers['content-type'] = ext_filetype
             # See #673 when merging multiple formats, the extension is appended to the tempname
             # by YoutubeDL resulting in empty .partial file + .partial.mp4 exists
+            # and #796 .mkv is chosen by ytdl sometimes
             tempstat = os.stat(tempname)
             if not tempstat.st_size:
-                tempname_with_ext = tempname + dot_ext
-                if os.path.isfile(tempname_with_ext):
-                    logger.debug('Youtubedl downloaded to %s instead of %s, moving',
-                                 os.path.basename(tempname),
-                                 os.path.basename(tempname_with_ext))
-                    os.remove(tempname)
-                    os.rename(tempname_with_ext, tempname)
+                for try_ext in (dot_ext, ".mp4", ".m4a", ".webm", ".mkv"):
+                    tempname_with_ext = tempname + try_ext
+                    if os.path.isfile(tempname_with_ext):
+                        logger.debug('Youtubedl downloaded to "%s" instead of "%s", moving',
+                                     os.path.basename(tempname_with_ext),
+                                     os.path.basename(tempname))
+                        os.remove(tempname)
+                        os.rename(tempname_with_ext, tempname)
+                        break
         return headers, res.get('url', self._url)
 
     def _my_hook(self, d):

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -869,7 +869,8 @@ class DownloadTask(object):
                 logger.info('Updating mime type: %s => %s', old_mimetype, new_mimetype)
                 old_extension = self.__episode.extension()
                 self.__episode.mime_type = new_mimetype
-                new_extension = self.__episode.extension()
+                # don't call local_filename because we'll get the old download name
+                new_extension = self.__episode.extension(may_call_local_filename=False)
 
                 # If the desired filename extension changed due to the new
                 # mimetype, we force an update of the local filename to fix the

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -243,10 +243,11 @@ class PodcastEpisode(PodcastModelObject):
     # In theory, Linux can have 255 bytes (not characters!) in a filename, but
     # filesystems like eCryptFS store metadata in the filename, making the
     # effective number of characters less than that. eCryptFS recommends
-    # 140 chars, we use 120 here (140 - len(extension) - len(".partial")).
+    # 140 chars, we use 120 here (140 - len(extension) - len(".partial.webm"))
+    # (youtube-dl appends an extension after .partial, ".webm" is the longest).
     # References: gPodder bug 1898, http://unix.stackexchange.com/a/32834
     MAX_FILENAME_LENGTH = 120  # without extension
-    MAX_FILENAME_WITH_EXT_LENGTH = 140 - len(".partial")  # with extension
+    MAX_FILENAME_WITH_EXT_LENGTH = 140 - len(".partial.webm")  # with extension
 
     __slots__ = schema.EpisodeColumns
 


### PR DESCRIPTION
Try known youtube-dl extensions in case it changed it.
eg. when downloading mp4 video + opus audio it need to combine it in an mkv container.