### PR TITLE
Do not show 'All episodes' on podcast search

### DIFF
--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -590,7 +590,7 @@ class PodcastListModel(Gtk.ListStore):
         # If searching is active, set visibility based on search text
         if self._search_term is not None:
             if isinstance(channel, PodcastChannelProxy):
-                return True
+                return not channel.ALL_EPISODES_PROXY
             key = self._search_term.lower()
             columns = (model.get_value(iter, c) for c in self.SEARCH_COLUMNS)
             return any((key in c.lower() for c in columns if c is not None))


### PR DESCRIPTION
Currently when searching podcasts, the 'All episodes' channel proxy and sections are always displayed on the results. This is confusing, since they do no match the search string.

This patch extends the keyword matching to PodcastChannelProxy titles, so they are only shown in search results when the title matches.

EDIT: This patch now just removes the 'All episodes' item from the podcast list during search.