### PR TITLE
Cancel failed download in progress tab when deleting episode.

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2850,6 +2850,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         if confirm and not self.show_confirmation(message, title):
             return False
 
+        self.on_item_cancel_download_activate(force=True)
+
         progress = ProgressIndicator(_('Deleting episodes'),
                 _('Please wait while episodes are deleted'),
                 parent=self.get_dialog_parent())
@@ -3088,7 +3090,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Executes after tasks have been registered
         util.idle_add(queue_tasks, new_tasks, queued_existing_task)
 
-    def cancel_task_list(self, tasks):
+    def cancel_task_list(self, tasks, force=False):
         if not tasks:
             return
 
@@ -3099,6 +3101,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 task.status = task.CANCELLED
                 # Call run, so the partial file gets deleted
                 task.run()
+            elif force:
+                task.status = task.CANCELLED
 
         self.update_episode_list_icons([task.url for task in tasks])
         self.play_or_download()
@@ -3569,7 +3573,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Update the tab title and downloads list
         self.update_downloads_list()
 
-    def on_item_cancel_download_activate(self, *params):
+    def on_item_cancel_download_activate(self, *params, force=False):
         if self.wNotebook.get_current_page() == 0:
             selection = self.treeAvailable.get_selection()
             (model, paths) = selection.get_selected_rows()
@@ -3582,7 +3586,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             (model, paths) = selection.get_selected_rows()
             selected_tasks = [model.get_value(model.get_iter(path),
                     self.download_status_model.C_TASK) for path in paths]
-        self.cancel_task_list(selected_tasks)
+        self.cancel_task_list(selected_tasks, force=force)
 
     def on_btnCancelAll_clicked(self, widget, *args):
         self.cancel_task_list(self.download_tasks_seen)


### PR DESCRIPTION
I still haven't figured out how to cancel when the episode is removed from the feed, but this partially fixes #682 when the user deletes an episode.