### PR TITLE
Do not show new episodes on view->Downloaded

### DIFF
--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -205,6 +205,10 @@
           <attribute name="action">win.viewHideBoringPodcasts</attribute>
           <attribute name="label" translatable="yes">Hide podcasts without episodes</attribute>
         </item>
+        <item>
+          <attribute name="action">win.viewAlwaysShowNewEpisodes</attribute>
+          <attribute name="label" translatable="yes">Always show New Episodes</attribute>
+        </item>
       </section>
       <submenu id="menuViewColumns">
         <attribute name="label" translatable="yes">Visible columns</attribute>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -162,6 +162,7 @@ defaults = {
                 'descriptions': True,
                 'view_mode': 1,
                 'columns': int('110', 2),  # bitfield of visible columns
+                'always_show_new': True,
             },
 
             'download_list': {

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -264,6 +264,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
         g.add_action(action)
 
         action = Gio.SimpleAction.new_stateful(
+            'viewAlwaysShowNewEpisodes', None, GLib.Variant.new_boolean(self.config.ui.gtk.episode_list.always_show_new))
+        action.connect('activate', self.on_item_view_always_show_new_episodes_toggled)
+        g.add_action(action)
+
+        action = Gio.SimpleAction.new_stateful(
             'searchAlwaysVisible', None, GLib.Variant.new_boolean(self.config.ui.gtk.search_always_visible))
         action.connect('activate', self.on_item_view_search_always_visible_toggled)
         g.add_action(action)
@@ -1241,7 +1246,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def _on_config_changed(self, name, old_value, new_value):
         if name == 'ui.gtk.toolbar':
             self.toolbar.set_property('visible', new_value)
-        elif name == 'ui.gtk.episode_list.descriptions':
+        elif name in ('ui.gtk.episode_list.descriptions',
+                'ui.gtk.episode_list.always_show_new'):
             self.update_episode_list_model()
         elif name in ('auto.update.enabled', 'auto.update.frequency'):
             self.restart_auto_update_timer()
@@ -3125,6 +3131,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.config.podcast_list_hide_boring = not state
         action.set_state(GLib.Variant.new_boolean(not state))
         self.apply_podcast_list_hide_boring()
+
+    def on_item_view_always_show_new_episodes_toggled(self, action, param):
+        state = action.get_state()
+        self.config.ui.gtk.episode_list.always_show_new = not state
+        action.set_state(GLib.Variant.new_boolean(not state))
 
     def on_item_view_search_always_visible_toggled(self, action, param):
         state = action.get_state()

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -390,7 +390,7 @@ class EpisodeListModel(Gtk.ListStore):
             elif episode.state == gpodder.STATE_NORMAL and \
                     episode.is_new:
                 tooltip.append(_('New episode'))
-                view_show_downloaded = True
+                view_show_downloaded = self._config.ui.gtk.episode_list.always_show_new
                 view_show_unplayed = True
             elif episode.state == gpodder.STATE_DOWNLOADED:
                 tooltip = []


### PR DESCRIPTION
Add 'Always show New episodes' toggle to View menu

Fixes #468.

Adds a new boolean config item ui.gtk.episode_list.always_show_new, which can be toggled from menu with View->Always show New episodes.

If set, the Downloaded episodes view also shows new episodes.