### PR TITLE
Allow re-download of failed episodes without manually canceling them.

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -460,6 +460,8 @@ class DownloadQueueManager(object):
     def queue_task(self, task):
         """Marks a task as queued
         """
+        if task.status != DownloadTask.QUEUED:
+            self.tasks.queue_task(task)
         self.__spawn_threads()
 
 

--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -161,6 +161,10 @@ class DownloadStatusModel:
         iter = self.list.append()
         self.request_update(iter, task)
 
+    def queue_task(self, task):
+        task.status = task.QUEUED
+        self.work_queue.add_task(task)
+
     def register_task(self, task):
         self.work_queue.add_task(task)
         util.idle_add(self.__add_new_task, task)


### PR DESCRIPTION
Fixes #1117.

@blushingpenguin Is there a better way to handle this?