### PR TITLE
Fix translation of Youtube playlist URL to a feed

### DIFF
--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -485,7 +485,7 @@ def parse_youtube_url(url):
 
         if 'list=' in query:
             playlist_query = [query_value for query_value in query.split("&") if 'list=' in query_value][0]
-            playlist_id = playlist_query.strip("list=")
+            playlist_id = playlist_query[5:]
             query = 'playlist_id={playlist_id}'.format(playlist_id=playlist_id)
 
         path = '/feeds/videos.xml'


### PR DESCRIPTION
There's a bug when converting a youtube playlist URL to a feed, which causes the feed URL to be malformed and thus not found. This patch fixes the URL conversion for youtube playlists.