### PR TITLE
Prevent text entry from expanding

### DIFF
--- a/share/gpodder/ui/gtk/gpodderaddpodcast.ui
+++ b/share/gpodder/ui/gtk/gpodderaddpodcast.ui
@@ -85,7 +85,7 @@
           </object>
           <packing>
             <property name="padding">0</property>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
           </packing>
         </child>


### PR DESCRIPTION
On mobile screens GtkDialog windows are stretched to cover all of the
screen. This prevents the hbox with the text entry from expanding when
the window grows (which looks rather unintuitive).

Fixes: #929