### PR TITLE
Query duration for youtube episodes when not using youtube-dl.

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -169,9 +169,17 @@ class PodcastParserFeed(Feed):
             # Detect (and update) existing episode based on GUIDs
             existing_episode = existing_guids.get(episode.guid, None)
             if existing_episode:
+                if existing_episode.total_time == 0 and 'youtube' in episode.url:
+                    # query duration for existing youtube episodes that haven't been downloaded or queried
+                    # such as live streams after they have ended
+                    existing_episode.total_time = youtube.get_total_time(episode)
+
                 existing_episode.update_from(episode)
                 existing_episode.save()
                 continue
+            elif episode.total_time == 0 and 'youtube' in episode.url:
+                # query duration for new youtube episodes
+                episode.total_time = youtube.get_total_time(episode)
 
             episode.save()
             new_episodes.append(episode)

--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -220,6 +220,34 @@ def youtube_get_new_endpoint(vid):
     return None, ipr.group(1)
 
 
+def get_total_time(episode):
+    try:
+        vid = get_youtube_id(episode.url)
+        if vid is None:
+            return 0
+
+        url = 'https://www.youtube.com/watch?v=' + vid
+        r = util.urlopen(url)
+        if not r.ok:
+            return 0
+
+        ipr = re.search(r'ytInitialPlayerResponse\s*=\s*({.+?})\s*;', r.text)
+        if ipr is None:
+            url = get_gdpr_consent_url(r.text)
+            r = util.urlopen(url)
+            if not r.ok:
+                return 0
+
+            ipr = re.search(r'ytInitialPlayerResponse\s*=\s*({.+?})\s*;', r.text)
+            if ipr is None:
+                return 0
+
+        player_response = json.loads(ipr.group(1))
+        return int(player_response['videoDetails']['lengthSeconds'])  # 0 if live
+    except:
+        return 0
+
+
 def get_real_download_url(url, allow_partial, preferred_fmt_ids=None):
     if not preferred_fmt_ids:
         preferred_fmt_ids, _, _ = formats_dict[22]  # MP4 720p


### PR DESCRIPTION
The duration is not available in the youtube feed and requires a request for each episode. It was set when downloading but the user had no way of knowing how long an episode was before downloading it. Live streams do not have a duration until they end, and remain blank until downloaded or the next update.

This will increase the time it takes to update feeds, with new subscriptions possibly taking 16x longer to update due to the 16 requests vs the previous single request. Updating existing feeds will only have an additional request for each new episode.