### PR TITLE
Disable open website menu item if channel or episode has no website.

### DIFF
--- a/share/gpodder/extensions/episode_website_context_menu.py
+++ b/share/gpodder/extensions/episode_website_context_menu.py
@@ -23,15 +23,21 @@ class gPodderExtension:
     def __init__(self, container):
         self.container = container
 
+    def has_website(self, episodes):
+        for episode in episodes:
+            if episode.link:
+                return True
+
     def open_website(self, episodes):
         for episode in episodes:
-            util.open_website(episode.link)
+            if episode.link:
+                util.open_website(episode.link)
 
     def open_channel_website(self, channel):
         util.open_website(channel.link)
 
     def on_episodes_context_menu(self, episodes):
-        return [(_('Open website'), self.open_website)]
+        return [(_('Open website'), self.open_website if self.has_website(episodes) else None)]
 
-    def on_channel_context_menu(self, episodes):
-        return [(_('Open website'), self.open_channel_website)]
+    def on_channel_context_menu(self, channel):
+        return [(_('Open website'), self.open_channel_website if channel.link else None)]

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1717,7 +1717,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 menu.append(Gtk.SeparatorMenuItem())
                 for label, callback in result:
                     item = Gtk.MenuItem(label)
-                    item.connect('activate', lambda item, callback: callback(self.active_channel), callback)
+                    if callback:
+                        item.connect('activate', lambda item, callback: callback(self.active_channel), callback)
+                    else:
+                        item.set_sensitive(False)
                     menu.append(item)
 
             menu.append(Gtk.SeparatorMenuItem())
@@ -1926,7 +1929,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 for label, callback in result:
                     key, sep, title = label.rpartition('/')
                     item = Gtk.ImageMenuItem(title)
-                    self._submenu_item_activate_hack(item, callback, episodes)
+                    if callback:
+                        self._submenu_item_activate_hack(item, callback, episodes)
+                    else:
+                        item.set_sensitive(False)
                     if key:
                         if key not in submenus:
                             sub_menu = self._add_sub_menu(menu, key)


### PR DESCRIPTION
Extensions can return [] to hide a menu item, but making it insensitive is less confusing than hiding it. The first patch allows extensions to disable menu items by returning None for the callback.
 
Closes #958.