### PR TITLE
Show channel or episode titles in delete dialog

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2823,8 +2823,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             titles.append('• ' + (html.escape(thing.title if len(thing.title) <= max_length else thing.title[:max_length] + '...')))
         if len(things) > max_things:
             titles.append('+%(count)d more ...' % {'count': len(things) - max_things})
-        titles.append(message)
-        return '\n\n'.join(titles)
+        return '\n'.join(titles) + '\n\n' + message
 
     def delete_episode_list(self, episodes, confirm=True, skip_locked=True,
             callback=None):

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2820,7 +2820,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def format_delete_message(self, message, things, max_things, max_length):
         titles = []
         for index, thing in zip(range(max_things), things):
-            titles.append(thing.title if len(thing.title) <= max_length else thing.title[:max_length] + '...')
+            titles.append(html.escape(thing.title) if len(thing.title) <= max_length else html.escape(thing.title[:max_length]) + '...')
         if len(things) > max_things:
             titles.append('+%(count)d more ...' % {'count': len(things) - max_things})
         titles.append(message)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2820,7 +2820,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def format_delete_message(self, message, things, max_things, max_length):
         titles = []
         for index, thing in zip(range(max_things), things):
-            titles.append(html.escape(thing.title) if len(thing.title) <= max_length else html.escape(thing.title[:max_length]) + '...')
+            titles.append('• ' + (html.escape(thing.title if len(thing.title) <= max_length else thing.title[:max_length] + '...')))
         if len(things) > max_things:
             titles.append('+%(count)d more ...' % {'count': len(things) - max_things})
         titles.append(message)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2817,6 +2817,15 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         self.application.remove_window(self.gPodder)
 
+    def format_delete_message(self, message, things, max_things, max_length):
+        titles = []
+        for index, thing in zip(range(max_things), things):
+            titles.append(thing.title if len(thing.title) <= max_length else thing.title[:max_length] + '...')
+        if len(things) > max_things:
+            titles.append('+%(count)d more ...' % {'count': len(things) - max_things})
+        titles.append(message)
+        return '\n\n'.join(titles)
+
     def delete_episode_list(self, episodes, confirm=True, skip_locked=True,
             callback=None):
         if not episodes:
@@ -2838,6 +2847,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         title = N_('Delete %(count)d episode?', 'Delete %(count)d episodes?',
                    count) % {'count': count}
         message = _('Deleting episodes removes downloaded files.')
+
+        message = self.format_delete_message(message, episodes, 8, 60)
 
         if confirm and not self.show_confirmation(message, title):
             return False
@@ -3270,6 +3281,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             title = _('Deleting podcasts')
             info = _('Please wait while the podcasts are deleted')
             message = _('These podcasts and all their episodes will be PERMANENTLY DELETED.\nAre you sure you want to continue?')
+
+        message = self.format_delete_message(message, channels, 8, 60)
 
         if confirm and not self.show_confirmation(message, title):
             return

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2847,7 +2847,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                    count) % {'count': count}
         message = _('Deleting episodes removes downloaded files.')
 
-        message = self.format_delete_message(message, episodes, 8, 60)
+        message = self.format_delete_message(message, episodes, 5, 60)
 
         if confirm and not self.show_confirmation(message, title):
             return False
@@ -3281,7 +3281,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             info = _('Please wait while the podcasts are deleted')
             message = _('These podcasts and all their episodes will be PERMANENTLY DELETED.\nAre you sure you want to continue?')
 
-        message = self.format_delete_message(message, channels, 8, 60)
+        message = self.format_delete_message(message, channels, 5, 60)
 
         if confirm and not self.show_confirmation(message, title):
             return


### PR DESCRIPTION
Provides a second, and better, indicator of which channel or episode is being deleted. Only 8 titles up to 60 characters each are shown to avoid excessively large dialogs.

The titles can blend with the final delete message. Should the final message be bold? Or should titles have a prefix such as '• '?

Should the 8 and 60 be adjusted? The dialog appears to self limit its width (wrapping lines), and 4-5@120 would allow fewer double line titles to be shown. It is less likely someone would read more than 4-5 titles when mass deleting, and showing more of long titles might be better.