### PR TITLE
Set episode selector title before creating window.

### DIFF
--- a/src/gpodder/gtkui/desktop/episodeselector.py
+++ b/src/gpodder/gtkui/desktop/episodeselector.py
@@ -89,7 +89,11 @@ class gPodderEpisodeSelector(BuilderWidget):
     COLUMN_ADDITIONAL = 3
 
     def new(self):
+        if hasattr(self, 'title'):
+            self.gPodderEpisodeSelector.set_title(self.title)
+
         self._config.connect_gtk_window(self.gPodderEpisodeSelector, 'episode_selector', True)
+
         if not hasattr(self, 'callback'):
             self.callback = None
 
@@ -125,9 +129,6 @@ class gPodderEpisodeSelector(BuilderWidget):
 
         if not hasattr(self, 'columns'):
             self.columns = (('title_markup', None, None, _('Episode')),)
-
-        if hasattr(self, 'title'):
-            self.gPodderEpisodeSelector.set_title(self.title)
 
         if hasattr(self, 'instructions'):
             self.labelInstructions.set_text(self.instructions)


### PR DESCRIPTION
Window managers can't restore position when the initial title isn't the same as the final title that gets stored.