### PR TITLE
Allow a narrower podcast directory window

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpodcastdirectory.ui
+++ b/share/gpodder/ui/gtk/gpodderpodcastdirectory.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.12"/>
   <object class="GtkDialog" id="gPodderPodcastDirectory">
     <property name="can-focus">False</property>
     <property name="border-width">6</property>
@@ -23,73 +23,12 @@
             <property name="can-focus">False</property>
             <property name="layout-style">end</property>
             <child>
-              <object class="GtkButton" id="btnSelectAll">
-                <property name="label" translatable="yes">Select All</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <signal name="clicked" handler="on_btnSelectAll_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btnSelectNone">
-                <property name="label" translatable="yes">Select None</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <signal name="clicked" handler="on_btnSelectNone_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btnCancel">
-                <property name="label">gtk-cancel</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="has-focus">True</property>
-                <property name="can-default">True</property>
-                <property name="has-default">True</property>
-                <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-                <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btnOK">
-                <property name="label">gtk-add</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
-                <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">3</property>
-              </packing>
+              <placeholder/>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -228,16 +167,111 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFlowBox" id="flowbox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="min-children-per-line">1</property>
+            <property name="max-children-per-line">2</property>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <child>
+                  <object class="GtkButtonBox" id="selectbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="layout-style">start</property>
+                    <child>
+                      <object class="GtkButton" id="btnSelectAll">
+                        <property name="label" translatable="yes">Select All</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <signal name="clicked" handler="on_btnSelectAll_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="btnSelectNone">
+                        <property name="label" translatable="yes">Select None</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <signal name="clicked" handler="on_btnSelectNone_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkFlowBoxChild">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <child>
+                  <object class="GtkButtonBox" id="addbox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="layout-style">end</property>
+                    <child>
+                      <object class="GtkButton" id="btnCancel">
+                        <property name="label" translatable="yes">Cancel</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="can-default">True</property>
+                        <property name="has-default">True</property>
+                        <property name="receives-default">False</property>
+                        <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="pack-type">end</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="btnOK">
+                        <property name="label" translatable="yes">Add</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="pack-type">end</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="0">btnSelectAll</action-widget>
-      <action-widget response="0">btnSelectNone</action-widget>
-      <action-widget response="0">btnCancel</action-widget>
-      <action-widget response="0">btnOK</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/share/gpodder/ui/gtk/gpodderpodcastdirectory.ui
+++ b/share/gpodder/ui/gtk/gpodderpodcastdirectory.ui
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <object class="GtkDialog" id="gPodderPodcastDirectory">
+  <object class="GtkWindow" id="gPodderPodcastDirectory">
     <property name="can-focus">False</property>
     <property name="border-width">6</property>
     <property name="title" translatable="yes">Find new podcasts</property>
@@ -11,27 +11,12 @@
     <property name="default-width">600</property>
     <property name="default-height">400</property>
     <property name="type-hint">dialog</property>
-    <child internal-child="vbox">
+    <child>
       <object class="GtkBox" id="vb_directory">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="hboxBottomButtons">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkPaned" id="hpaned">
             <property name="visible">True</property>
@@ -268,7 +253,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/share/gpodder/ui/gtk/gpodderpodcastdirectory.ui
+++ b/share/gpodder/ui/gtk/gpodderpodcastdirectory.ui
@@ -1,36 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <!-- interface-requires gtk+ 2.16 -->
-  <!-- interface-naming-policy toplevel-contextual -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="gPodderPodcastDirectory">
-    <property name="visible">False</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">6</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">6</property>
     <property name="title" translatable="yes">Find new podcasts</property>
     <property name="modal">True</property>
-    <property name="transient-for">parent_widget</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="default_width">600</property>
-    <property name="default_height">400</property>
-    <property name="type_hint">dialog</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">600</property>
+    <property name="default-height">400</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="vb_directory">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="spacing">6</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="hboxBottomButtons">
+          <object class="GtkButtonBox" id="hboxBottomButtons">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btnSelectAll">
                 <property name="label" translatable="yes">Select All</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-underline">True</property>
                 <signal name="clicked" handler="on_btnSelectAll_clicked" swapped="no"/>
               </object>
               <packing>
@@ -43,9 +41,9 @@
               <object class="GtkButton" id="btnSelectNone">
                 <property name="label" translatable="yes">Select None</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-underline">True</property>
                 <signal name="clicked" handler="on_btnSelectNone_clicked" swapped="no"/>
               </object>
               <packing>
@@ -58,12 +56,12 @@
               <object class="GtkButton" id="btnCancel">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="has-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -76,9 +74,9 @@
               <object class="GtkButton" id="btnOK">
                 <property name="label">gtk-add</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
               </object>
               <packing>
@@ -91,30 +89,31 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkPaned" id="hpaned">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can-focus">True</property>
             <child>
               <object class="GtkScrolledWindow" id="sw_providers">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">never</property>
-                <property name="vscrollbar_policy">automatic</property>
-                <property name="shadow_type">in</property>
+                <property name="can-focus">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkTreeView" id="tv_providers">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="headers_visible">False</property>
-                    <property name="enable_search">False</property>
-                    <signal name="row-activated" handler="on_tv_providers_row_activated" swapped="no"/>
+                    <property name="can-focus">True</property>
+                    <property name="headers-visible">False</property>
+                    <property name="enable-search">False</property>
                     <signal name="cursor-changed" handler="on_tv_providers_cursor_changed" swapped="no"/>
+                    <signal name="row-activated" handler="on_tv_providers_row_activated" swapped="no"/>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
@@ -126,19 +125,18 @@
             <child>
               <object class="GtkBox" id="vb_podcasts">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="spacing">5</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">5</property>
                 <child>
                   <object class="GtkBox" id="hb_text_entry">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">5</property>
-                    <property name="orientation">horizontal</property>
                     <child>
                       <object class="GtkLabel" id="lb_search">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">label</property>
                       </object>
                       <packing>
@@ -150,12 +148,10 @@
                     <child>
                       <object class="GtkEntry" id="en_query">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="invisible_char">•</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="secondary_icon_activatable">False</property>
-                        <property name="primary_icon_sensitive">True</property>
-                        <property name="secondary_icon_sensitive">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="invisible-char">•</property>
+                        <property name="primary-icon-activatable">False</property>
+                        <property name="secondary-icon-activatable">False</property>
                         <signal name="activate" handler="on_bt_search_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -168,8 +164,8 @@
                       <object class="GtkButton" id="bt_search">
                         <property name="label" translatable="yes">...</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                         <signal name="clicked" handler="on_bt_search_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -188,9 +184,7 @@
                 <child>
                   <object class="GtkScrolledWindow" id="sw_tagcloud">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <placeholder/>
                     </child>
@@ -204,15 +198,17 @@
                 <child>
                   <object class="GtkScrolledWindow" id="sw_podcasts">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">never</property>
-                    <property name="vscrollbar_policy">automatic</property>
-                    <property name="shadow_type">in</property>
+                    <property name="can-focus">True</property>
+                    <property name="hscrollbar-policy">never</property>
+                    <property name="shadow-type">in</property>
                     <child>
                       <object class="GtkTreeView" id="tv_podcasts">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="headers_visible">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/src/gpodder/gtkui/desktop/podcastdirectory.py
+++ b/src/gpodder/gtkui/desktop/podcastdirectory.py
@@ -127,6 +127,7 @@ class gPodderPodcastDirectory(BuilderWidget):
     def setup_podcasts_treeview(self):
         column = Gtk.TreeViewColumn('')
         cell = Gtk.CellRendererToggle()
+        cell.set_fixed_size(48, -1)
         column.pack_start(cell, False)
         column.add_attribute(cell, 'active', DirectoryPodcastsModel.C_SELECTED)
         cell.connect('toggled', lambda cell, path: self.podcasts_model.toggle(path))


### PR DESCRIPTION
I'm trying to reduce the delta between adaptive and master. This PR moves the 'Select All' and 'Select None' buttons in gPodderPodcastDirectory window to a separate box (or row), so that the window can be made narrower. After this patch the only change needed to gPodderPodcastDirectory in adaptive is to replace GtkPaned with HdyFlap.