### PR TITLE
Gtk UI: Use GtkStack and put switcher in header bar

### DIFF
--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -31,8 +31,9 @@
     <property name="urgency_hint">False</property>
     <signal handler="on_gPodder_delete_event" name="delete-event"/>
     <child>
-      <object class="GtkGrid" id="vMain">
+      <object class="GtkVBox" id="vMain">
         <property name="visible">True</property>
+        <property name="spacing">0</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkToolbar" id="toolbar">
@@ -140,27 +141,26 @@
               </packing>
             </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+          </packing>
         </child>
         <child>
           <object class="GtkGrid" id="hboxContainer">
-            <property name="border_width">5</property>
+            <property name="border_width">0</property>
             <property name="visible">True</property>
             <property name="orientation">horizontal</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <child>
-              <object class="GtkNotebook" id="wNotebook">
+              <object class="GtkStack" id="wNotebook">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="show_tabs">True</property>
-                <property name="show_border">True</property>
-                <property name="tab_pos">GTK_POS_TOP</property>
-                <property name="scrollable">False</property>
-                <property name="enable_popup">False</property>
-                <signal handler="on_wNotebook_switch_page" name="switch_page"/>
+                <property name="transition-type">slide-left-right</property>
+                <signal handler="on_wNotebook_switch_page" name="notify::visible-child"/>
                 <child>
                   <object class="GtkPaned" id="channelPaned">
-                    <property name="border_width">5</property>
+                    <property name="border_width">0</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="orientation">horizontal</property>
@@ -335,21 +335,8 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="tab_expand">False</property>
-                    <property name="tab_fill">True</property>
+                    <property name="title" translatable="yes">Podcasts</property>
                   </packing>
-                </child>
-                <child type="tab">
-                  <object class="GtkLabel" id="label2">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Podcasts</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
-                  </object>
                 </child>
                 <child>
                   <object class="GtkGrid" id="vboxDownloadStatusWidgets">
@@ -462,27 +449,12 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="tab_expand">False</property>
-                    <property name="tab_fill">True</property>
+                    <property name="title" translatable="yes">Progress</property>
                   </packing>
-                </child>
-                <child type="tab">
-                  <object class="GtkLabel" id="labelDownloads">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Progress</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
-                  </object>
                 </child>
               </object>
             </child>
           </object>
-          <packing>
-          </packing>
         </child>
       </object>
     </child>


### PR DESCRIPTION
This uses `GtkStack` and `GtkStackSwitcher` to be more in line with the GNOME HIG. Still have to figure out where to put all the items from the main menu + toolbar (those should most likely not appear in the final UI. Also made sure that the non-CSD (`GTK_CSD=0`) UI gains access to the main menu again and that everything is workable there as well.

I haven't looked at the adaptive branch; maybe this becomes obsolete with the adaptive branch, but it still looks nice in the Linux Desktop situation (with Ubuntu/GNOME).

Without CSD (note the added "gPodder" menu, which contains the app menu):

![Screenshot from 2021-08-19 16-19-45](https://user-images.githubusercontent.com/135241/130085705-bcab6f28-c785-431c-8bd5-2bd9e0df85ce.png)

With CSD (again, the menu bar is only temporary until those items can find a better spot, most likely in the header bar like Nautilus has):

![Screenshot from 2021-08-19 16-19-30](https://user-images.githubusercontent.com/135241/130085727-9f3fc792-e508-4afa-add2-09d261906859.png)

We could replace this with `HdyViewSwitcher` in the future: https://developer.gnome.org/hig/patterns/nav/view-switchers.html