### PR TITLE
Prevent soundcloud from downloading existing episodes each update.

### DIFF
--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -153,7 +153,7 @@ class SoundcloudUser(object):
                     'url': url,
                     'file_size': int(filesize),
                     'mime_type': filetype,
-                    'guid': track.get('permalink', track.get('id')),
+                    'guid': str(track.get('permalink', track.get('id'))),
                     'published': soundcloud_parsedate(track.get('created_at', None)),
                 }
         finally:


### PR DESCRIPTION
GUIDs are stored in the database as strings, but soundcloud creates them as integers. Python no longer succeeds when comparing these integers to the string keys from the existing database entries. This produces new episodes on every update which then collide with the existing GUIDs.

Fixes #1064.