### PR TITLE
Fix #921 select episodes in section

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -53,7 +53,7 @@ from .interface.addpodcast import gPodderAddPodcast
 from .interface.common import BuilderWidget, TreeViewHelper
 from .interface.progress import ProgressIndicator
 from .interface.searchtree import SearchTree
-from .model import EpisodeListModel, PodcastListModel
+from .model import EpisodeListModel, PodcastChannelProxy, PodcastListModel
 from .services import CoverDownloader
 from .widgets import SimpleMessageArea
 
@@ -705,11 +705,6 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # When no podcast is selected, clear the episode list model
         selection = self.treeChannels.get_selection()
 
-        def select_function(selection, model, path, path_currently_selected):
-            url = model.get_value(model.get_iter(path), PodcastListModel.C_URL)
-            return (url != '-')
-        selection.set_select_function(select_function)  # full=True)
-
         # Set up type-ahead find for the podcast list
         def on_key_press(treeview, event):
             if event.keyval == Gdk.KEY_Right:
@@ -731,21 +726,17 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     step = 1
 
                 path = model.get_path(it)
-                while True:
-                    path = (path[0] + step,)
+                path = (path[0] + step,)
 
-                    if path[0] < 0:
-                        # Valid paths must have a value >= 0
-                        return True
+                if path[0] < 0:
+                    # Valid paths must have a value >= 0
+                    return True
 
-                    try:
-                        it = model.get_iter(path)
-                    except ValueError:
-                        # Already at the end of the list
-                        return True
-
-                    if model.get_value(it, PodcastListModel.C_URL) != '-':
-                        break
+                try:
+                    it = model.get_iter(path)
+                except ValueError:
+                    # Already at the end of the list
+                    return True
 
                 self.treeChannels.set_cursor(path)
             elif event.keyval == Gdk.KEY_Escape:
@@ -2714,9 +2705,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 # Process received episode actions for all updated URLs
                 self.process_received_episode_actions()
 
-                # If we are currently viewing "All episodes", update its episode list now
+                # If we are currently viewing "All episodes" or a section, update its episode list now
                 if self.active_channel is not None and \
-                        getattr(self.active_channel, 'ALL_EPISODES_PROXY', False):
+                        isinstance(self.active_channel, PodcastChannelProxy):
                     self.update_episode_list_model()
 
                 if self.feed_cache_update_cancelled:
@@ -3477,8 +3468,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             if self.active_channel == old_active_channel:
                 return
 
-            # Dirty hack to check for "All episodes" (see gpodder.gtkui.model)
-            if getattr(self.active_channel, 'ALL_EPISODES_PROXY', False):
+            # Dirty hack to check for "All episodes" or a section (see gpodder.gtkui.model)
+            if isinstance(self.active_channel, PodcastChannelProxy):
                 self.edit_channel_action.set_enabled(False)
             else:
                 self.edit_channel_action.set_enabled(True)

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -617,12 +617,6 @@ class PodcastListModel(Gtk.ListStore):
     def get_search_term(self):
         return self._search_term
 
-    def enable_separators(self, channeltree):
-        channeltree.set_row_separator_func(self._show_row_separator)
-
-    def _show_row_separator(self, model, iter):
-        return model.get_value(iter, self.C_SEPARATOR)
-
     def set_max_image_size(self, size):
         self._max_image_side = size
         self._cover_cache = {}


### PR DESCRIPTION
- sections are now navigable by keyboard and selectable.
  This enables exporting all episodes in a section to disk, etc.
- when a channel query is active, only display episodes for matching channels
  (when All Episodes or a section is selected)

Closes #921 