### PR TITLE
Create an html description when none provided.

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -15,7 +15,8 @@ from youtube_dl.utils import DownloadError, ExtractorError, sanitize_url
 
 import gpodder
 from gpodder import download, feedcore, model, registry, youtube
-from gpodder.util import mimetype_from_extension, remove_html_tags
+from gpodder.util import (mimetype_from_extension, nice_html_description,
+                          remove_html_tags)
 
 _ = gpodder.gettext
 
@@ -213,7 +214,7 @@ class YoutubeFeed(model.Feed):
         for en in self._ie_result['entries']:
             guid = video_guid(en['id'])
             description = remove_html_tags(en.get('description') or _('No description available'))
-            html_description = self.nice_html_description(en, description)
+            html_description = nice_html_description(en.get('thumbnail'), description)
             if en.get('ext'):
                 mime_type = mimetype_from_extension('.{}'.format(en['ext']))
             else:
@@ -249,25 +250,6 @@ class YoutubeFeed(model.Feed):
                                  as a fully parsed Feed or None
         """
         return None
-
-    @staticmethod
-    def nice_html_description(en, description):
-        """
-        basic html formating + hyperlink highlighting + video thumbnail
-        """
-        description = re.sub(r'''https?://[^\s]+''',
-                             r'''<a href="\g<0>">\g<0></a>''',
-                             description)
-        description = description.replace('\n', '<br>')
-        html = """<style type="text/css">
-        body > img { float: left; max-width: 30vw; margin: 0 1em 1em 0; }
-        </style>
-        """
-        img = en.get('thumbnail')
-        if img:
-            html += '<img src="{}">'.format(img)
-        html += '<p>{}</p>'.format(description)
-        return html
 
 
 class gPodderYoutubeDL(download.CustomDownloader):

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -283,6 +283,10 @@ class PodcastEpisode(PodcastModelObject):
         episode.description = entry['description']
         if entry.get('description_html'):
             episode.description_html = entry['description_html']
+        else:
+            thumbnail = entry.get('episode_art_url')
+            description = util.remove_html_tags(episode.description or _('No description available'))
+            episode.description_html = util.nice_html_description(thumbnail, description)
 
         episode.total_time = entry['total_time']
         episode.published = entry['published']

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -802,6 +802,24 @@ def extract_hyperlinked_text(html):
         return ExtractHyperlinkedTextHTMLParser()(html)
 
 
+def nice_html_description(img, description):
+    """
+    basic html formating + hyperlink highlighting + video thumbnail
+    """
+    description = re.sub(r'''https?://[^\s]+''',
+                         r'''<a href="\g<0>">\g<0></a>''',
+                         description)
+    description = description.replace('\n', '<br>')
+    html = """<style type="text/css">
+    body > img { float: left; max-width: 30vw; margin: 0 1em 1em 0; }
+    </style>
+    """
+    if img:
+        html += '<img src="{}">'.format(img)
+    html += '<p>{}</p>'.format(description)
+    return html
+
+
 def wrong_extension(extension):
     """
     Determine if a given extension looks like it's


### PR DESCRIPTION
The youtube-dl extension code is moved into gPodder to provide this feature for all feeds lacking an html description. This enables clickable links inside non-html descriptions. And if available, an image tag for the episode art URL is prepended to the html description (currently only available in html shownotes).