### PR TITLE
Allow distributions to disable the update check.

### DIFF
--- a/bin/gpodder
+++ b/bin/gpodder
@@ -82,6 +82,9 @@ def main():
 
     gpodder.prefix = prefix
 
+    # Package managers can install the empty file {prefix}/share/gpodder/no-update-check to disable update checks
+    gpodder.no_update_check_file = os.path.join(prefix, 'share', 'gpodder', 'no-update-check')
+
     # Enable i18n for gPodder translations
     _ = gpodder.gettext
 

--- a/src/gpodder/__init__.py
+++ b/src/gpodder/__init__.py
@@ -166,6 +166,8 @@ prefix = None
 
 ENV_HOME, ENV_DOWNLOADS = 'GPODDER_HOME', 'GPODDER_DOWNLOAD_DIR'
 
+no_update_check_file = None
+
 
 # Function to set a new gPodder home folder
 def set_home(new_home):

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -261,7 +261,10 @@ class gPodderApplication(Gtk.Application):
         self.window.mygpo_client.open_website()
 
     def on_check_for_updates_activate(self, action, param):
-        self.window.check_for_updates(silent=False)
+        if os.path.exists(gpodder.no_update_check_file):
+            self.window.check_for_distro_updates()
+        else:
+            self.window.check_for_updates(silent=False)
 
     def on_extension_enabled(self, extension):
         self.window.on_extension_enabled(extension)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -251,7 +251,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             diff = time.time() - self.config.software_update.last_check
             if diff > (60 * 60 * 24) * self.config.software_update.interval:
                 self.config.software_update.last_check = int(time.time())
-                self.check_for_updates(silent=True)
+                if not os.path.exists(gpodder.no_update_check_file):
+                    self.check_for_updates(silent=True)
 
     def create_actions(self):
         g = self.gPodder
@@ -3455,6 +3456,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
     def on_homepage_activate(self, widget, *args):
         util.open_website(gpodder.__url__)
+
+    def check_for_distro_updates(self):
+        title = _('Managed by distribution')
+        message = _('Please check your distribution for gPodder updates.')
+        self.show_message(message, title, important=True)
 
     def check_for_updates(self, silent):
         """Check for updates and (optionally) show a message


### PR DESCRIPTION
Package managers can install `/usr/share/gpodder/no-update-check` to disable the automatic check at startup, and the `Software update` menu item.

Fixes #1103.