### PR TITLE
gtkui: properly scale cover/pill on high resolution displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ PyPI. With this, you get a self-contained gPodder CLI codebase.
 ### GTK3 UI - Additional Dependencies
 
 - [PyGObject](https://wiki.gnome.org/PyGObject) 3.22.0 or newer
+- [GTK+3](https://www.gtk.org/) 3.10 or newer
 
 
 ### Optional Dependencies

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -48,7 +48,7 @@ from .desktop.welcome import gPodderWelcome
 from .desktopfile import UserAppsReader
 from .download import DownloadStatusModel
 from .draw import (cake_size_from_widget, draw_cake_pixbuf,
-                   draw_text_box_centered)
+                   draw_iconcell_scale, draw_text_box_centered)
 from .interface.addpodcast import gPodderAddPodcast
 from .interface.common import BuilderWidget, TreeViewHelper
 from .interface.progress import ProgressIndicator
@@ -678,7 +678,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
     def init_podcast_list_treeview(self):
         size = cake_size_from_widget(self.treeChannels) * 2
-        self.podcast_list_model.set_max_image_size(size)
+        scale = self.treeChannels.get_scale_factor()
+        self.podcast_list_model.set_max_image_size(size, scale)
         # Set up podcast channel tree view widget
         column = Gtk.TreeViewColumn('')
         iconcell = Gtk.CellRendererPixbuf()
@@ -686,6 +687,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         column.pack_start(iconcell, False)
         column.add_attribute(iconcell, 'pixbuf', PodcastListModel.C_COVER)
         column.add_attribute(iconcell, 'visible', PodcastListModel.C_COVER_VISIBLE)
+        if scale != 1:
+            column.set_cell_data_func(iconcell, draw_iconcell_scale, scale)
 
         namecell = Gtk.CellRendererText()
         namecell.set_property('ellipsize', Pango.EllipsizeMode.END)
@@ -697,6 +700,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         column.pack_start(iconcell, False)
         column.add_attribute(iconcell, 'pixbuf', PodcastListModel.C_PILL)
         column.add_attribute(iconcell, 'visible', PodcastListModel.C_PILL_VISIBLE)
+        if scale != 1:
+            column.set_cell_data_func(iconcell, draw_iconcell_scale, scale)
 
         self.treeChannels.append_column(column)
 

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -585,6 +585,7 @@ class PodcastListModel(Gtk.ListStore):
 
         self._cover_cache = {}
         self._max_image_side = 40
+        self._scale = 1
         self._cover_downloader = cover_downloader
 
         self.ICON_DISABLED = 'media-playback-pause'
@@ -653,8 +654,9 @@ class PodcastListModel(Gtk.ListStore):
     def get_search_term(self):
         return self._search_term
 
-    def set_max_image_size(self, size):
-        self._max_image_side = size
+    def set_max_image_size(self, size, scale):
+        self._max_image_side = size * scale
+        self._scale = scale
         self._cover_cache = {}
 
     def _resize_pixbuf_keep_ratio(self, url, pixbuf):
@@ -769,7 +771,10 @@ class PodcastListModel(Gtk.ListStore):
 
     def _get_pill_image(self, channel, count_downloaded, count_unplayed):
         if count_unplayed > 0 or count_downloaded > 0:
-            return draw.draw_pill_pixbuf('{:n}'.format(count_unplayed), '{:n}'.format(count_downloaded), widget=self.widget)
+            return draw.draw_pill_pixbuf('{:n}'.format(count_unplayed),
+                                         '{:n}'.format(count_downloaded),
+                                         widget=self.widget,
+                                         scale=self._scale)
         else:
             return None
 


### PR DESCRIPTION
Fix the cover images and "pill" looking blurry on high resolution displays. For example, when the adaptive version of gPodder is used with Phosh on the PinePhone.

Get the scale parameter from the gtkTreeView object and pass it down to the cover thumbnail size and to draw_text_pill. If the scaling is not 1, then use the new draw_iconcell_scale() function to draw the pixbuf with high resolution.

## Screenshots

Before and after, with scaling factor 2:

### Regular UI
<details>

![](https://ollieparanoid.github.io/img/2021-07-23/gpodder-fix-scaling/regular_old.png)
</details>
<details>

![](https://ollieparanoid.github.io/img/2021-07-23/gpodder-fix-scaling/regular_new.png)
</details>

### Adaptive UI (@tpikonen)
<details>

![](https://ollieparanoid.github.io/img/2021-07-23/gpodder-fix-scaling/adaptive_old.png)
</details>

<details>

![](https://ollieparanoid.github.io/img/2021-07-23/gpodder-fix-scaling/adaptive_new.png)
</details>