### PR TITLE
Add option to rename_download.py to put the sortdate after the podcast title

### DIFF
--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -24,7 +24,7 @@ __category__ = 'post-download'
 DefaultConfig = {
     'add_sortdate': False,  # Add the sortdate as prefix
     'add_podcast_title': False,  # Add the podcast title as prefix
-    'sortdate_after_podcast_title': False, # put the sortdate after podcast title
+    'sortdate_after_podcast_title': False,  # put the sortdate after podcast title
 }
 
 

--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -24,6 +24,7 @@ __category__ = 'post-download'
 DefaultConfig = {
     'add_sortdate': False,  # Add the sortdate as prefix
     'add_podcast_title': False,  # Add the podcast title as prefix
+    'sortdate_after_podcast_title': False
 }
 
 
@@ -50,10 +51,16 @@ class gPodderExtension:
 
         new_basename = []
         new_basename.append(title)
-        if self.config.add_podcast_title:
-            new_basename.insert(0, podcast_title)
-        if self.config.add_sortdate:
-            new_basename.insert(0, sortdate)
+        if self.config.sortdate_after_podcast_title:
+            if self.config.add_sortdate:
+                new_basename.insert(0, sortdate)
+            if self.config.add_podcast_title:
+                new_basename.insert(0, podcast_title)
+        else:
+            if self.config.add_podcast_title:
+                new_basename.insert(0, podcast_title)
+            if self.config.add_sortdate:
+                new_basename.insert(0, sortdate)
         new_basename = ' - '.join(new_basename)
 
         # Remove unwanted characters and shorten filename (#494)

--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -24,7 +24,7 @@ __category__ = 'post-download'
 DefaultConfig = {
     'add_sortdate': False,  # Add the sortdate as prefix
     'add_podcast_title': False,  # Add the podcast title as prefix
-    'sortdate_after_podcast_title': False
+    'sortdate_after_podcast_title': False, # put the sortdate after podcast title
 }
 
 


### PR DESCRIPTION
I find it very useful to have the option when renaming download files to put the sortdate after the podcast title.  This allows me to easily sort by podcast and then date within podcast.