### PR TITLE
Add option to require control click to sort episodes.

### DIFF
--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -209,6 +209,10 @@
           <attribute name="action">win.viewAlwaysShowNewEpisodes</attribute>
           <attribute name="label" translatable="yes">Always show New Episodes</attribute>
         </item>
+        <item>
+          <attribute name="action">win.viewCtrlClickToSortEpisodes</attribute>
+          <attribute name="label" translatable="yes">Require control click to sort episodes</attribute>
+        </item>
       </section>
       <submenu id="menuViewColumns">
         <attribute name="label" translatable="yes">Visible columns</attribute>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -169,6 +169,7 @@ defaults = {
                 'view_mode': 1,
                 'columns': int('110', 2),  # bitfield of visible columns
                 'always_show_new': True,
+                'ctrl_click_to_sort': False,
             },
 
             'download_list': {


### PR DESCRIPTION
This avoids accidental sorting when trying to select the top episode.

Requested by Fourhundred Thecat on mailing list, but is also an issue I've run into many times.