### PR TITLE
Add more episode details to shownotes

### DIFF
--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -57,6 +57,7 @@ def get_shownotes(enable_html, pane):
 class gPodderShownotes:
     def __init__(self, shownotes_pane):
         self.shownotes_pane = shownotes_pane
+        self.details_fmt = _('%s | %s | %s')
 
         self.scrolled_window = Gtk.ScrolledWindow()
         self.scrolled_window.set_shadow_type(Gtk.ShadowType.IN)
@@ -186,6 +187,7 @@ class gPodderShownotesText(gPodderShownotes):
         self.text_buffer = Gtk.TextBuffer()
         self.text_buffer.create_tag('heading', scale=1.2, weight=Pango.Weight.BOLD)
         self.text_buffer.create_tag('subheading', scale=1.0)
+        self.text_buffer.create_tag('details', scale=0.9)
         self.text_view.set_buffer(self.text_buffer)
         self.text_view.set_property('expand', True)
         self.text_view.connect('button-release-event', self.on_button_release)
@@ -196,12 +198,19 @@ class gPodderShownotesText(gPodderShownotes):
     def update(self, episode):
         heading = episode.title
         subheading = _('from %s') % (episode.channel.title)
+        details = self.details_fmt % (
+            util.format_date(episode.published),
+            util.format_filesize(episode.file_size, digits=1)
+            if episode.file_size > 0 else "-",
+            episode.get_play_info_string())
         self.define_colors()
         hyperlinks = [(0, None)]
         self.text_buffer.set_text('')
         self.text_buffer.insert_with_tags_by_name(self.text_buffer.get_end_iter(), heading, 'heading')
         self.text_buffer.insert_at_cursor('\n')
         self.text_buffer.insert_with_tags_by_name(self.text_buffer.get_end_iter(), subheading, 'subheading')
+        self.text_buffer.insert_at_cursor('\n')
+        self.text_buffer.insert_with_tags_by_name(self.text_buffer.get_end_iter(), details, 'details')
         self.text_buffer.insert_at_cursor('\n\n')
         for target, text in util.extract_hyperlinked_text(episode.description_html or episode.description):
             hyperlinks.append((self.text_buffer.get_char_count(), target))
@@ -294,9 +303,14 @@ class gPodderShownotesHTML(gPodderShownotes):
         stylesheet = self.get_stylesheet()
         if stylesheet:
             self.manager.add_style_sheet(stylesheet)
-        heading = html.escape(episode.title)
-        subheading = _('from %s') % (html.escape(episode.channel.title))
-        header_html = _('<div id="gpodder-title">\n<h3>%s</h3>\n<p>%s</p>\n</div>\n') % (heading, subheading)
+        heading = '<h3>%s</h3>' % html.escape(episode.title)
+        subheading = _('from %s') % html.escape(episode.channel.title)
+        details = '<small>%s</small>' % html.escape(self.details_fmt % (
+            util.format_date(episode.published),
+            util.format_filesize(episode.file_size, digits=1)
+            if episode.file_size > 0 else "-",
+            episode.get_play_info_string()))
+        header_html = _('<div id="gpodder-title">\n%s\n<p>%s</p>\n<p>%s</p></div>\n') % (heading, subheading, details)
         description_html = episode.description_html
         if not description_html:
             description_html = re.sub(r'\n', '<br>\n', episode.description)

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -579,7 +579,7 @@ def format_filesize(bytesize, use_si_units=False, digits=2):
             used_value = bytesize / float(value)
             used_unit = unit
 
-    return locale.format_string('%.' + str(digits) + 'f %s', (used_value, used_unit))
+    return locale.format_string('%.' + str(digits) + 'f\u00a0%s', (used_value, used_unit))
 
 
 def delete_file(filename):


### PR DESCRIPTION
Add a line after subheading in shownotes with episode release date, length and size.

I usually have just the 'Released' column visible in the episode list TreeView, so having these visible in the shownotes is useful.

The formatting and the items in the details can be discussed in this PR and changed accordingly.