### PR TITLE
bin/gpodder: add -c / --close-after-startup option

### DIFF
--- a/bin/gpodder
+++ b/bin/gpodder
@@ -113,10 +113,14 @@ def main():
                            action="store_true", dest="quiet", default=False,
                            help=_("reduce warnings on the console"))
 
+    grp_advanced = OptionGroup(parser, "Advanced")
+    parser.add_option_group(grp_advanced)
+
+    grp_advanced.add_option("--close-after-startup", action="store_true",
+                            help=_("exit once started up (for profiling)"))
+
     # On Mac OS X, support the "psn" parameter for compatibility (bug 939)
     if gpodder.ui.osx:
-        grp_advanced = OptionGroup(parser, "Advanced")
-        parser.add_option_group(grp_advanced)
         grp_advanced.add_option('-p', '--psn', dest='macpsn', metavar='PSN',
                                 help=_('Mac OS X application process number'))
 

--- a/bin/gpodder
+++ b/bin/gpodder
@@ -33,7 +33,7 @@ import os.path
 import platform
 import subprocess
 import sys
-from optparse import OptionParser
+from optparse import OptionGroup, OptionParser
 
 logger = logging.getLogger(__name__)
 
@@ -95,21 +95,30 @@ def main():
 
     parser = OptionParser(usage=s_usage, version=s_version)
 
-    parser.add_option("-v", "--verbose",
-                      action="store_true", dest="verbose", default=False,
-                      help=_("print logging output on the console"))
+    grp_subscriptions = OptionGroup(parser, "Subscriptions")
+    parser.add_option_group(grp_subscriptions)
 
-    parser.add_option("-q", "--quiet",
-                      action="store_true", dest="quiet", default=False,
-                      help=_("reduce warnings on the console"))
+    grp_subscriptions.add_option('-s', '--subscribe', dest='subscribe',
+                                 metavar='URL',
+                                 help=_('subscribe to the feed at URL'))
 
-    parser.add_option('-s', '--subscribe', dest='subscribe', metavar='URL',
-                      help=_('subscribe to the feed at URL'))
+    grp_logging = OptionGroup(parser, "Logging")
+    parser.add_option_group(grp_logging)
+
+    grp_logging.add_option("-v", "--verbose",
+                           action="store_true", dest="verbose", default=False,
+                           help=_("print logging output on the console"))
+
+    grp_logging.add_option("-q", "--quiet",
+                           action="store_true", dest="quiet", default=False,
+                           help=_("reduce warnings on the console"))
 
     # On Mac OS X, support the "psn" parameter for compatibility (bug 939)
     if gpodder.ui.osx:
-        parser.add_option('-p', '--psn', dest='macpsn', metavar='PSN',
-                          help=_('Mac OS X application process number'))
+        grp_advanced = OptionGroup(parser, "Advanced")
+        parser.add_option_group(grp_advanced)
+        grp_advanced.add_option('-p', '--psn', dest='macpsn', metavar='PSN',
+                                help=_('Mac OS X application process number'))
 
     options, args = parser.parse_args(sys.argv)
 

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
 import threading
 import time
@@ -252,6 +253,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
             if diff > (60 * 60 * 24) * self.config.software_update.interval:
                 self.config.software_update.last_check = int(time.time())
                 self.check_for_updates(silent=True)
+
+        if self.options.close_after_startup:
+            logger.warning("Startup done, closing (--close-after-startup)")
+            self.core.db.close()
+            sys.exit()
 
     def create_actions(self):
         g = self.gPodder


### PR DESCRIPTION
Group command-line options into rest / logging / advanced, and add a new option to advanced that helps with profiling startup performance. (I used this together with a profiler to figure out that it spends most of the time resizing covers, which lead to #1105).