### PR TITLE
Allow '+' as a version number separator

### DIFF
--- a/src/gpodder/__init__.py
+++ b/src/gpodder/__init__.py
@@ -26,7 +26,10 @@ __copyright__ = '© 2005-2021 The gPodder Team'
 __license__ = 'GNU General Public License, version 3 or later'
 __url__ = 'http://gpodder.org/'
 
-__version_info__ = tuple(int(x) for x in __version__.split('.'))
+# Use public version part for __version_info__, see PEP 440
+__public_version__, __local_version__ = next(
+    (v[0], v[1] if len(v) > 1 else '') for v in (__version__.split('+'),))
+__version_info__ = tuple(int(x) for x in __public_version__.split('.'))
 
 import gettext
 import locale

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1853,7 +1853,11 @@ def get_update_info():
     days_since_release = (datetime.datetime.today() - release_parsed).days
 
     def convert(s):
-        return tuple(int(x) for x in s.split('.'))
+        # Use both public and local version label, see PEP 440
+        pubv, locv = next(
+            (v[0], v[1] if len(v) > 1 else '') for v in (s.split('+'),))
+        return tuple(int(x) if x.isdigit() else x.lower()
+            for x in pubv.split('.') + (locv.split('.') if locv else []))
 
     up_to_date = (convert(gpodder.__version__) >= convert(latest_version))
 


### PR DESCRIPTION
The adaptive branch currently has version numbers like '3.10.21+1', which breaks when trying to split() the version string on periods. This PR fixes or removes the version string splitting.

The unused variable `__version_info__` is removed, and re.split() is used in util.get_update_info() which allows splitting also on '+'.