### PR TITLE
Remove GTK stock items and other deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ PyPI. With this, you get a self-contained gPodder CLI codebase.
 ### GTK3 UI - Additional Dependencies
 
 - [PyGObject](https://wiki.gnome.org/PyGObject) 3.22.0 or newer
-- [GTK+3](https://www.gtk.org/) 3.10 or newer
+- [GTK+3](https://www.gtk.org/) 3.16 or newer
 
 
 ### Optional Dependencies

--- a/share/gpodder/extensions/concatenate_videos.py
+++ b/share/gpodder/extensions/concatenate_videos.py
@@ -38,8 +38,8 @@ class gPodderExtension:
         dlg = Gtk.FileChooserDialog(title=_('Save video'),
                 parent=self.gpodder.get_dialog_parent(),
                 action=Gtk.FileChooserAction.SAVE)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        dlg.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+        dlg.add_button('_Save', Gtk.ResponseType.OK)
 
         if dlg.run() == Gtk.ResponseType.OK:
             filename = dlg.get_filename()

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -37,7 +37,7 @@
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Download</property>
                 <property name="use-underline">True</property>
-                <property name="stock-id">gtk-go-down</property>
+                <property name="icon-name">go-down</property>
                 <signal name="clicked" handler="on_download_selected_episodes" swapped="no"/>
               </object>
               <packing>
@@ -51,7 +51,8 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
-                <property name="stock-id">gtk-media-play</property>
+                <property name="label" translatable="yes">Play</property>
+                <property name="icon-name">media-playback-start</property>
                 <signal name="clicked" handler="on_playback_selected_episodes" swapped="no"/>
               </object>
               <packing>
@@ -67,7 +68,7 @@
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Cancel</property>
                 <property name="use-underline">True</property>
-                <property name="stock-id">gtk-cancel</property>
+                <property name="icon-name">gtk-cancel</property>
                 <signal name="clicked" handler="on_item_cancel_download_activate" swapped="no"/>
               </object>
               <packing>
@@ -91,7 +92,7 @@
                 <property name="can-focus">False</property>
                 <property name="action-name">app.preferences</property>
                 <property name="label" translatable="yes">Preferences</property>
-                <property name="stock-id">gtk-preferences</property>
+                <property name="icon-name">gtk-preferences</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -113,7 +114,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Quit</property>
-                <property name="stock-id">gtk-quit</property>
+                <property name="icon-name">gtk-quit</property>
                 <signal name="clicked" handler="on_gPodder_delete_event" swapped="no"/>
               </object>
               <packing>
@@ -192,7 +193,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>
-                                <property name="secondary-icon-stock">gtk-close</property>
+                                <property name="secondary-icon-name">gtk-close</property>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
@@ -276,7 +277,7 @@
                                       <object class="GtkImage" id="image3209">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="stock">gtk-cancel</property>
+                                        <property name="icon-name">gtk-cancel</property>
                                       </object>
                                     </child>
                                   </object>
@@ -423,7 +424,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>
-                                <property name="secondary-icon-stock">gtk-close</property>
+                                <property name="secondary-icon-name">gtk-close</property>
                               </object>
                               <packing>
                                 <property name="left-attach">1</property>

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -384,7 +384,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="has-tooltip">True</property>
-                                <property name="rules-hint">True</property>
                                 <property name="enable-search">False</property>
                                 <property name="rubber-banding">True</property>
                                 <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -190,7 +190,7 @@
                             <child>
                               <object class="GtkEntry" id="entry_search_podcasts">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>
                                 <property name="secondary-icon-stock">gtk-close</property>
                               </object>
@@ -421,7 +421,7 @@
                             <child>
                               <object class="GtkEntry" id="entry_search_episodes">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>
                                 <property name="secondary-icon-stock">gtk-close</property>
                               </object>

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -1,54 +1,44 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <!-- interface-requires gtk+ 3.10 -->
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">10240</property>
     <property name="lower">0.5</property>
-    <property name="page_increment">0</property>
-    <property name="step_increment">0.5</property>
-    <property name="page_size">0</property>
+    <property name="upper">10240</property>
+    <property name="step-increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
-    <property name="upper">16</property>
     <property name="lower">1</property>
-    <property name="page_increment">0</property>
-    <property name="step_increment">1</property>
-    <property name="page_size">0</property>
+    <property name="upper">16</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkApplicationWindow" id="gPodder">
     <property name="name">gPodder</property>
-    <property name="application">app</property>
-    <property name="visible">False</property>
+    <property name="can-focus">False</property>
     <property name="title">gPodder</property>
-    <property name="window_position">GTK_WIN_POS_CENTER</property>
-    <property name="modal">False</property>
-    <property name="destroy_with_parent">False</property>
-    <property name="skip_taskbar_hint">False</property>
-    <property name="skip_pager_hint">False</property>
-    <property name="type_hint">GDK_WINDOW_TYPE_HINT_NORMAL</property>
-    <property name="focus_on_map">True</property>
-    <property name="urgency_hint">False</property>
-    <signal handler="on_gPodder_delete_event" name="delete-event"/>
+    <property name="window-position">center</property>
+    <signal name="delete-event" handler="on_gPodder_delete_event" swapped="no"/>
     <child>
+      <!-- n-columns=3 n-rows=3 -->
       <object class="GtkGrid" id="vMain">
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkToolbar" id="toolbar">
             <property name="visible">True</property>
-            <property name="show_arrow">True</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkToolButton" id="toolDownload">
                 <property name="visible">True</property>
-                <property name="label" translatable="yes">Download</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-go-down</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">True</property>
                 <property name="sensitive">False</property>
-                <signal handler="on_download_selected_episodes" name="clicked"/>
+                <property name="can-focus">False</property>
+                <property name="is-important">True</property>
+                <property name="label" translatable="yes">Download</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-go-down</property>
+                <signal name="clicked" handler="on_download_selected_episodes" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -58,12 +48,11 @@
             <child>
               <object class="GtkToolButton" id="toolPlay">
                 <property name="visible">True</property>
-                <property name="stock_id">gtk-media-play</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">True</property>
                 <property name="sensitive">False</property>
-                <signal handler="on_playback_selected_episodes" name="clicked"/>
+                <property name="can-focus">False</property>
+                <property name="is-important">True</property>
+                <property name="stock-id">gtk-media-play</property>
+                <signal name="clicked" handler="on_playback_selected_episodes" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -73,14 +62,13 @@
             <child>
               <object class="GtkToolButton" id="toolCancel">
                 <property name="visible">True</property>
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-cancel</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">True</property>
                 <property name="sensitive">False</property>
-                <signal handler="on_item_cancel_download_activate" name="clicked"/>
+                <property name="can-focus">False</property>
+                <property name="is-important">True</property>
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-cancel</property>
+                <signal name="clicked" handler="on_item_cancel_download_activate" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -90,8 +78,7 @@
             <child>
               <object class="GtkSeparatorToolItem" id="toolbutton3">
                 <property name="visible">True</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
+                <property name="can-focus">False</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -101,12 +88,10 @@
             <child>
               <object class="GtkToolButton" id="toolPreferences">
                 <property name="visible">True</property>
-                <property name="stock_id">gtk-preferences</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">False</property>
+                <property name="can-focus">False</property>
                 <property name="action-name">app.preferences</property>
                 <property name="label" translatable="yes">Preferences</property>
+                <property name="stock-id">gtk-preferences</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -116,8 +101,7 @@
             <child>
               <object class="GtkSeparatorToolItem" id="toolbutton2">
                 <property name="visible">True</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
+                <property name="can-focus">False</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -127,12 +111,10 @@
             <child>
               <object class="GtkToolButton" id="toolQuit">
                 <property name="visible">True</property>
-                <property name="stock_id">gtk-quit</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">False</property>
-                <signal handler="on_gPodder_delete_event" name="clicked"/>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Quit</property>
+                <property name="stock-id">gtk-quit</property>
+                <signal name="clicked" handler="on_gPodder_delete_event" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -140,349 +122,681 @@
               </packing>
             </child>
           </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
+          </packing>
         </child>
         <child>
+          <!-- n-columns=3 n-rows=3 -->
           <object class="GtkGrid" id="hboxContainer">
-            <property name="border_width">5</property>
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
+            <property name="border-width">5</property>
             <child>
               <object class="GtkNotebook" id="wNotebook">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="show_tabs">True</property>
-                <property name="show_border">True</property>
-                <property name="tab_pos">GTK_POS_TOP</property>
-                <property name="scrollable">False</property>
-                <property name="enable_popup">False</property>
-                <signal handler="on_wNotebook_switch_page" name="switch_page"/>
+                <property name="can-focus">True</property>
+                <signal name="switch-page" handler="on_wNotebook_switch_page" swapped="no"/>
                 <child>
                   <object class="GtkPaned" id="channelPaned">
-                    <property name="border_width">5</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">True</property>
+                    <property name="border-width">5</property>
                     <child>
+                      <!-- n-columns=3 n-rows=3 -->
                       <object class="GtkGrid" id="vboxChannelNavigator">
                         <property name="visible">True</property>
-                        <property name="row_spacing">5</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
+                        <property name="row-spacing">5</property>
                         <child>
                           <object class="GtkScrolledWindow" id="scrolledwindow6">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="vexpand">True</property>                            
-                            <property name="shadow_type">GTK_SHADOW_IN</property>
-                            <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                            <property name="can-focus">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="shadow-type">in</property>
                             <child>
                               <object class="GtkTreeView" id="treeChannels">
                                 <property name="name">treeChannels</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="headers_visible">False</property>
-                                <property name="rules_hint">False</property>
+                                <property name="can-focus">True</property>
                                 <property name="has-tooltip">True</property>
-                                <property name="reorderable">False</property>
-                                <property name="enable_search">True</property>
-                                <property name="fixed_height_mode">False</property>
-                                <property name="hover_selection">False</property>
-                                <property name="hover_expand">False</property>
-                                <signal handler="on_treeChannels_row_activated" name="row_activated"/>
-                                <signal handler="on_treeChannels_cursor_changed" name="cursor_changed"/>
-                                <signal handler="on_treeview_query_tooltip" name="query-tooltip"/>
-                                <signal handler="on_treeview_expose_event" name="draw"/>
-                                <signal handler="on_treeview_button_pressed" name="button-press-event"/>
-                                <signal handler="on_treeview_podcasts_button_released" name="button-release-event"/>
+                                <property name="headers-visible">False</property>
+                                <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
+                                <signal name="button-release-event" handler="on_treeview_podcasts_button_released" swapped="no"/>
+                                <signal name="cursor-changed" handler="on_treeChannels_cursor_changed" swapped="no"/>
+                                <signal name="draw" handler="on_treeview_expose_event" swapped="no"/>
+                                <signal name="query-tooltip" handler="on_treeview_query_tooltip" swapped="no"/>
+                                <signal name="row-activated" handler="on_treeChannels_row_activated" swapped="no"/>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hbox_search_podcasts">
-                            <property name="column_spacing">6</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">6</property>
                             <child>
                               <object class="GtkEntry" id="entry_search_podcasts">
-                                <property name="hexpand">True</property>
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="hexpand">True</property>
                                 <property name="secondary-icon-stock">gtk-close</property>
                               </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkGrid" id="vbox42">
-                            <property name="visible">True</property>
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkButton" id="btnUpdateFeeds">
-                                <property name="label" translatable="yes">Check for new episodes</property>
-                                <property name="can_focus">True</property>
-                                <property name="focus_on_click">True</property>
-                                <property name="action-name">win.update</property>
-                                <property name="hexpand">True</property>
-                              </object>
                               <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
                               </packing>
                             </child>
                             <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <!-- n-columns=3 n-rows=3 -->
+                          <object class="GtkGrid" id="vbox42">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkButton" id="btnUpdateFeeds">
+                                <property name="label" translatable="yes">Check for new episodes</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="action-name">win.update</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <!-- n-columns=3 n-rows=3 -->
                               <object class="GtkGrid" id="hboxUpdateFeeds">
-                                <property name="column_spacing">6</property>
-                                <property name="orientation">horizontal</property>
+                                <property name="can-focus">False</property>
+                                <property name="column-spacing">6</property>
                                 <child>
                                   <object class="GtkProgressBar" id="pbFeedUpdate">
+                                    <property name="can-focus">False</property>
                                     <property name="hexpand">True</property>
-                                    <property name="pulse_step">0.10000000149</property>
+                                    <property name="pulse-step">0.10000000149</property>
                                     <property name="show-text">True</property>
-                                    <property name="ellipsize">PANGO_ELLIPSIZE_MIDDLE</property>
+                                    <property name="ellipsize">middle</property>
                                   </object>
                                   <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="btnCancelFeedUpdate">
-                                    <property name="can_focus">True</property>
-                                    <property name="focus_on_click">True</property>
-                                    <signal handler="on_btnCancelFeedUpdate_clicked" name="clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <signal name="clicked" handler="on_btnCancelFeedUpdate_clicked" swapped="no"/>
                                     <child>
                                       <object class="GtkImage" id="image3209">
                                         <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-cancel</property>
-                                        <property name="icon_size">4</property>
                                       </object>
                                     </child>
                                   </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">1</property>
                               </packing>
                             </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
-                        <property name="shrink">False</property>
                         <property name="resize">False</property>
+                        <property name="shrink">False</property>
                       </packing>
                     </child>
                     <child>
+                      <!-- n-columns=3 n-rows=3 -->
                       <object class="GtkGrid" id="vbox_episode_list">
                         <property name="visible">True</property>
-                        <property name="row_spacing">6</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
+                        <property name="row-spacing">6</property>
                         <child>
                           <object class="GtkScrolledWindow" id="scrollAvailable">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="shadow_type">GTK_SHADOW_IN</property>
-                            <property name="hexpand">True</property>                            
-                            <property name="vexpand">True</property>                            
-                            <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                            <property name="can-focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="shadow-type">in</property>
                             <child>
                               <object class="GtkTreeView" id="treeAvailable">
                                 <property name="name">treeAvailable</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="headers_visible">True</property>
-                                <property name="rules_hint">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="has-tooltip">True</property>
+                                <property name="rules-hint">True</property>
+                                <property name="enable-search">False</property>
                                 <property name="rubber-banding">True</property>
-                                <property name="reorderable">False</property>
-                                <property name="enable_search">False</property>
-                                <property name="fixed_height_mode">False</property>
-                                <property name="hover_selection">False</property>
-                                <property name="hover_expand">False</property>
-                                <signal handler="on_treeAvailable_row_activated" name="row_activated"/>
-                                <signal handler="on_treeview_query_tooltip" name="query-tooltip"/>
-                                <signal handler="on_treeview_expose_event" name="draw"/>
-                                <signal handler="on_treeview_button_pressed" name="button-press-event"/>
-                                <signal handler="on_treeview_episodes_button_released" name="button-release-event"/>
+                                <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
+                                <signal name="button-release-event" handler="on_treeview_episodes_button_released" swapped="no"/>
+                                <signal name="draw" handler="on_treeview_expose_event" swapped="no"/>
+                                <signal name="query-tooltip" handler="on_treeview_query_tooltip" swapped="no"/>
+                                <signal name="row-activated" handler="on_treeAvailable_row_activated" swapped="no"/>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hbox_search_episodes">
-                            <property name="column_spacing">6</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label_search_episodes">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Filter:</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkEntry" id="entry_search_episodes">
-                                <property name="hexpand">True</property>
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="hexpand">True</property>
                                 <property name="secondary-icon-stock">gtk-close</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="resize">True</property>
+                        <property name="shrink">False</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child type="tab">
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Podcasts</property>
+                  </object>
+                  <packing>
+                    <property name="tab-fill">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <!-- n-columns=3 n-rows=3 -->
+                  <object class="GtkGrid" id="vboxDownloadStatusWidgets">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
+                    <property name="orientation">vertical</property>
+                    <property name="row-spacing">5</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow-type">in</property>
+                        <child>
+                          <object class="GtkTreeView" id="treeDownloads">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="headers-visible">False</property>
+                            <property name="reorderable">True</property>
+                            <property name="rubber-banding">True</property>
+                            <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
+                            <signal name="button-release-event" handler="on_treeview_downloads_button_released" swapped="no"/>
+                            <signal name="draw" handler="on_treeview_expose_event" swapped="no"/>
+                            <signal name="row-activated" handler="on_treeDownloads_row_activated" swapped="no"/>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="shrink">False</property>
-                        <property name="resize">True</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
-                  </object>
-                  <packing>
-                    <property name="tab_expand">False</property>
-                    <property name="tab_fill">True</property>
-                  </packing>
-                </child>
-                <child type="tab">
-                  <object class="GtkLabel" id="label2">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Podcasts</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkGrid" id="vboxDownloadStatusWidgets">
-                    <property name="border_width">5</property>
-                    <property name="visible">True</property>
-                    <property name="row_spacing">5</property>
-                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="shadow_type">GTK_SHADOW_IN</property>
-                        <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-                        <child>
-                          <object class="GtkTreeView" id="treeDownloads">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="headers_visible">False</property>
-                            <property name="rules_hint">False</property>
-                            <property name="rubber-banding">True</property>
-                            <property name="reorderable">True</property>
-                            <property name="enable_search">True</property>
-                            <property name="fixed_height_mode">False</property>
-                            <property name="hover_selection">False</property>
-                            <property name="hover_expand">False</property>
-                            <signal handler="on_treeDownloads_row_activated" name="row_activated"/>
-                            <signal handler="on_treeview_expose_event" name="draw"/>
-                            <signal handler="on_treeview_button_pressed" name="button-press-event"/>
-                            <signal handler="on_treeview_downloads_button_released" name="button-release-event"/>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
+                      <!-- n-columns=3 n-rows=3 -->
                       <object class="GtkGrid" id="hboxDownloadSettings">
-                        <property name="border_width">5</property>
                         <property name="visible">True</property>
-                        <property name="column_spacing">10</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can-focus">False</property>
+                        <property name="border-width">5</property>
+                        <property name="column-spacing">10</property>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hboxDownloadLimit">
                             <property name="visible">True</property>
-                            <property name="column_spacing">5</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">5</property>
                             <child>
                               <object class="GtkCheckButton" id="cbLimitDownloads">
                                 <property name="label" translatable="yes">Limit rate to</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_cbLimitDownloads_toggled"/>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_cbLimitDownloads_toggled" swapped="no"/>
                               </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spinLimitDownloads">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="invisible_char">&#x25CF;</property>
-                                <property name="climb_rate">1</property>
-                                <property name="digits">1</property>
+                                <property name="can-focus">True</property>
+                                <property name="invisible-char">●</property>
                                 <property name="adjustment">adjustment1</property>
+                                <property name="climb-rate">1</property>
+                                <property name="digits">1</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="labelLimitRate">
                                 <property name="visible">True</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">KiB/s</property>
+                                <property name="xalign">0</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="DownloadSettingsSpacer">
                             <property name="visible">True</property>
-                            <property name="hexpand">True</property>                            
+                            <property name="can-focus">False</property>
+                            <property name="hexpand">True</property>
                           </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hboxDownloadRate">
                             <property name="visible">True</property>
-                            <property name="column_spacing">5</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">5</property>
                             <child>
                               <object class="GtkCheckButton" id="cbMaxDownloads">
                                 <property name="label" translatable="yes">Limit downloads to</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_cbMaxDownloads_toggled"/>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_cbMaxDownloads_toggled" swapped="no"/>
                               </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spinMaxDownloads">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="invisible_char">&#x25CF;</property>
-                                <property name="climb_rate">1</property>
+                                <property name="can-focus">True</property>
+                                <property name="invisible-char">●</property>
                                 <property name="adjustment">adjustment2</property>
+                                <property name="climb-rate">1</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="tab_expand">False</property>
-                    <property name="tab_fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child type="tab">
                   <object class="GtkLabel" id="labelDownloads">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Progress</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
                   </object>
+                  <packing>
+                    <property name="position">1</property>
+                    <property name="tab-fill">False</property>
+                  </packing>
                 </child>
               </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
           </object>
           <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">1</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
     </child>

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -20,7 +20,7 @@
     <property name="window-position">center</property>
     <signal name="delete-event" handler="on_gPodder_delete_event" swapped="no"/>
     <child>
-      <!-- n-columns=3 n-rows=3 -->
+      <!-- n-columns=1 n-rows=2 -->
       <object class="GtkGrid" id="vMain">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -129,7 +129,7 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=3 -->
+          <!-- n-columns=1 n-rows=1 -->
           <object class="GtkGrid" id="hboxContainer">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -147,7 +147,7 @@
                     <property name="can-focus">True</property>
                     <property name="border-width">5</property>
                     <child>
-                      <!-- n-columns=3 n-rows=3 -->
+                      <!-- n-columns=1 n-rows=3 -->
                       <object class="GtkGrid" id="vboxChannelNavigator">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -184,7 +184,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=1 n-rows=1 -->
                           <object class="GtkGrid" id="hbox_search_podcasts">
                             <property name="can-focus">False</property>
                             <property name="column-spacing">6</property>
@@ -200,30 +200,6 @@
                                 <property name="top-attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -231,7 +207,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=1 n-rows=2 -->
                           <object class="GtkGrid" id="vbox42">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -251,7 +227,7 @@
                               </packing>
                             </child>
                             <child>
-                              <!-- n-columns=3 n-rows=3 -->
+                              <!-- n-columns=2 n-rows=1 -->
                               <object class="GtkGrid" id="hboxUpdateFeeds">
                                 <property name="can-focus">False</property>
                                 <property name="column-spacing">6</property>
@@ -286,77 +262,17 @@
                                     <property name="top-attach">0</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
                                 <property name="top-attach">1</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
                             <property name="top-attach">2</property>
                           </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -365,7 +281,7 @@
                       </packing>
                     </child>
                     <child>
-                      <!-- n-columns=3 n-rows=3 -->
+                      <!-- n-columns=1 n-rows=2 -->
                       <object class="GtkGrid" id="vbox_episode_list">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -403,7 +319,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=2 n-rows=1 -->
                           <object class="GtkGrid" id="hbox_search_episodes">
                             <property name="can-focus">False</property>
                             <property name="column-spacing">6</property>
@@ -430,53 +346,11 @@
                                 <property name="top-attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
                             <property name="top-attach">1</property>
                           </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -747,56 +621,11 @@
                 <property name="top-attach">0</property>
               </packing>
             </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
           </object>
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">1</property>
           </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
         </child>
       </object>
     </child>

--- a/share/gpodder/ui/gtk/gpodderaddpodcast.ui
+++ b/share/gpodder/ui/gtk/gpodderaddpodcast.ui
@@ -19,11 +19,10 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btn_close">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btn_close_clicked" swapped="no"/>
               </object>
               <packing>
@@ -34,12 +33,11 @@
             </child>
             <child>
               <object class="GtkButton" id="btn_add">
-                <property name="label">gtk-add</property>
+                <property name="label" translatable="yes">Add</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btn_add_clicked" swapped="no"/>
               </object>
               <packing>
@@ -90,11 +88,10 @@
             </child>
             <child>
               <object class="GtkButton" id="btn_paste">
-                <property name="label">gtk-paste</property>
+                <property name="label" translatable="yes">Paste</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btn_paste_clicked" swapped="no"/>
               </object>
               <packing>

--- a/share/gpodder/ui/gtk/gpodderaddpodcast.ui
+++ b/share/gpodder/ui/gtk/gpodderaddpodcast.ui
@@ -1,92 +1,113 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkDialog" id="gPodderAddPodcast">
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Add a new podcast</property>
-    <property name="type_hint">dialog</property>
     <property name="modal">True</property>
-    <property name="transient-for">parent_widget</property>
-    <property name="default_width">400</property>
+    <property name="default-width">400</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="vboxmain">
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="hbuttonbox">
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+          <object class="GtkButtonBox" id="hbuttonbox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btn_close">
-                <property name="visible">True</property>
                 <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_btn_close_clicked" name="clicked"/>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_btn_close_clicked" swapped="no"/>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_add">
-                <property name="visible">True</property>
                 <property name="label">gtk-add</property>
-                <property name="sensitive">false</property>
-                <property name="use_stock">True</property>
-                <signal handler="on_btn_add_clicked" name="clicked"/>
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_btn_add_clicked" swapped="no"/>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">GTK_PACK_END</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="hboxurlentry">
-            <property name="border_width">10</property>
             <property name="visible">True</property>
-            <property name="homogeneous">False</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">10</property>
             <property name="spacing">5</property>
-            <property name="orientation">horizontal</property>
             <child>
               <object class="GtkLabel" id="label_add">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">URL:</property>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_url">
                 <property name="visible">True</property>
-                <property name="has_focus">True</property>
-                <property name="activates_default">True</property>
-                <signal handler="on_entry_url_changed" name="changed"/>
+                <property name="can-focus">False</property>
+                <property name="has-focus">True</property>
+                <property name="activates-default">True</property>
+                <signal name="changed" handler="on_entry_url_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_paste">
                 <property name="label">gtk-paste</property>
-                <property name="use_stock">True</property>
                 <property name="visible">True</property>
-                <signal handler="on_btn_paste_clicked" name="clicked"/>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_btn_paste_clicked" swapped="no"/>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/share/gpodder/ui/gtk/gpodderchannel.ui
+++ b/share/gpodder/ui/gtk/gpodderchannel.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkDialog" id="gPodderChannel">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Channel Editor</property>

--- a/share/gpodder/ui/gtk/gpodderconfigeditor.ui
+++ b/share/gpodder/ui/gtk/gpodderconfigeditor.ui
@@ -1,153 +1,148 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkDialog" id="gPodderConfigEditor">
     <property name="visible">True</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">gPodder Configuration Editor</property>
-    <property name="window_position">GTK_WIN_POS_CENTER_ON_PARENT</property>
     <property name="modal">True</property>
-    <property name="transient-for">parent_widget</property>
-    <property name="default_width">750</property>
-    <property name="default_height">450</property>
-    <property name="destroy_with_parent">False</property>
-    <property name="skip_taskbar_hint">False</property>
-    <property name="skip_pager_hint">False</property>
-    <property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
-    <property name="focus_on_map">True</property>
-    <property name="urgency_hint">False</property>
-    <signal handler="on_gPodderConfigEditor_destroy" name="destroy"/>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">750</property>
+    <property name="default-height">450</property>
+    <property name="type-hint">dialog</property>
+    <signal name="destroy" handler="on_gPodderConfigEditor_destroy" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox13">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox" id="vbox_for_episode_selector">
-            <property name="border_width">5</property>
             <property name="visible">True</property>
-            <property name="spacing">5</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">5</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
             <child>
               <object class="GtkBox" id="hbox38">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
+                <property name="can-focus">False</property>
                 <property name="spacing">6</property>
-                <property name="orientation">horizontal</property>
                 <child>
                   <object class="GtkLabel" id="label121">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Search for:</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkEntry" id="entryFilter">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_focus">True</property>
-                    <property name="max_length">0</property>
-                    <property name="has_frame">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="activates_default">False</property>
-                    <signal handler="on_entryFilter_changed" name="changed"/>
+                    <property name="can-focus">True</property>
+                    <property name="has-focus">True</property>
+                    <property name="invisible-char">●</property>
+                    <signal name="changed" handler="on_entryFilter_changed" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="btnShowAll">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
                     <property name="label" translatable="yes">Show All</property>
-                    <property name="use_underline">True</property>
-                    <property name="focus_on_click">True</property>
-                    <signal handler="on_btnShowAll_clicked" name="clicked"/>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="use-underline">True</property>
+                    <signal name="clicked" handler="on_btnShowAll_clicked" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow8">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                <property name="shadow_type">GTK_SHADOW_IN</property>
-                <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                <property name="can-focus">True</property>
+                <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkTreeView" id="configeditor">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="headers_visible">True</property>
-                    <property name="rules_hint">False</property>
-                    <property name="reorderable">False</property>
-                    <property name="enable_search">True</property>
-                    <property name="fixed_height_mode">False</property>
-                    <property name="hover_selection">False</property>
-                    <property name="hover_expand">False</property>
+                    <property name="can-focus">True</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
           <object class="GtkHButtonBox" id="hbuttonbox2">
             <property name="visible">True</property>
-            <property name="layout_style">GTK_BUTTONBOX_END</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btnClose">
-                <property name="visible">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="can_focus">True</property>
                 <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
-                <property name="focus_on_click">True</property>
-                <signal handler="on_btnClose_clicked" name="clicked"/>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_btnClose_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/share/gpodder/ui/gtk/gpodderconfigeditor.ui
+++ b/share/gpodder/ui/gtk/gpodderconfigeditor.ui
@@ -117,7 +117,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox2">
+          <object class="GtkButtonBox" id="hbuttonbox2">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="layout-style">end</property>

--- a/share/gpodder/ui/gtk/gpodderconfigeditor.ui
+++ b/share/gpodder/ui/gtk/gpodderconfigeditor.ui
@@ -123,13 +123,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btnClose">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="has-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnClose_clicked" swapped="no"/>
               </object>
               <packing>

--- a/share/gpodder/ui/gtk/gpodderepisodeselector.ui
+++ b/share/gpodder/ui/gtk/gpodderepisodeselector.ui
@@ -1,130 +1,165 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkDialog" id="gPodderEpisodeSelector">
-    <property name="visible">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Select episodes</property>
-    <property name="window_position">GTK_WIN_POS_CENTER_ON_PARENT</property>
     <property name="modal">True</property>
-    <property name="transient-for">parent_widget</property>
-    <property name="destroy_with_parent">False</property>
-    <property name="skip_taskbar_hint">False</property>
-    <property name="skip_pager_hint">False</property>
-    <property name="type_hint">GDK_WINDOW_TYPE_HINT_DIALOG</property>
-    <property name="focus_on_map">True</property>
-    <property name="urgency_hint">False</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox10">
         <property name="visible">True</property>
-        <property name="homogeneous">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox" id="vbox_for_episode_selector">
-            <property name="border_width">5</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="hbox35">
             <property name="visible">True</property>
-            <property name="spacing">5</property>
-            <property name="orientation">vertical</property>
+            <property name="can-focus">False</property>
             <child>
-              <object class="GtkLabel" id="labelInstructions">
-                <property name="label">additional text</property>
-                <property name="use_underline">False</property>
-                <property name="use_markup">False</property>
-                <property name="wrap">False</property>
-                <property name="selectable">False</property>
-                <property name="xalign">0</property>
-                <property name="width_chars">-1</property>
-                <property name="single_line_mode">False</property>
+              <object class="GtkButton" id="btnRemoveAction">
+                <property name="label">Remove</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_remove_action_activate" swapped="no"/>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btnCancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btnOK">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox_for_episode_selector">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">5</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkLabel" id="labelInstructions">
+                <property name="can-focus">False</property>
+                <property name="label">additional text</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow7">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                <property name="shadow_type">GTK_SHADOW_IN</property>
-                <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                <property name="can-focus">True</property>
+                <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkTreeView" id="treeviewEpisodes">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_focus">True</property>
-                    <property name="headers_visible">False</property>
-                    <property name="rules_hint">False</property>
-                    <property name="reorderable">False</property>
-                    <property name="enable_search">False</property>
-                    <property name="fixed_height_mode">False</property>
-                    <property name="hover_selection">False</property>
-                    <property name="hover_expand">False</property>
-                    <signal name="row_activated" handler="on_row_activated"/>
+                    <property name="can-focus">True</property>
+                    <property name="has-focus">True</property>
+                    <property name="headers-visible">False</property>
+                    <property name="enable-search">False</property>
+                    <signal name="row-activated" handler="on_row_activated" swapped="no"/>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="hboxButtons">
                 <property name="visible">True</property>
-                <property name="homogeneous">False</property>
+                <property name="can-focus">False</property>
                 <property name="spacing">5</property>
-                <property name="orientation">horizontal</property>
                 <child>
                   <object class="GtkButton" id="btnCheckAll">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="focus_on_click">True</property>
-                    <signal handler="on_btnCheckAll_clicked" name="clicked"/>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <signal name="clicked" handler="on_btnCheckAll_clicked" swapped="no"/>
                     <child>
                       <object class="GtkAlignment" id="alignment22">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xscale">0</property>
                         <property name="yscale">0</property>
-                        <property name="top_padding">0</property>
-                        <property name="bottom_padding">0</property>
-                        <property name="left_padding">0</property>
-                        <property name="right_padding">0</property>
                         <child>
                           <object class="GtkBox" id="hbox34">
                             <property name="visible">True</property>
-                            <property name="homogeneous">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">2</property>
-                            <property name="orientation">horizontal</property>
                             <child>
                               <object class="GtkImage" id="image2636">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="stock">gtk-apply</property>
-                                <property name="icon_size">4</property>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="label107">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Select all</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_markup">False</property>
-                                <property name="wrap">False</property>
-                                <property name="selectable">False</property>
-                                <property name="width_chars">-1</property>
-                                <property name="single_line_mode">False</property>
+                                <property name="use-underline">True</property>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
@@ -133,59 +168,51 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="btnCheckNone">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="focus_on_click">True</property>
-                    <signal handler="on_btnCheckNone_clicked" name="clicked"/>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <signal name="clicked" handler="on_btnCheckNone_clicked" swapped="no"/>
                     <child>
                       <object class="GtkAlignment" id="alignment21">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="xscale">0</property>
                         <property name="yscale">0</property>
-                        <property name="top_padding">0</property>
-                        <property name="bottom_padding">0</property>
-                        <property name="left_padding">0</property>
-                        <property name="right_padding">0</property>
                         <child>
                           <object class="GtkBox" id="hbox33">
                             <property name="visible">True</property>
-                            <property name="homogeneous">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">2</property>
-                            <property name="orientation">horizontal</property>
                             <child>
                               <object class="GtkImage" id="image2635">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="stock">gtk-revert-to-saved</property>
-                                <property name="icon_size">4</property>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="label106">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Select none</property>
-                                <property name="use_underline">True</property>
-                                <property name="use_markup">False</property>
-                                <property name="wrap">False</property>
-                                <property name="selectable">False</property>
-                                <property name="width_chars">-1</property>
-                                <property name="single_line_mode">False</property>
+                                <property name="use-underline">True</property>
                               </object>
                               <packing>
-                                <property name="padding">0</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
@@ -194,101 +221,36 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="labelTotalSize">
                     <property name="visible">True</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="justify">GTK_JUSTIFY_RIGHT</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="justify">right</property>
                     <property name="xalign">1</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
                   </object>
                   <packing>
-                    <property name="padding">0</property>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="padding">0</property>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="padding">0</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
-          </packing>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkBox" id="hbox35">
-            <property name="visible">True</property>
-            <property name="homogeneous">False</property>
-            <property name="spacing">5</property>
-            <property name="orientation">horizontal</property>
-            <child>
-              <object class="GtkButton" id="btnRemoveAction">
-                <property name="visible">False</property>
-                <property name="can_focus">True</property>
-                <property name="label">Remove</property>
-                <property name="use_stock">True</property>
-                <property name="focus_on_click">True</property>
-                <signal handler="on_remove_action_activate" name="clicked"/>
-              </object>
-              <packing>
-                <property name="padding">0</property>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btnCancel">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <property name="focus_on_click">True</property>
-                <signal handler="on_btnCancel_clicked" name="clicked"/>
-              </object>
-              <packing>
-                <property name="padding">0</property>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btnOK">
-                <property name="visible">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="can_focus">True</property>
-                <property name="label">gtk-ok</property>
-                <property name="use_stock">True</property>
-                <property name="focus_on_click">True</property>
-                <signal handler="on_btnOK_clicked" name="clicked"/>
-              </object>
-              <packing>
-                <property name="padding">0</property>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="padding">0</property>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/share/gpodder/ui/gtk/gpodderepisodeselector.ui
+++ b/share/gpodder/ui/gtk/gpodderepisodeselector.ui
@@ -20,10 +20,9 @@
             <property name="can-focus">False</property>
             <child>
               <object class="GtkButton" id="btnRemoveAction">
-                <property name="label">Remove</property>
+                <property name="label" translatable="yes">Remove</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_remove_action_activate" swapped="no"/>
               </object>
               <packing>
@@ -34,11 +33,10 @@
             </child>
             <child>
               <object class="GtkButton" id="btnCancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -49,13 +47,12 @@
             </child>
             <child>
               <object class="GtkButton" id="btnOK">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">OK</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="has-default">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
               </object>
               <packing>

--- a/share/gpodder/ui/gtk/gpodderepisodeselector.ui
+++ b/share/gpodder/ui/gtk/gpodderepisodeselector.ui
@@ -124,42 +124,34 @@
                     <property name="receives-default">False</property>
                     <signal name="clicked" handler="on_btnCheckAll_clicked" swapped="no"/>
                     <child>
-                      <object class="GtkAlignment" id="alignment22">
+                      <object class="GtkBox" id="hbox34">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
+                        <property name="spacing">2</property>
                         <child>
-                          <object class="GtkBox" id="hbox34">
+                          <object class="GtkImage" id="image2636">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image2636">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="icon-name">gtk-apply</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label107">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Select all</property>
-                                <property name="use-underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="icon-name">gtk-apply</property>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label107">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Select all</property>
+                            <property name="use-underline">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                     </child>
@@ -177,42 +169,34 @@
                     <property name="receives-default">False</property>
                     <signal name="clicked" handler="on_btnCheckNone_clicked" swapped="no"/>
                     <child>
-                      <object class="GtkAlignment" id="alignment21">
+                      <object class="GtkBox" id="hbox33">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
+                        <property name="spacing">2</property>
                         <child>
-                          <object class="GtkBox" id="hbox33">
+                          <object class="GtkImage" id="image2635">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image2635">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="icon-name">gtk-revert-to-saved</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label106">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Select none</property>
-                                <property name="use-underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="icon-name">gtk-revert-to-saved</property>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label106">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Select none</property>
+                            <property name="use-underline">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                     </child>

--- a/share/gpodder/ui/gtk/gpodderepisodeselector.ui
+++ b/share/gpodder/ui/gtk/gpodderepisodeselector.ui
@@ -138,7 +138,7 @@
                               <object class="GtkImage" id="image2636">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="stock">gtk-apply</property>
+                                <property name="icon-name">gtk-apply</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -191,7 +191,7 @@
                               <object class="GtkImage" id="image2635">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="stock">gtk-revert-to-saved</property>
+                                <property name="icon-name">gtk-revert-to-saved</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/share/gpodder/ui/gtk/gpodderexporttolocalfolder.ui
+++ b/share/gpodder/ui/gtk/gpodderexporttolocalfolder.ui
@@ -1,35 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
+  <object class="GtkCheckButton" id="allsamefolder">
+    <property name="visible">True</property>
+    <property name="can-focus">True</property>
+    <property name="receives-default">False</property>
+    <property name="draw-indicator">True</property>
+  </object>
   <object class="GtkFileChooserDialog" id="gPodderExportToLocalFolder">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Select destination</property>
     <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
     <property name="action">save</property>
-    <property name="do_overwrite_confirmation">True</property>
-    <property name="preview_widget_active">False</property>
-    <property name="use_preview_label">False</property>
-    <property name="extra_widget">allsamefolder</property>
+    <property name="do-overwrite-confirmation">True</property>
+    <property name="extra-widget">allsamefolder</property>
+    <property name="preview-widget-active">False</property>
+    <property name="use-preview-label">False</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btnOK">
                 <property name="label">gtk-save</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
               </object>
               <packing>
@@ -42,9 +49,9 @@
               <object class="GtkButton" id="btnCancel">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -62,16 +69,9 @@
         </child>
       </object>
     </child>
-    <!-- to be recognized by the embedded GtkFileChooser -->
     <action-widgets>
       <action-widget response="-3">btnOK</action-widget>
       <action-widget response="-6">btnCancel</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkCheckButton" id="allsamefolder">
-	<property name="visible">True</property>
-	<property name="can_focus">True</property>
-	<property name="receives_default">False</property>
-	<property name="draw_indicator">True</property>
   </object>
 </interface>

--- a/share/gpodder/ui/gtk/gpodderexporttolocalfolder.ui
+++ b/share/gpodder/ui/gtk/gpodderexporttolocalfolder.ui
@@ -30,13 +30,12 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btnOK">
-                <property name="label">gtk-save</property>
+                <property name="label" translatable="yes">Save</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-default">True</property>
                 <property name="has-default">True</property>
                 <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
               </object>
               <packing>
@@ -47,11 +46,10 @@
             </child>
             <child>
               <object class="GtkButton" id="btnCancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
               </object>
               <packing>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1,62 +1,101 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="adjustment_episode_limit">
-    <property name="upper">1000</property>
     <property name="lower">100</property>
-    <property name="page_increment">10</property>
-    <property name="step_increment">10</property>
-    <property name="page_size">0</property>
+    <property name="upper">1000</property>
     <property name="value">200</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment_update_interval">
-    <property name="upper">360</property>
-    <property name="lower">0</property>
-    <property name="page_increment">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_size">0</property>
-    <property name="value">0</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_expiration">
     <property name="upper">30</property>
-    <property name="lower">0</property>
-    <property name="page_increment">10</property>
-    <property name="step_increment">1</property>
-    <property name="page_size">0</property>
     <property name="value">7</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_update_interval">
+    <property name="upper">360</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkDialog" id="gPodderPreferences">
-    <property name="visible">False</property>
-    <property name="modal">True</property>
-    <property name="transient-for">parent_widget</property>
-    <property name="window-position">GTK_WIN_POS_CENTER_ON_PARENT</property>
-    <property name="default_height">260</property>
-    <property name="default_width">320</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
-    <property name="type_hint">dialog</property>
-    <signal name="destroy" handler="on_dialog_destroy"/>
+    <property name="modal">True</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">320</property>
+    <property name="default-height">260</property>
+    <property name="type-hint">dialog</property>
+    <signal name="destroy" handler="on_dialog_destroy" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox">
-        <property name="border_width">2</property>
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="action_area">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="button_advanced">
+                <property name="label" translatable="yes">Edit config</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <signal name="clicked" handler="on_button_advanced_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_close">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkNotebook" id="notebook">
-            <property name="border_width">6</property>
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">6</property>
             <child>
               <object class="GtkBox" id="vbox_general">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <!-- n-columns=3 n-rows=2 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="column-spacing">12</property>
                     <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_video_player">
                         <property name="visible">True</property>
@@ -144,20 +183,34 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_general">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_show_all_episodes">
                     <property name="label" translatable="yes">"All episodes" in podcast list</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
@@ -165,147 +218,181 @@
                   <object class="GtkCheckButton" id="checkbutton_podcast_sections">
                     <property name="label" translatable="yes">Use sections for podcast list</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="tab-label" translatable="yes">General</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_video">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
+                  <!-- n-columns=3 n-rows=5 -->
                   <object class="GtkGrid" id="table_video">
-                    <property name="column_spacing">12</property>
-                    <property name="row_spacing">6</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_preferred_youtube_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Preferred YouTube format:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combobox_preferred_youtube_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <signal name="changed" handler="on_combobox_preferred_youtube_format_changed" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label_preferred_youtube_hls_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Preferred YouTube HLS format:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combobox_preferred_youtube_hls_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <signal name="changed" handler="on_combobox_preferred_youtube_hls_format_changed" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label_preferred_vimeo_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Preferred Vimeo format:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combobox_preferred_vimeo_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <signal name="changed" handler="on_combobox_preferred_vimeo_format_changed" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Video</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_extensions">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow2">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="shadow_type">in</property>
-		    <property name="hscrollbar-policy">GTK_POLICY_AUTOMATIC</property>
-		    <property name="vscrollbar-policy">GTK_POLICY_AUTOMATIC</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
                     <child>
                       <object class="GtkTreeView" id="treeviewExtensions">
                         <property name="visible">True</property>
-                        <property name="headers_visible">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="reorderable">False</property>
-                        <property name="enable_search">True</property>
-                        <property name="search_column">1</property>
-                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="search-column">1</property>
                         <signal name="button-release-event" handler="on_treeview_extension_button_released" swapped="no"/>
+                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Extensions</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="mygpo_config">
-                <property name="margin">12</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
@@ -314,16 +401,24 @@
                   <object class="GtkCheckButton" id="checkbutton_enable">
                     <property name="label" translatable="yes">Synchronize subscriptions and episode actions</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                     <signal name="toggled" handler="on_enabled_toggled" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <!-- n-columns=2 n-rows=4 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="column-spacing">12</property>
                     <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_server">
                         <property name="visible">True</property>
@@ -339,8 +434,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_server">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="changed" handler="on_server_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -363,8 +458,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_username">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="changed" handler="on_username_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -375,8 +470,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_password">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <property name="visibility">False</property>
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
                       </object>
@@ -412,8 +507,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_caption">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="changed" handler="on_device_caption_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -422,6 +517,11 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="button_overwrite">
@@ -431,145 +531,173 @@
                     <property name="receives-default">False</property>
                     <signal name="clicked" handler="on_button_overwrite_clicked" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">gpodder.net</property>
                 <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_updating">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="hbox_updating_interval">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_update_interval">
-                        <property name="label" translatable="yes">Update interval:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
-                        <property name="yalign">0.1</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Update interval:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.10000000149011612</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScale" id="hscale_update_interval">
-                        <property name="digits">0</property>
-                        <property name="is_focus">True</property>
-                        <property name="restrict_to_fill_level">False</property>
-                        <property name="value_pos">bottom</property>
                         <property name="visible">True</property>
-                        <property name="adjustment">adjustment_update_interval</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can-focus">False</property>
+                        <property name="is-focus">True</property>
                         <property name="hexpand">True</property>
-                        <signal name="format-value" handler="format_update_interval_value"/>
-                        <signal name="value-changed" handler="on_update_interval_value_changed"/>
+                        <property name="adjustment">adjustment_update_interval</property>
+                        <property name="restrict-to-fill-level">False</property>
+                        <property name="digits">0</property>
+                        <property name="value-pos">bottom</property>
+                        <signal name="format-value" handler="format_update_interval_value" swapped="no"/>
+                        <signal name="value-changed" handler="on_update_interval_value_changed" swapped="no"/>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_updating">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="hbox_episode_limit">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_episode_limit">
-                        <property name="label" translatable="yes">Maximum number of episodes per podcast:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Maximum number of episodes per podcast:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSpinButton" id="spinbutton_episode_limit">
-                        <property name="adjustment">adjustment_episode_limit</property>
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="adjustment">adjustment_episode_limit</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_updating2">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="hbox_auto_download">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_auto_download">
-                        <property name="label" translatable="yes">When new episodes are found:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">When new episodes are found:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combo_auto_download">
                         <property name="visible">True</property>
-                        <signal name="changed" handler="on_combo_auto_download_changed"/>
+                        <property name="can-focus">False</property>
+                        <signal name="changed" handler="on_combo_auto_download_changed" swapped="no"/>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_updating3">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">6</property>
                   </packing>
                 </child>
@@ -577,68 +705,83 @@
                   <object class="GtkCheckButton" id="checkbutton_check_connection">
                     <property name="label" translatable="yes">Check connection before updating (if supported)</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">7</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Updating</property>
                 <property name="position">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_downloads">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="hbox_expiration">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_expiration">
-                        <property name="label" translatable="yes">Delete played episodes:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
-                        <property name="yalign">0.1</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Delete played episodes:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.10000000149011612</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScale" id="hscale_expiration">
-                        <property name="digits">0</property>
-                        <property name="is_focus">True</property>
-                        <property name="value_pos">bottom</property>
                         <property name="visible">True</property>
-                        <property name="adjustment">adjustment_expiration</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can-focus">False</property>
+                        <property name="is-focus">True</property>
                         <property name="hexpand">True</property>
-                        <signal name="format-value" handler="format_expiration_value"/>
-                        <signal name="value-changed" handler="on_expiration_value_changed"/>
+                        <property name="adjustment">adjustment_expiration</property>
+                        <property name="digits">0</property>
+                        <property name="value-pos">bottom</property>
+                        <signal name="format-value" handler="format_expiration_value" swapped="no"/>
+                        <signal name="value-changed" handler="on_expiration_value_changed" swapped="no"/>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_expiration_unfinished">
                     <property name="label" translatable="yes">Remove played episodes even if unfinished</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -646,35 +789,41 @@
                   <object class="GtkCheckButton" id="checkbutton_expiration_unplayed">
                     <property name="label" translatable="yes">Also remove unplayed episodes</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Clean-up</property>
                 <property name="position">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_devices">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="border-width">12</property>
-                <property name="spacing">6</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <!-- n-columns=2 n-rows=2 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="column-spacing">12</property>
+                    <property name="can-focus">False</property>
                     <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_device_type">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Device type:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -684,6 +833,7 @@
                     <child>
                       <object class="GtkComboBox" id="combobox_device_type">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <signal name="changed" handler="on_combobox_device_type_changed" swapped="no"/>
                       </object>
@@ -695,8 +845,9 @@
                     <child>
                       <object class="GtkLabel" id="label_device_mount">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Mountpoint:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -706,8 +857,9 @@
                     <child>
                       <object class="GtkButton" id="btn_filesystemMountpoint">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="can-focus">False</property>
                         <property name="receives-default">False</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="on_btn_device_mountpoint_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -716,25 +868,38 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_create_playlists">
                     <property name="label" translatable="yes">Create playlists on device</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_checkbutton_create_playlists_toggled" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_device_playlists">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Playlists Folder:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -745,6 +910,7 @@
                     <child>
                       <object class="GtkButton" id="btn_playlistfolder">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="receives-default">False</property>
                         <signal name="clicked" handler="on_btn_playlist_folder_clicked" swapped="no"/>
                       </object>
@@ -755,24 +921,37 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_delete_using_playlists">
                     <property name="label" translatable="yes">Remove episodes deleted on device from gPodder</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_on_sync">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">After syncing an episode:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -783,6 +962,7 @@
                     <child>
                       <object class="GtkComboBox" id="combobox_on_sync">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <signal name="changed" handler="on_combobox_on_sync_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -792,26 +972,42 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_skip_played_episodes">
                     <property name="label" translatable="yes">Only sync unplayed episodes</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">5</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_delete_deleted_episodes">
                     <property name="label" translatable="yes">Remove episodes deleted in gPodder from device</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">6</property>
+                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Devices</property>
                 <property name="position">4</property>
               </packing>
             </child>
@@ -820,38 +1016,6 @@
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">2</property>
-          </packing>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="action_area">
-            <property name="border_width">5</property>
-            <property name="layout_style">end</property>
-            <property name="spacing">6</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkButton" id="button_advanced">
-                <property name="label" translatable="yes">Edit config</property>
-                <property name="visible">True</property>
-                <signal name="clicked" handler="on_button_advanced_clicked"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
-                <property name="visible">True</property>
-                <signal name="clicked" handler="on_button_close_clicked"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="pack_type">end</property>
           </packing>
         </child>
       </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -130,7 +130,7 @@
                           <object class="GtkImage" id="image4">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="stock">gtk-edit</property>
+                            <property name="icon-name">gtk-edit</property>
                           </object>
                         </child>
                       </object>
@@ -173,7 +173,7 @@
                           <object class="GtkImage" id="image3">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="stock">gtk-edit</property>
+                            <property name="icon-name">gtk-edit</property>
                           </object>
                         </child>
                       </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -911,7 +911,7 @@
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <!-- n-columns=3 n-rows=5 -->
+                  <!-- n-columns=2 n-rows=3 -->
                   <object class="GtkGrid" id="table_video">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -950,7 +950,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">2</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
@@ -962,7 +962,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">2</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
@@ -974,7 +974,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">4</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
@@ -985,35 +985,8 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">4</property>
+                        <property name="top-attach">2</property>
                       </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
                     </child>
                   </object>
                   <packing>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -229,6 +229,20 @@
                   </packing>
                 </child>
               </object>
+              <packing>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">General</property>
+              </object>
+              <packing>
+                <property name="tab-fill">False</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_video">
@@ -351,7 +365,18 @@
                 </child>
               </object>
               <packing>
-                <property name="position">1</property>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Video</property>
+              </object>
+              <packing>
+                <property name="position">5</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -388,7 +413,18 @@
                 </child>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">6</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Extensions</property>
+              </object>
+              <packing>
+                <property name="position">6</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -540,6 +576,17 @@
               </object>
               <packing>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">gpodder.net</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -720,6 +767,17 @@
                 <property name="position">2</property>
               </packing>
             </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Updating</property>
+              </object>
+              <packing>
+                <property name="position">2</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkBox" id="vbox_downloads">
                 <property name="visible">True</property>
@@ -802,6 +860,17 @@
               </object>
               <packing>
                 <property name="position">3</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Clean-up</property>
+              </object>
+              <packing>
+                <property name="position">3</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -1009,6 +1078,17 @@
               </object>
               <packing>
                 <property name="position">4</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Devices</property>
+              </object>
+              <packing>
+                <property name="position">4</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -229,9 +229,6 @@
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child type="tab">
               <object class="GtkLabel">
@@ -240,190 +237,6 @@
                 <property name="label" translatable="yes">General</property>
               </object>
               <packing>
-                <property name="tab-fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox_video">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="border-width">12</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <!-- n-columns=3 n-rows=5 -->
-                  <object class="GtkGrid" id="table_video">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="row-spacing">6</property>
-                    <property name="column-spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="label_preferred_youtube_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Preferred YouTube format:</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBox" id="combobox_preferred_youtube_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="hexpand">True</property>
-                        <signal name="changed" handler="on_combobox_preferred_youtube_format_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_preferred_youtube_hls_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Preferred YouTube HLS format:</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBox" id="combobox_preferred_youtube_hls_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="hexpand">True</property>
-                        <signal name="changed" handler="on_combobox_preferred_youtube_hls_format_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_preferred_vimeo_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Preferred Vimeo format:</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBox" id="combobox_preferred_vimeo_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <signal name="changed" handler="on_combobox_preferred_vimeo_format_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">5</property>
-              </packing>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Video</property>
-              </object>
-              <packing>
-                <property name="position">5</property>
-                <property name="tab-fill">False</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox_extensions">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="border-width">12</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow2">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="shadow-type">in</property>
-                    <child>
-                      <object class="GtkTreeView" id="treeviewExtensions">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="headers-visible">False</property>
-                        <property name="search-column">1</property>
-                        <signal name="button-release-event" handler="on_treeview_extension_button_released" swapped="no"/>
-                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection"/>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">6</property>
-              </packing>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Extensions</property>
-              </object>
-              <packing>
-                <property name="position">6</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>
@@ -1088,6 +901,189 @@
               </object>
               <packing>
                 <property name="position">4</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox_video">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <!-- n-columns=3 n-rows=5 -->
+                  <object class="GtkGrid" id="table_video">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="label_preferred_youtube_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Preferred YouTube format:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="combobox_preferred_youtube_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <signal name="changed" handler="on_combobox_preferred_youtube_format_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_preferred_youtube_hls_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Preferred YouTube HLS format:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="combobox_preferred_youtube_hls_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <signal name="changed" handler="on_combobox_preferred_youtube_hls_format_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_preferred_vimeo_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Preferred Vimeo format:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="combobox_preferred_vimeo_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <signal name="changed" handler="on_combobox_preferred_vimeo_format_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Video</property>
+              </object>
+              <packing>
+                <property name="position">5</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox_extensions">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTreeView" id="treeviewExtensions">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="search-column">1</property>
+                        <signal name="button-release-event" handler="on_treeview_extension_button_released" swapped="no"/>
+                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">6</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Extensions</property>
+              </object>
+              <packing>
+                <property name="position">6</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -56,11 +56,10 @@
             </child>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>
               <packing>

--- a/share/gpodder/ui/gtk/gpodderwelcome.ui
+++ b/share/gpodder/ui/gtk/gpodderwelcome.ui
@@ -22,11 +22,10 @@
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="btnCancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">Cancel</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
               </object>
               <packing>

--- a/share/gpodder/ui/gtk/gpodderwelcome.ui
+++ b/share/gpodder/ui/gtk/gpodderwelcome.ui
@@ -1,93 +1,146 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkDialog" id="gPodderWelcome">
-    <property name="default_height">230</property>
-    <property name="default_width">340</property>
-    <property name="modal">True</property>
-    <property name="transient-for">parent_widget</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Getting started</property>
+    <property name="modal">True</property>
+    <property name="default-width">340</property>
+    <property name="default-height">230</property>
+    <property name="type-hint">normal</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog1-vbox">
-        <property name="border_width">2</property>
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog1-action_area">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="btnCancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkBox" id="vbox1">
-            <property name="border_width">12</property>
-            <property name="spacing">12</property>
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">12</property>
             <property name="orientation">vertical</property>
+            <property name="spacing">12</property>
             <child>
               <object class="GtkLabel" id="label1">
-                <property name="label" translatable="yes">&lt;big&gt;Welcome to gPodder&lt;/big&gt;</property>
-                <property name="use_markup">True</property>
                 <property name="visible">True</property>
-                <property name="xalign">0.0</property>
-                <property name="yalign">1.0</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">&lt;big&gt;Welcome to gPodder&lt;/big&gt;</property>
+                <property name="use-markup">True</property>
+                <property name="xalign">0</property>
+                <property name="yalign">1</property>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkLabel" id="label2">
-                <property name="label" translatable="yes">Your podcast list is empty.</property>
                 <property name="visible">True</property>
-                <property name="xalign">0.0</property>
-                <property name="yalign">0.0</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Your podcast list is empty.</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_buttons">
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkButton" id="btnOPML">
-                    <property name="is_focus">True</property>
                     <property name="label" translatable="yes">Choose from a list of example podcasts</property>
                     <property name="visible">True</property>
-                    <signal handler="on_show_example_podcasts" name="clicked"/>
+                    <property name="can-focus">False</property>
+                    <property name="is-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <signal name="clicked" handler="on_show_example_podcasts" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="btnAddURL">
-                    <property name="is_focus">True</property>
                     <property name="label" translatable="yes">Add a podcast by entering its URL</property>
                     <property name="visible">True</property>
-                    <signal handler="on_add_podcast_via_url" name="clicked"/>
+                    <property name="can-focus">False</property>
+                    <property name="is-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <signal name="clicked" handler="on_add_podcast_via_url" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="btnMygPodder">
                     <property name="label" translatable="yes">Restore my subscriptions from gpodder.net</property>
                     <property name="visible">True</property>
-                    <signal handler="on_setup_my_gpodder" name="clicked"/>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <signal name="clicked" handler="on_setup_my_gpodder" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
-            </child>
-          </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog1-action_area">
-            <property name="border_width">5</property>
-            <property name="layout_style">end</property>
-            <property name="spacing">6</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkButton" id="btnCancel">
-                <property name="label">gtk-cancel</property>
-                <property name="use_stock">True</property>
-                <property name="visible">True</property>
-                <signal handler="on_btnCancel_clicked" name="clicked"/>
-              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="pack_type">end</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -202,7 +202,7 @@ class gPodderApplication(Gtk.Application):
     def on_about(self, action, param):
         dlg = Gtk.Dialog(_('About gPodder'), self.window.gPodder,
                 Gtk.DialogFlags.MODAL)
-        dlg.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.OK).show()
+        dlg.add_button('_Close', Gtk.ResponseType.OK).show()
         dlg.set_resizable(True)
 
         bg = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6, margin=16)

--- a/src/gpodder/gtkui/desktop/channel.py
+++ b/src/gpodder/gtkui/desktop/channel.py
@@ -112,7 +112,7 @@ class gPodderChannel(BuilderWidget):
 
     def on_button_add_section_clicked(self, widget):
         text = self.show_text_edit_dialog(_('Add section'), _('New section:'),
-            affirmative_text=Gtk.STOCK_ADD)
+            affirmative_text='_Add')
 
         if text is not None:
             for index, (section,) in enumerate(self.section_list):
@@ -146,8 +146,8 @@ class gPodderChannel(BuilderWidget):
             title=_('Select new podcast cover artwork'),
             parent=self.gPodderChannel,
             action=Gtk.FileChooserAction.OPEN)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dlg.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+        dlg.add_button('_Open', Gtk.ResponseType.OK)
 
         if dlg.run() == Gtk.ResponseType.OK:
             url = dlg.get_uri()

--- a/src/gpodder/gtkui/desktop/episodeselector.py
+++ b/src/gpodder/gtkui/desktop/episodeselector.py
@@ -326,9 +326,9 @@ class gPodderEpisodeSelector(BuilderWidget):
             self.btnOK.set_sensitive(count > 0)
             self.btnRemoveAction.set_sensitive(count > 0)
             if count > 0:
-                self.btnCancel.set_label(Gtk.STOCK_CANCEL)
+                self.btnCancel.set_label(_('Cancel'))
             else:
-                self.btnCancel.set_label(Gtk.STOCK_CLOSE)
+                self.btnCancel.set_label(_('Close'))
         else:
             self.btnOK.set_sensitive(False)
             self.btnRemoveAction.set_sensitive(False)

--- a/src/gpodder/gtkui/desktop/episodeselector.py
+++ b/src/gpodder/gtkui/desktop/episodeselector.py
@@ -60,9 +60,9 @@ class gPodderEpisodeSelector(BuilderWidget):
       - instructions: (optional) A one-line text describing what the
                       user should select / what the selection is for
       - stock_ok_button: (optional) Will replace the "OK" button with
-                         another GTK+ stock item to be used for the
+                         another GTK stock item to be used for the
                          affirmative button of the dialog (e.g. can
-                         be Gtk.STOCK_DELETE when the episodes to be
+                         be '_Delete' when the episodes to be
                          selected will be deleted after closing the
                          dialog)
       - selection_buttons: (optional) A dictionary with labels as

--- a/src/gpodder/gtkui/desktop/episodeselector.py
+++ b/src/gpodder/gtkui/desktop/episodeselector.py
@@ -89,6 +89,7 @@ class gPodderEpisodeSelector(BuilderWidget):
     COLUMN_ADDITIONAL = 3
 
     def new(self):
+        self.gPodderEpisodeSelector.set_transient_for(self.parent_widget)
         if hasattr(self, 'title'):
             self.gPodderEpisodeSelector.set_title(self.title)
 

--- a/src/gpodder/gtkui/desktop/exportlocal.py
+++ b/src/gpodder/gtkui/desktop/exportlocal.py
@@ -31,6 +31,7 @@ N_ = gpodder.ngettext
 class gPodderExportToLocalFolder(BuilderWidget):
     """ Export to Local Folder UI: file dialog + checkbox to save all to same folder """
     def new(self):
+        self.gPodderExportToLocalFolder.set_transient_for(self.parent_widget)
         self._config.connect_gtk_window(self.gPodderExportToLocalFolder,
                                         'export_to_local_folder', True)
         self._ok = False

--- a/src/gpodder/gtkui/desktop/podcastdirectory.py
+++ b/src/gpodder/gtkui/desktop/podcastdirectory.py
@@ -99,6 +99,7 @@ class DirectoryProvidersModel(Gtk.ListStore):
 
 class gPodderPodcastDirectory(BuilderWidget):
     def new(self):
+        self.gPodderPodcastDirectory.set_transient_for(self.parent_widget)
         if hasattr(self, 'custom_title'):
             self.main_window.set_title(self.custom_title)
 

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -672,8 +672,8 @@ class gPodderPreferences(BuilderWidget):
         fs = Gtk.FileChooserDialog(title=_('Select folder for mount point'),
                 action=Gtk.FileChooserAction.SELECT_FOLDER)
         fs.set_local_only(False)
-        fs.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        fs.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        fs.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+        fs.add_button('_Open', Gtk.ResponseType.OK)
 
         fs.set_uri(self.btn_filesystemMountpoint.get_label() or "")
         if fs.run() == Gtk.ResponseType.OK:
@@ -690,8 +690,8 @@ class gPodderPreferences(BuilderWidget):
         fs = Gtk.FileChooserDialog(title=_('Select folder for playlists'),
                 action=Gtk.FileChooserAction.SELECT_FOLDER)
         fs.set_local_only(False)
-        fs.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        fs.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        fs.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+        fs.add_button('_Open', Gtk.ResponseType.OK)
 
         device_folder = util.new_gio_file(self._config.device_sync.device_folder)
         playlists_folder = device_folder.resolve_relative_path(self._config.device_sync.playlists.folder)

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -185,6 +185,7 @@ class gPodderPreferences(BuilderWidget):
     C_TOGGLE, C_LABEL, C_EXTENSION, C_SHOW_TOGGLE = list(range(4))
 
     def new(self):
+        self.gPodderPreferences.set_transient_for(self.parent_widget)
         for cb in (self.combo_audio_player_app, self.combo_video_player_app):
             cellrenderer = Gtk.CellRendererPixbuf()
             cb.pack_start(cellrenderer, False)

--- a/src/gpodder/gtkui/desktop/welcome.py
+++ b/src/gpodder/gtkui/desktop/welcome.py
@@ -29,6 +29,7 @@ class gPodderWelcome(BuilderWidget):
     PADDING = 10
 
     def new(self):
+        self.gPodderWelcome.set_transient_for(self.parent_widget)
         for widget in self.vbox_buttons.get_children():
             for child in widget.get_children():
                 if isinstance(child, Gtk.Alignment):

--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -155,7 +155,7 @@ class UserAppsReader(object):
         self.apps.append(UserApplication(
             _('Default application'), 'default',
             ';'.join((mime + '/*' for mime in self.mimetypes)),
-            Gtk.STOCK_OPEN))
+            'document-open'))
 
     def add_separator(self):
         self.apps.append(UserApplication(

--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -96,7 +96,7 @@ class DownloadStatusModel:
         # Set up stock icon IDs for tasks
         self._status_ids = collections.defaultdict(lambda: None)
         self._status_ids[download.DownloadTask.DOWNLOADING] = 'go-down'
-        self._status_ids[download.DownloadTask.DONE] = Gtk.STOCK_APPLY
+        self._status_ids[download.DownloadTask.DONE] = 'gtk-apply'
         self._status_ids[download.DownloadTask.FAILED] = 'dialog-error'
         self._status_ids[download.DownloadTask.CANCELLED] = 'media-playback-stop'
         self._status_ids[download.DownloadTask.PAUSED] = 'media-playback-pause'

--- a/src/gpodder/gtkui/interface/addpodcast.py
+++ b/src/gpodder/gtkui/interface/addpodcast.py
@@ -28,6 +28,7 @@ _ = gpodder.gettext
 
 class gPodderAddPodcast(BuilderWidget):
     def new(self):
+        self.gPodderAddPodcast.set_transient_for(self.parent_widget)
         if not hasattr(self, 'add_podcast_list'):
             self.add_podcast_list = None
         if hasattr(self, 'custom_label'):

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -95,11 +95,11 @@ class BuilderWidget(GtkBuilderWidget):
         return response == Gtk.ResponseType.YES
 
     def show_text_edit_dialog(self, title, prompt, text=None, empty=False,
-            is_url=False, affirmative_text=Gtk.STOCK_OK):
+            is_url=False, affirmative_text='_OK'):
         dialog = Gtk.Dialog(title, self.get_dialog_parent(),
             Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT)
 
-        dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        dialog.add_button('_Cancel', Gtk.ResponseType.CANCEL)
         dialog.add_button(affirmative_text, Gtk.ResponseType.OK)
 
         dialog.set_default_size(300, -1)
@@ -235,8 +235,8 @@ class BuilderWidget(GtkBuilderWidget):
             initial_directory = os.path.expanduser('~')
 
         dlg = Gtk.FileChooserDialog(title=title, parent=self.main_window, action=Gtk.FileChooserAction.SELECT_FOLDER)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        dlg.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+        dlg.add_button('_Save', Gtk.ResponseType.OK)
 
         dlg.set_do_overwrite_confirmation(True)
         dlg.set_current_folder(initial_directory)

--- a/src/gpodder/gtkui/interface/configeditor.py
+++ b/src/gpodder/gtkui/interface/configeditor.py
@@ -30,6 +30,7 @@ _ = gpodder.gettext
 
 class gPodderConfigEditor(BuilderWidget):
     def new(self):
+        self.gPodderConfigEditor.set_transient_for(self.parent_widget)
         name_column = Gtk.TreeViewColumn(_('Setting'))
         name_renderer = Gtk.CellRendererText()
         name_column.pack_start(name_renderer, True)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2805,8 +2805,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         if downloading:
             dialog = Gtk.MessageDialog(self.gPodder, Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.NONE)
-            dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-            quit_button = dialog.add_button(Gtk.STOCK_QUIT, Gtk.ResponseType.CLOSE)
+            dialog.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+            quit_button = dialog.add_button('_Quit', Gtk.ResponseType.CLOSE)
 
             title = _('Quit gPodder')
             message = _('You are downloading episodes. You can resume downloads the next time you start gPodder. Do you want to quit now?')
@@ -3397,8 +3397,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             dlg = Gtk.FileChooserDialog(title=_('Import from OPML'),
                     parent=self.main_window,
                     action=Gtk.FileChooserAction.OPEN)
-            dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-            dlg.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+            dlg.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+            dlg.add_button('_Open', Gtk.ResponseType.OK)
             dlg.set_filter(self.get_opml_filter())
             response = dlg.run()
             filename = None
@@ -3425,8 +3425,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         dlg = Gtk.FileChooserDialog(title=_('Export to OPML'),
                                     parent=self.gPodder,
                                     action=Gtk.FileChooserAction.SAVE)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        dlg.add_button('_Cancel', Gtk.ResponseType.CANCEL)
+        dlg.add_button('_Save', Gtk.ResponseType.OK)
         dlg.set_filter(self.get_opml_filter())
         response = dlg.run()
         if response == Gtk.ResponseType.OK:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -565,7 +565,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     episodes=changes,
                     columns=columns,
                     size_attribute=None,
-                    stock_ok_button=Gtk.STOCK_APPLY,
+                    stock_ok_button='_Apply',
                     callback=execute_podcast_actions,
                     _config=self.config)
 
@@ -2956,7 +2956,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.main_window, title=_('Delete episodes'),
             instructions=instructions,
             episodes=episodes, selected=selected, columns=columns,
-            stock_ok_button='edit-delete', callback=self.delete_episode_list,
+            stock_ok_button='_Delete', callback=self.delete_episode_list,
             selection_buttons=selection_buttons, _config=self.config)
 
     def on_selected_episodes_status_changed(self):
@@ -3296,7 +3296,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 episodes=self.channels,
                 columns=columns,
                 size_attribute=None,
-                stock_ok_button=_('Delete'),
+                stock_ok_button='_Delete',
                 callback=self.remove_podcast_list,
                 _config=self.config)
 

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -89,6 +89,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self._search_podcasts = None
         self._search_episodes = None
         BuilderWidget.__init__(self, None, _builder_expose={'app': app})
+        self.gPodder.set_property('application', app)
 
         self.last_episode_date_refresh = None
         self.refresh_episode_dates()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2227,9 +2227,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
             can_delete = not can_cancel
 
         if open_instead_of_play:
-            self.toolPlay.set_stock_id(Gtk.STOCK_OPEN)
+            self.toolPlay.set_icon_name('document-open')
         else:
-            self.toolPlay.set_stock_id(Gtk.STOCK_MEDIA_PLAY)
+            self.toolPlay.set_icon_name('media-playback-start')
         self.toolPlay.set_sensitive(can_play)
         self.toolDownload.set_sensitive(can_download)
         self.toolCancel.set_sensitive(can_cancel)

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -196,7 +196,7 @@ class EpisodeListModel(Gtk.ListStore):
         self.ICON_VIDEO_FILE = 'video-x-generic'
         self.ICON_IMAGE_FILE = 'image-x-generic'
         self.ICON_GENERIC_FILE = 'text-x-generic'
-        self.ICON_DOWNLOADING = Gtk.STOCK_GO_DOWN
+        self.ICON_DOWNLOADING = 'go-down'
         self.ICON_DELETED = 'edit-delete'
         self.ICON_ERROR = 'dialog-error'
 

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -31,7 +31,7 @@ from gpodder.gtkui.draw import (draw_text_box_centered, get_background_color,
 import gi  # isort:skip
 gi.require_version('Gdk', '3.0')  # isort:skip
 gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import Gdk, Gtk, Pango  # isort:skip
+from gi.repository import Gdk, Gio, GLib, Gtk, Pango  # isort:skip
 
 
 _ = gpodder.gettext
@@ -418,8 +418,8 @@ class gPodderShownotesHTML(gPodderShownotes):
             decision.use()
             return False
 
-    def on_open_in_browser(self, action):
-        util.open_website(action.url)
+    def on_open_in_browser(self, action, var):
+        util.open_website(var.get_string())
 
     def on_authenticate(self, view, request):
         if request.is_retry():
@@ -449,10 +449,10 @@ class gPodderShownotesHTML(gPodderShownotes):
             return False
 
     def create_open_item(self, name, label, url):
-        action = Gtk.Action.new(name, label, None, Gtk.STOCK_OPEN)
-        action.url = url
+        action = Gio.SimpleAction.new(name, GLib.VariantType.new('s'))
         action.connect('activate', self.on_open_in_browser)
-        return WebKit2.ContextMenuItem.new(action)
+        var = GLib.Variant.new_string(url)
+        return WebKit2.ContextMenuItem.new_from_gaction(action, label, var)
 
     def get_stylesheet(self):
         if self.stylesheet is None:


### PR DESCRIPTION
This PR removes all usage of deprecated GTK stock features. I used Glade to fix the ui-files, which caused quite a bit of churn, but hopefully this makes future UI changes easier.

One instance of (deprecated) Gtk.Action was also replaced by Gio.SimpleAction.

I went through all the dialogs and they seem to work, but I mostly use the adaptive version, so I may have missed some of the breakage caused by saving the ui-files with Glade. Please test.