### PR TITLE
Strip HTML tags from channel descriptions

### DIFF
--- a/src/gpodder/gtkui/desktop/channel.py
+++ b/src/gpodder/gtkui/desktop/channel.py
@@ -83,7 +83,7 @@ class gPodderChannel(BuilderWidget):
             err = '\n\nERROR: {}'.format(self.channel._update_error)
         else:
             err = ''
-        b.set_text(self.channel.description + err)
+        b.set_text(util.remove_html_tags(self.channel.description) + err)
         self.channel_description.set_buffer(b)
 
         # Add Drag and Drop Support

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1324,16 +1324,17 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
                 box.add(Gtk.HSeparator())
 
+                channel_description = util.remove_html_tags(channel.description)
                 if channel._update_error is not None:
                     description = _('ERROR: %s') % channel._update_error
-                elif len(channel.description) < 500:
-                    description = channel.description
+                elif len(channel_description) < 500:
+                    description = channel_description
                 else:
-                    pos = channel.description.find('\n\n')
+                    pos = channel_description.find('\n\n')
                     if pos == -1 or pos > 500:
-                        description = channel.description[:498] + '[...]'
+                        description = channel_description[:498] + '[...]'
                     else:
-                        description = channel.description[:pos]
+                        description = channel_description[:pos]
 
                 description = Gtk.Label(label=description)
                 description.set_max_width_chars(60)

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -744,7 +744,8 @@ class PodcastListModel(Gtk.ListStore):
         if channel._update_error is not None:
             description_markup = html.escape(_('ERROR: %s') % channel._update_error)
         elif not channel.pause_subscription:
-            description_markup = html.escape(util.get_first_line(channel.description) or ' ')
+            description_markup = html.escape(
+                util.get_first_line(util.remove_html_tags(channel.description)) or ' ')
         else:
             description_markup = html.escape(_('Subscription paused'))
         d = []


### PR DESCRIPTION
Run util.remove_html_tags() on channel description strings shown in the UI.