### PR TITLE
Disable circleci for adaptive branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,7 @@ workflows:
   build-bundle:
     jobs:
       - release-from-macos
+        filters:
+          branches:
+            ignore:
+              - adaptive


### PR DESCRIPTION
There is no reason to generate mac builds until gpodder-osx-bundle gets libhandy, if ever.

@elelay Does this look like it would work?