### PR TITLE
Fix warning on non-200 status codes in coverart

### DIFF
--- a/src/gpodder/coverart.py
+++ b/src/gpodder/coverart.py
@@ -85,7 +85,11 @@ class CoverDownloader(object):
 
             try:
                 logger.info('Downloading cover art: %s', cover_url)
-                data = util.urlopen(cover_url, timeout=self.TIMEOUT).content
+                response = util.urlopen(cover_url, timeout=self.TIMEOUT)
+                if response.status_code != 200:
+                    msg = '%s returned status code %d' % (cover_url, response.status_code)
+                    raise ValueError(msg)
+                data = response.content
             except Exception as e:
                 logger.warn('Cover art download failed: %s', e)
                 return self._fallback_filename(title)


### PR DESCRIPTION
before:
```
[gpodder.coverart] WARNING: Cannot save cover art
Traceback (most recent call last):
  File "/home/michal/build/gpodder/src/gpodder/coverart.py", line 103, in get_cover
    raise ValueError(msg)
ValueError: Unknown file type: <URL> (b'')
```

after:
```
[gpodder.coverart] WARNING: Cover art download failed: <URL> returned status code 404
```
