### PR TITLE
Show section if any of its channels have an update error.

### DIFF
--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -603,6 +603,11 @@ class PodcastListModel(Gtk.ListStore):
             columns = (model.get_value(iter, c) for c in self.SEARCH_COLUMNS)
             return any((key in c.lower() for c in columns if c is not None))
 
+        # Show section if any of its channels have an update error
+        if isinstance(channel, PodcastChannelProxy) and not channel.ALL_EPISODES_PROXY:
+            if any(c._update_error is not None for c in channel.channels):
+                return True
+
         if model.get_value(iter, self.C_SEPARATOR):
             return True
         elif getattr(channel, '_update_error', None) is not None:


### PR DESCRIPTION
A channel with an update error might not any have visible episodes. When its section has no other visible channels, the section must still be displayed to prevent the channel with an error from appearing to be in a different section.