### PR TITLE
Add tools/requirements.txt

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,13 @@
+# PyPI / pip requirements for Linux
+# For the benefit of e.g. flatpak-pip-generator.
+#
+mygpoclient==1.8
+podcastparser==0.6.6
+requests[socks]==2.25.1
+urllib3==1.26.4
+html5lib==1.1
+mutagen==1.45.1
+dbus-python
+youtube_dl
+# eyed3 is optional and pulls in a lot of dependencies, so disable by default
+# eyed3


### PR DESCRIPTION
There seems to be no machine readable dependency list for the Python packages used by gPodder. This PR adds a pip-compatible [requirements](https://pip.pypa.io/en/stable/cli/pip_install/#requirements-file-format) file, which can be used to get the correct dependencies. I hope I did not miss anything.

I needed this when fixing the dependencies in the flatpak [package](https://github.com/flathub/org.gpodder.gpodder). There's a tool called [flatpak-pip-generator](https://github.com/flatpak/flatpak-builder-tools/tree/master/pip) which converts the requirements file to the format understood by flatpak-builder.
