### PR TITLE
Skip episode media with 'application/*' mime type

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -300,8 +300,8 @@ class PodcastEpisode(PodcastModelObject):
                 continue
 
             # If we have audio or video available later on, skip
-            # 'application/octet-stream' data types (fixes Linux Outlaws)
-            if episode.mime_type == 'application/octet-stream' and (audio_available or video_available):
+            # all 'application/*' data types (fixes Linux Outlaws and peertube feeds)
+            if episode.mime_type.startswith('application/') and (audio_available or video_available):
                 continue
 
             episode.url = util.normalize_feed_url(enclosure['url'])


### PR DESCRIPTION
Some peertube feeds (example: https://tilvids.com/feeds/videos.xml?videoChannelId=42) have 'application/x-bittorrent' URLs in the 'enclosure' tags. This patch makes gpodder skip all URLs with 'application/' mime type, if there are enclosures with audio or video available.