### PR TITLE
Fix "GtkSelectionData has no 'data'" exception in drag_data_received().

### DIFF
--- a/src/gpodder/gtkui/desktop/channel.py
+++ b/src/gpodder/gtkui/desktop/channel.py
@@ -170,7 +170,7 @@ class gPodderChannel(BuilderWidget):
         util.idle_add(set_cover, channel, pixbuf)
 
     def drag_data_received(self, widget, content, x, y, sel, ttype, time):
-        files = sel.data.strip().split('\n')
+        files = sel.get_text().strip().split('\n')
         if len(files) != 1:
             self.show_message(
                 _('You can only drop a single image or URL here.'),


### PR DESCRIPTION
This happens when dragging an image URL to the cover art in channel dialog.

I don't know if this is the correct fix, but it allows an image to be dragged from a web browser.