### PR TITLE
Fix connection checking and add checkbox to disable it

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -563,6 +563,26 @@
                     <property name="position">5</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkSeparator" id="hseparator_updating3">
+                    <property name="orientation">horizontal</property>
+                    <property name="visible">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="position">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="checkbutton_check_connection">
+                    <property name="label" translatable="yes">Check connection before updating (if supported)</property>
+                    <property name="visible">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="position">7</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="tab-label" translatable="yes">Updating</property>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -91,6 +91,8 @@ defaults = {
         'retries': 3,  # number of retries when downloads time out
     },
 
+    'check_connection': True,
+
     # Software updates from gpodder.org
     'software_update': {
         'check_on_startup': True,  # check for updates on start

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -254,6 +254,9 @@ class gPodderPreferences(BuilderWidget):
         self.combo_auto_download.add_attribute(cellrenderer, 'text', NewEpisodeActionList.C_CAPTION)
         self.combo_auto_download.set_active(self.auto_download_model.get_index())
 
+        self._config.connect_gtk_togglebutton('check_connection',
+                                              self.checkbutton_check_connection)
+
         if self._config.auto_remove_played_episodes:
             adjustment_expiration = self.hscale_expiration.get_adjustment()
             if self._config.episode_old_age > adjustment_expiration.get_upper():

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2611,7 +2611,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
     def update_feed_cache(self, channels=None,
                           show_new_episodes_dialog=True):
-        if not util.connection_available():
+        if self.config.check_connection and not util.connection_available():
             self.show_message(_('Please connect to a network, then try again.'),
                     _('No network connection'), important=True)
             return
@@ -3526,7 +3526,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     interval, self._on_auto_update_timer)
 
     def _on_auto_update_timer(self):
-        if not util.connection_available():
+        if self.config.check_connection and not util.connection_available():
             logger.debug('Skipping auto update (no connection available)')
             return True
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1837,7 +1837,7 @@ def linux_get_active_interfaces():
     for record in re.split(r'^\d+: ',
                            data.decode(locale.getpreferredencoding()),
                            flags=re.MULTILINE):
-        mo = re.match(r'^([^:]*):.*inet.*brd', record, flags=re.DOTALL)
+        mo = re.match(r'^([^:]*):.*inet.*scope', record, flags=re.DOTALL)
         if mo:
             yield mo.group(1)
 


### PR DESCRIPTION
The new `Check connection (if supported)` checkbox is in the updating tab. Thoughts on a better label for it?

Fixes #1014 