### PR TITLE
Streaming fixes

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -901,6 +901,10 @@ class DownloadTask(object):
         if self.status == DownloadTask.FAILED:
             self.__episode._download_error = self.error_message
 
+            # Delete empty partial files, they prevent streaming after a download failure (live stream)
+            if util.calculate_size(self.filename) == 0:
+                util.delete_file(self.tempname)
+
         if self.status == DownloadTask.DOWNLOADING:
             # Everything went well - we're done
             self.status = DownloadTask.DONE

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2073,14 +2073,20 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def playback_episodes_for_real(self, episodes):
         groups = collections.defaultdict(list)
         for episode in episodes:
+            episode._download_error = None
+
             player = self.episode_player(episode)
+
+            try:
+                allow_partial = (player != 'default')
+                filename = episode.get_playback_url(self.config, allow_partial)
+            except Exception as e:
+                episode._download_error = str(e)
+                continue
 
             # Mark episode as played in the database
             episode.playback_mark()
             self.mygpo_client.on_playback([episode])
-
-            allow_partial = (player != 'default')
-            filename = episode.get_playback_url(self.config, allow_partial)
 
             # Determine the playback resume position - if the file
             # was played 100%, we simply start from the beginning

--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -261,7 +261,7 @@ def get_real_download_url(url, allow_partial, preferred_fmt_ids=None):
                     return
 
             if error_message is not None:
-                raise YouTubeError('Cannot download video: %s' % error_message)
+                raise YouTubeError(('Cannot stream video: %s' if allow_partial else 'Cannot download video: %s') % error_message)
 
             r4 = re.search(r'url_encoded_fmt_stream_map=([^&]+)', page)
             if r4 is not None:


### PR DESCRIPTION
Attempting to download a live stream fails and then prevents streaming it. This fixes it by removing the empty partial file after failure.

The download error icon is also cleared before streaming an episode, and any error thrown when getting filename now produce an error icon.