### PR TITLE
Fix uncaught exception on channel list key navigation

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -717,12 +717,15 @@ class gPodder(BuilderWidget, dbus.service.Object):
             elif event.keyval in (Gdk.KEY_Up, Gdk.KEY_Down):
                 # If section markers exist in the treeview, we want to
                 # "jump over" them when moving the cursor up and down
-                selection = self.treeChannels.get_selection()
-                model, it = selection.get_selected()
-
                 if event.keyval == Gdk.KEY_Up:
                     step = -1
                 else:
+                    step = 1
+
+                selection = self.treeChannels.get_selection()
+                model, it = selection.get_selected()
+                if it is None:
+                    it = model.get_iter_first()
                     step = 1
 
                 path = model.get_path(it)


### PR DESCRIPTION
Typing a long search term to the channel list search until there is no matching channels left, and then shortening the search term with backspace results in a channel treeview with episodes, but with nothing selected.

Using the arrow key navigation in this state (like pressing 2 times Up arrow) results in this uncaught exception:
```
ERROR: Uncaught exception: Traceback (most recent call last):
  File "/home/tpikonen/src/gpodder/git-gpodder/src/gpodder/gtkui/main.py", line 728, in on_key_press
    path = model.get_path(it)
TypeError: Argument 1 does not allow None as a value
```

This PR selects the first episode in the list, when keyboard-navigating in a treeview without selection.