### PR TITLE
Return an audio mime-type from Youtube-DL when given a video extension.

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -116,6 +116,10 @@ class YoutubeCustomDownload(download.CustomDownload):
                         break
             ext_filetype = mimetype_from_extension(dot_ext)
             if ext_filetype:
+                # Youtube weba formats have a webm extension and get a video/webm mime-type
+                # but audio content has no width or height, so change it to audio/webm for correct icon and player
+                if ext_filetype.startswith('video/') and ('height' not in res or res['height'] is None):
+                    ext_filetype = ext_filetype.replace('video/', 'audio/')
                 headers['content-type'] = ext_filetype
         return headers, res.get('url', self._url)
 


### PR DESCRIPTION
This uses audio icon and player when audio formats are downloaded with youtube-dl. Both youtube-dl and built-in download a weba file, but youtube-dl uses its `ext` field (which contains webm) and produces the wrong mime-type.

This also guarantees all supported youtube-dl sites will produce an audio mime-type if youtube-dl has the wrong `ext` value.