### PR TITLE
Show URL that caused invalid feed error

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -214,7 +214,7 @@ class gPodderFetcher(feedcore.Fetcher):
             feed['headers'] = headers
             return feedcore.Result(status, PodcastParserFeed(feed, self, max_episodes))
         except ValueError as e:
-            raise feedcore.InvalidFeed('Could not parse feed: {msg}'.format(msg=e))
+            raise feedcore.InvalidFeed('Could not parse feed: {url}: {msg}'.format(url=url, msg=e))
 
 
 # Our podcast model:


### PR DESCRIPTION
The error may originate from another page in the feed, and only showing the original URL makes it harder to track down invalid feed issues (see #967).