### PR TITLE
Allow episodes with youtube-dl compatible URLs

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -438,8 +438,6 @@ class gPodderYoutubeDL(download.CustomDownloader):
             return None
         if self.is_supported_url(episode.url):
             return YoutubeCustomDownload(self, episode.url, episode)
-        elif self.is_supported_url(episode.link):
-            return YoutubeCustomDownload(self, episode.link, episode)
 
         return None
 

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -285,6 +285,10 @@ class gPodderYoutubeDL(download.CustomDownloader):
             self._ydl_opts['verbose'] = True
         else:
             self._ydl_opts['quiet'] = True
+        # Don't create downloaders for URLs supported by these youtube-dl extractors
+        self.ie_blacklist = ["Generic"]
+        # Cache URL regexes from youtube-dl matches here, seed with youtube regex
+        self.regex_cache = [re.compile(r'https://www.youtube.com/watch\?v=.+')]
         # #686 on windows without a console, sys.stdout is None, causing exceptions
         # when adding podcasts.
         # See https://docs.python.org/3/library/sys.html#sys.__stderr__ Note
@@ -411,16 +415,32 @@ class gPodderYoutubeDL(download.CustomDownloader):
             return self.refresh(url, channel.url, max_episodes)
         return None
 
+    def is_supported_url(self, url):
+        if self.regex_cache[0].match(url) is not None:
+            return True
+        for r in self.regex_cache[1:]:
+            if r.match(url) is not None:
+                self.regex_cache.remove(r)
+                self.regex_cache.insert(0, r)
+                return True
+        with youtube_dl.YoutubeDL(self._ydl_opts) as ydl:
+            for ie in ydl._ies:
+                if ie.suitable(url) and ie.ie_key() not in self.ie_blacklist:
+                    self.regex_cache.insert(0, ie._VALID_URL_RE)
+                    return True
+        return False
+
     def custom_downloader(self, unused_config, episode):
         """
         called from registry.custom_downloader.resolve
         """
         if not self.force and not self.my_config.manage_downloads:
             return None
-        if re.match(r'''https://www.youtube.com/watch\?v=.+''', episode.url):
+        if self.is_supported_url(episode.url):
             return YoutubeCustomDownload(self, episode.url, episode)
-        elif re.match(r'''https://www.youtube.com/watch\?v=.+''', episode.link):
+        elif self.is_supported_url(episode.link):
             return YoutubeCustomDownload(self, episode.link, episode)
+
         return None
 
 

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -327,6 +327,10 @@ class PodcastEpisode(PodcastModelObject):
         if file_type is not None:
             return episode
 
+        # Check if any extensions (e.g. youtube-dl) support the link
+        if registry.custom_downloader.resolve(None, None, episode) is not None:
+            return episode
+
         return None
 
     def __init__(self, channel):

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -290,18 +290,26 @@ class PodcastEpisode(PodcastModelObject):
 
         audio_available = any(enclosure['mime_type'].startswith('audio/') for enclosure in entry['enclosures'])
         video_available = any(enclosure['mime_type'].startswith('video/') for enclosure in entry['enclosures'])
+        link_has_media = False
+        if not (audio_available or video_available):
+            _url = episode.url
+            episode.url = util.normalize_feed_url(entry['link'])
+            # Check if any extensions (e.g. youtube-dl) support the link
+            link_has_media = registry.custom_downloader.resolve(None, None, episode) is not None
+            episode.url = _url
+        media_available = audio_available or video_available or link_has_media
 
         for enclosure in entry['enclosures']:
             episode.mime_type = enclosure['mime_type']
 
             # Skip images in feeds if audio or video is available (bug 979)
             # This must (and does) also look in Media RSS enclosures (bug 1430)
-            if episode.mime_type.startswith('image/') and (audio_available or video_available):
+            if episode.mime_type.startswith('image/') and media_available:
                 continue
 
             # If we have audio or video available later on, skip
             # all 'application/*' data types (fixes Linux Outlaws and peertube feeds)
-            if episode.mime_type.startswith('application/') and (audio_available or video_available):
+            if episode.mime_type.startswith('application/') and media_available:
                 continue
 
             episode.url = util.normalize_feed_url(enclosure['url'])
@@ -327,8 +335,7 @@ class PodcastEpisode(PodcastModelObject):
         if file_type is not None:
             return episode
 
-        # Check if any extensions (e.g. youtube-dl) support the link
-        if registry.custom_downloader.resolve(None, None, episode) is not None:
+        if link_has_media:
             return episode
 
         return None


### PR DESCRIPTION
This PR allows subscribing to feeds with links to youtube-dl compatible content and a config var to enable streaming of unrecognized episode URLs with the configured video player.

Specifically:
 * Allow creation of custom downloaders  in the youtube-dl extension for all URLs supported by youtube-dl
 * Accept episodes in RSS feeds where the 'link' element has an URL for which a custom downloader can be created
 * Remove legacy settings 'player' and 'videoplayer'
 * Add setting 'player.videoplayer_youtube_dl_support' which enables streaming of episodes with URLs with otherwise unrecognized file type

Downloads with youtube-dl work if a suitable format string is set to youtube.preferred_fmt_ids, but this setting is a bit non-obvious for my taste.