### PR TITLE
Fixed some typos and added some translations

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -348,7 +348,7 @@ msgstr ""
 #: src/gpodder/gtkui/main.py:3033
 #: src/gpodder/gtkui/desktop/episodeselector.py:127
 msgid "Episode"
-msgstr "Espisódio"
+msgstr "Episódio"
 
 #: src/gpodder/syncui.py:275
 msgid "Episodes have been deleted on device"
@@ -484,7 +484,7 @@ msgstr[1] "%(count)d arquivos parciais"
 
 #: src/gpodder/gtkui/main.py:378
 msgid "Resume all"
-msgstr "Resumir tudo"
+msgstr "Continuar todos"
 
 #: src/gpodder/gtkui/main.py:390
 msgid "Incomplete downloads from a previous session were found."
@@ -936,7 +936,7 @@ msgstr ""
 
 #: src/gpodder/gtkui/main.py:2759 bin/gpo:837
 msgid "Episodes are locked"
-msgstr "Os espisódos estão protegidos"
+msgstr "Os episódos estão protegidos"
 
 #: src/gpodder/gtkui/main.py:2761 bin/gpo:839
 msgid ""
@@ -1621,7 +1621,7 @@ msgstr "Conversão falhou"
 
 #: share/gpodder/extensions/command_on_download.py:18
 msgid "Run a Command on Download"
-msgstr ""
+msgstr "Rodar um comando no Download"
 
 #: share/gpodder/extensions/command_on_download.py:19
 msgid "Run a predefined external command upon download completion."
@@ -1642,7 +1642,7 @@ msgstr ""
 
 #: share/gpodder/extensions/concatenate_videos.py:38
 msgid "Save video"
-msgstr ""
+msgstr "Salvar vídeo"
 
 #: share/gpodder/extensions/concatenate_videos.py:67
 #, fuzzy
@@ -1688,7 +1688,7 @@ msgstr "Enfileirar em"
 #: share/gpodder/extensions/enqueue_in_mediaplayer.py:97
 #, fuzzy
 msgid "Resume in"
-msgstr "Resumir tudo"
+msgstr "Continuar tudo"
 
 #: share/gpodder/extensions/episode_website_context_menu.py:15
 msgid "\"Open website\" episode and podcast context menu"
@@ -1720,7 +1720,7 @@ msgstr ""
 
 #: share/gpodder/extensions/filter.py:53
 msgid "Regular Expression"
-msgstr ""
+msgstr "Expressão Regular"
 
 #: share/gpodder/extensions/filter.py:56
 msgid "Ignore Case"
@@ -1790,11 +1790,11 @@ msgstr "Arquivo normalizado"
 
 #: share/gpodder/extensions/notification-win32.py:55
 msgid "Notification Bubbles for Windows"
-msgstr ""
+msgstr "Janelas de notificação para Windows"
 
 #: share/gpodder/extensions/notification-win32.py:56
 msgid "Display notification bubbles for different events."
-msgstr ""
+msgstr "Mostra janelas de notificações para vários eventos."
 
 #: share/gpodder/extensions/rename_download.py:17
 msgid "Rename episodes after download"
@@ -1855,7 +1855,7 @@ msgstr "Mostrar progresso do download no ícone do Lançador do Unity."
 
 #: share/gpodder/extensions/taskbar_progress.py:36
 msgid "Displays the progress on the Windows taskbar."
-msgstr ""
+msgstr "Mostra o progresso na barra de tarefas do Windows."
 
 #: share/gpodder/extensions/ted_subtitles.py:17
 msgid "Subtitle Downloader for TED Talks"
@@ -1906,11 +1906,11 @@ msgstr "Conversão falhou"
 #: share/gpodder/extensions/video_converter.py:21
 #, fuzzy
 msgid "Transcode video files to avi/mp4/m4v"
-msgstr "Transcodificar arquivos .ogg para .mp3 usando ffmpeg"
+msgstr "Transcodificar arquivos de vídeos para avi/mp4/m4v"
 
 #: share/gpodder/extensions/youtube-dl.py:27
 msgid "Manage Youtube subscriptions using youtube-dl (pip install youtube_dl)"
-msgstr ""
+msgstr "Gerenciar inscrições do Youtube com o youtube-dl (pip install youtube_dl)"
 
 #: share/gpodder/extensions/youtube-dl.py:432
 #, fuzzy
@@ -2020,15 +2020,15 @@ msgstr ""
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:1
 #: share/gpodder/ui/gtk/gpodder.ui.h:3 share/gpodder/ui/gtk/menus.ui.h:1
 msgid "Preferences"
-msgstr "Preferencias"
+msgstr "Preferências"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:2
 msgid "Audio player:"
-msgstr "Player de Audio"
+msgstr "Player de Áudio:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:3
 msgid "Video player:"
-msgstr "Player de vídeo"
+msgstr "Player de vídeo:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:4
 msgid "\"All episodes\" in podcast list"
@@ -2054,7 +2054,7 @@ msgstr "Sincronizar inscrições e ações de episódios"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:12
 msgid "Server:"
-msgstr ""
+msgstr "Servidor:"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:15
 msgid "Replace list on server with local subscriptions"
@@ -2124,7 +2124,7 @@ msgstr "Lista de reprodução vazia"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:31
 msgid "Remove episodes deleted on device from gPodder"
-msgstr ""
+msgstr "Remove episódios deletados no dispositivo do gPodder"
 
 #: share/gpodder/ui/gtk/gpodderpreferences.ui.h:32
 msgid "Only sync unplayed episodes"
@@ -2160,7 +2160,7 @@ msgstr "KiB/s"
 
 #: share/gpodder/ui/gtk/gpodder.ui.h:10
 msgid "Limit downloads to"
-msgstr "Limite o download a"
+msgstr "Limite o(s) download(s) a"
 
 #: share/gpodder/ui/gtk/gpodderwelcome.ui.h:2
 msgid "<big>Welcome to gPodder</big>"
@@ -2197,7 +2197,7 @@ msgstr "_Ajuda"
 
 #: share/gpodder/ui/gtk/menus.ui.h:5
 msgid "About"
-msgstr ""
+msgstr "Sobre"
 
 #: share/gpodder/ui/gtk/menus.ui.h:7
 #, fuzzy
@@ -2212,7 +2212,7 @@ msgstr "Baixe novos episódios"
 #, fuzzy
 #| msgid "Find new podcasts"
 msgid "Find Podcast"
-msgstr "Ache novos podcasts"
+msgstr "Procure novos podcasts"
 
 #: share/gpodder/ui/gtk/menus.ui.h:12
 #, fuzzy
@@ -2238,7 +2238,7 @@ msgstr "Exportar para arquivo OPML"
 #: share/gpodder/ui/gtk/menus.ui.h:20
 #, fuzzy
 msgid "_Episodes"
-msgstr "Espisódio"
+msgstr "Episódio"
 
 #: share/gpodder/ui/gtk/menus.ui.h:26
 msgid "Toggle new status"
@@ -2374,7 +2374,7 @@ msgstr[1] "%(count)d novos episódios"
 
 #: bin/gpo:556
 msgid "Checking for new episodes"
-msgstr "Verificando por novos espisódios"
+msgstr "Verificando por novos episódios"
 
 #: bin/gpo:565
 #, python-format
@@ -2393,7 +2393,7 @@ msgstr "Excluir episódios"
 #: bin/gpo:689
 #, fuzzy
 msgid "Episode has already been deleted."
-msgstr "Os espisódos estão protegidos"
+msgstr "Os episódos já foram apagados."
 
 #: bin/gpo:704
 #, python-format
@@ -2434,7 +2434,7 @@ msgstr ""
 
 #: bin/gpo:827 bin/gpo:996
 msgid "yes"
-msgstr ""
+msgstr "sim"
 
 #: bin/gpo:865
 #, fuzzy, python-format
@@ -2468,7 +2468,7 @@ msgstr ""
 
 #: bin/gpo:990
 msgid "Title:"
-msgstr ""
+msgstr "Título: "
 
 #: bin/gpo:991
 #, fuzzy
@@ -2484,7 +2484,7 @@ msgstr "Seção:"
 
 #: bin/gpo:993
 msgid "Authors:"
-msgstr ""
+msgstr "Autores: "
 
 #: bin/gpo:995
 #, fuzzy
@@ -2497,7 +2497,7 @@ msgstr ""
 
 #: bin/gpo:996
 msgid "no"
-msgstr ""
+msgstr "não"
 
 #: bin/gpo:1021
 msgid "enabled"


### PR DESCRIPTION
"Resumir" is a false cognate. It doesn't mean "to resume".

```
verbo
1.
transitivo direto e pronominal
condensar em poucas palavras; abreviar, sintetizar.
"r. um texto"
2.
transitivo direto
conter em resumo; reunir, sintetizar.
"o livro resume a história da pintura"
3.
transitivo direto
simbolizar, representar.
"pode-se dizer que gregos e romanos resumem a Antiguidade"
4.
bitransitivo
fazer transformar em; converter.
"a enchente resumiu a cidade a um rio"
5.
bitransitivo e pronominal
fazer consistir ou consistir apenas em; concentrar(-se), limitar(-se), reduzir(-se).
"procurava r. no trabalho sua razão de viver"
6.
pronominal
reportar-se, aludir.
"o costume resume-se ao Império Romano"
```