### PR TITLE
Fix missing extension when downloading youtube-dl format=worstaudio

### DIFF
--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -152,6 +152,7 @@ _MIME_TYPE_LIST = [
     ('.wmv', 'video/x-ms-wmv'),
     ('.opus', 'audio/opus'),
     ('.webm', 'video/webm'),
+    ('.webm', 'audio/webm'),
 ]
 
 _MIME_TYPES = dict((k, v) for v, k in _MIME_TYPE_LIST)


### PR DESCRIPTION
See https://www.youtube.com/channel/UCPiFOcskeiOj0jHz3YCWDBQ with settings:

```
 "youtube": {
    "preferred_fmt_id": 0,
    "preferred_fmt_ids": [
      "worstaudio"
    ]
  }
```

The mime type reported by youtube-dl is 'audio/webm', then the end filename doesn't have an extension.