### PR TITLE
Preferences: Remove deprecated GTK features

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ PyPI. With this, you get a self-contained gPodder CLI codebase.
 ### GTK3 UI - Additional Dependencies
 
 - [PyGObject](https://wiki.gnome.org/PyGObject) 3.22.0 or newer
-- [GTK+3](https://www.gtk.org/) 3.10 or newer
+- [GTK+3](https://www.gtk.org/) 3.16 or newer
 
 
 ### Optional Dependencies

--- a/share/gpodder/ui/gtk/gpodderchannel.ui
+++ b/share/gpodder/ui/gtk/gpodderchannel.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkDialog" id="gPodderChannel">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Channel Editor</property>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1,62 +1,101 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="adjustment_episode_limit">
-    <property name="upper">1000</property>
     <property name="lower">100</property>
-    <property name="page_increment">10</property>
-    <property name="step_increment">10</property>
-    <property name="page_size">0</property>
+    <property name="upper">1000</property>
     <property name="value">200</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment_update_interval">
-    <property name="upper">360</property>
-    <property name="lower">0</property>
-    <property name="page_increment">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_size">0</property>
-    <property name="value">0</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_expiration">
     <property name="upper">30</property>
-    <property name="lower">0</property>
-    <property name="page_increment">10</property>
-    <property name="step_increment">1</property>
-    <property name="page_size">0</property>
     <property name="value">7</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_update_interval">
+    <property name="upper">360</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkDialog" id="gPodderPreferences">
-    <property name="visible">False</property>
-    <property name="modal">True</property>
-    <property name="transient-for">parent_widget</property>
-    <property name="window-position">GTK_WIN_POS_CENTER_ON_PARENT</property>
-    <property name="default_height">260</property>
-    <property name="default_width">320</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
-    <property name="type_hint">dialog</property>
-    <signal name="destroy" handler="on_dialog_destroy"/>
+    <property name="modal">True</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="default-width">320</property>
+    <property name="default-height">260</property>
+    <property name="type-hint">dialog</property>
+    <signal name="destroy" handler="on_dialog_destroy" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="vbox">
-        <property name="border_width">2</property>
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="action_area">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="button_advanced">
+                <property name="label" translatable="yes">Edit config</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <signal name="clicked" handler="on_button_advanced_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_close">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="receives-default">False</property>
+                <property name="use-stock">True</property>
+                <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkNotebook" id="notebook">
-            <property name="border_width">6</property>
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="border-width">6</property>
             <child>
               <object class="GtkBox" id="vbox_general">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <!-- n-columns=3 n-rows=2 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="column-spacing">12</property>
                     <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_video_player">
                         <property name="visible">True</property>
@@ -144,20 +183,34 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_general">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_show_all_episodes">
                     <property name="label" translatable="yes">"All episodes" in podcast list</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
@@ -165,147 +218,181 @@
                   <object class="GtkCheckButton" id="checkbutton_podcast_sections">
                     <property name="label" translatable="yes">Use sections for podcast list</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="tab-label" translatable="yes">General</property>
-              </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_video">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
+                  <!-- n-columns=3 n-rows=5 -->
                   <object class="GtkGrid" id="table_video">
-                    <property name="column_spacing">12</property>
-                    <property name="row_spacing">6</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_preferred_youtube_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Preferred YouTube format:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combobox_preferred_youtube_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <signal name="changed" handler="on_combobox_preferred_youtube_format_changed" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label_preferred_youtube_hls_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Preferred YouTube HLS format:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combobox_preferred_youtube_hls_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <signal name="changed" handler="on_combobox_preferred_youtube_hls_format_changed" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label_preferred_vimeo_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Preferred Vimeo format:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combobox_preferred_vimeo_format">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <signal name="changed" handler="on_combobox_preferred_vimeo_format_changed" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Video</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_extensions">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow2">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="shadow_type">in</property>
-		    <property name="hscrollbar-policy">GTK_POLICY_AUTOMATIC</property>
-		    <property name="vscrollbar-policy">GTK_POLICY_AUTOMATIC</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
                     <child>
                       <object class="GtkTreeView" id="treeviewExtensions">
                         <property name="visible">True</property>
-                        <property name="headers_visible">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="reorderable">False</property>
-                        <property name="enable_search">True</property>
-                        <property name="search_column">1</property>
-                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="search-column">1</property>
                         <signal name="button-release-event" handler="on_treeview_extension_button_released" swapped="no"/>
+                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Extensions</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="mygpo_config">
-                <property name="margin">12</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
@@ -314,16 +401,24 @@
                   <object class="GtkCheckButton" id="checkbutton_enable">
                     <property name="label" translatable="yes">Synchronize subscriptions and episode actions</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                     <signal name="toggled" handler="on_enabled_toggled" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <!-- n-columns=2 n-rows=4 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="column-spacing">12</property>
                     <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_server">
                         <property name="visible">True</property>
@@ -339,8 +434,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_server">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="changed" handler="on_server_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -363,8 +458,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_username">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="changed" handler="on_username_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -375,8 +470,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_password">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <property name="visibility">False</property>
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
                       </object>
@@ -412,8 +507,8 @@
                     <child>
                       <object class="GtkEntry" id="entry_caption">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
                         <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="changed" handler="on_device_caption_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -422,6 +517,11 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="button_overwrite">
@@ -431,145 +531,173 @@
                     <property name="receives-default">False</property>
                     <signal name="clicked" handler="on_button_overwrite_clicked" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">gpodder.net</property>
                 <property name="position">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_updating">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="hbox_updating_interval">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_update_interval">
-                        <property name="label" translatable="yes">Update interval:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
-                        <property name="yalign">0.1</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Update interval:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.10000000149011612</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScale" id="hscale_update_interval">
-                        <property name="digits">0</property>
-                        <property name="is_focus">True</property>
-                        <property name="restrict_to_fill_level">False</property>
-                        <property name="value_pos">bottom</property>
                         <property name="visible">True</property>
-                        <property name="adjustment">adjustment_update_interval</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can-focus">False</property>
+                        <property name="is-focus">True</property>
                         <property name="hexpand">True</property>
-                        <signal name="format-value" handler="format_update_interval_value"/>
-                        <signal name="value-changed" handler="on_update_interval_value_changed"/>
+                        <property name="adjustment">adjustment_update_interval</property>
+                        <property name="restrict-to-fill-level">False</property>
+                        <property name="digits">0</property>
+                        <property name="value-pos">bottom</property>
+                        <signal name="format-value" handler="format_update_interval_value" swapped="no"/>
+                        <signal name="value-changed" handler="on_update_interval_value_changed" swapped="no"/>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_updating">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="hbox_episode_limit">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_episode_limit">
-                        <property name="label" translatable="yes">Maximum number of episodes per podcast:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Maximum number of episodes per podcast:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkSpinButton" id="spinbutton_episode_limit">
-                        <property name="adjustment">adjustment_episode_limit</property>
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="adjustment">adjustment_episode_limit</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_updating2">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">4</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="hbox_auto_download">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_auto_download">
-                        <property name="label" translatable="yes">When new episodes are found:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">When new episodes are found:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkComboBox" id="combo_auto_download">
                         <property name="visible">True</property>
-                        <signal name="changed" handler="on_combo_auto_download_changed"/>
+                        <property name="can-focus">False</property>
+                        <signal name="changed" handler="on_combo_auto_download_changed" swapped="no"/>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkSeparator" id="hseparator_updating3">
-                    <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">6</property>
                   </packing>
                 </child>
@@ -577,68 +705,83 @@
                   <object class="GtkCheckButton" id="checkbutton_check_connection">
                     <property name="label" translatable="yes">Check connection before updating (if supported)</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">7</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Updating</property>
                 <property name="position">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_downloads">
-                <property name="border_width">12</property>
-                <property name="spacing">6</property>
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="hbox_expiration">
-                    <property name="spacing">12</property>
                     <property name="visible">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">False</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_expiration">
-                        <property name="label" translatable="yes">Delete played episodes:</property>
                         <property name="visible">True</property>
-                        <property name="xalign">0.0</property>
-                        <property name="yalign">0.1</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Delete played episodes:</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0.10000000149011612</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScale" id="hscale_expiration">
-                        <property name="digits">0</property>
-                        <property name="is_focus">True</property>
-                        <property name="value_pos">bottom</property>
                         <property name="visible">True</property>
-                        <property name="adjustment">adjustment_expiration</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can-focus">False</property>
+                        <property name="is-focus">True</property>
                         <property name="hexpand">True</property>
-                        <signal name="format-value" handler="format_expiration_value"/>
-                        <signal name="value-changed" handler="on_expiration_value_changed"/>
+                        <property name="adjustment">adjustment_expiration</property>
+                        <property name="digits">0</property>
+                        <property name="value-pos">bottom</property>
+                        <signal name="format-value" handler="format_expiration_value" swapped="no"/>
+                        <signal name="value-changed" handler="on_expiration_value_changed" swapped="no"/>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_expiration_unfinished">
                     <property name="label" translatable="yes">Remove played episodes even if unfinished</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -646,35 +789,41 @@
                   <object class="GtkCheckButton" id="checkbutton_expiration_unplayed">
                     <property name="label" translatable="yes">Also remove unplayed episodes</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="receives-default">False</property>
+                    <property name="draw-indicator">False</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Clean-up</property>
                 <property name="position">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_devices">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="border-width">12</property>
-                <property name="spacing">6</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
                 <child>
                   <!-- n-columns=2 n-rows=2 -->
                   <object class="GtkGrid">
                     <property name="visible">True</property>
-                    <property name="column-spacing">12</property>
+                    <property name="can-focus">False</property>
                     <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_device_type">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Device type:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -684,6 +833,7 @@
                     <child>
                       <object class="GtkComboBox" id="combobox_device_type">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <signal name="changed" handler="on_combobox_device_type_changed" swapped="no"/>
                       </object>
@@ -695,8 +845,9 @@
                     <child>
                       <object class="GtkLabel" id="label_device_mount">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Mountpoint:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -706,8 +857,9 @@
                     <child>
                       <object class="GtkButton" id="btn_filesystemMountpoint">
                         <property name="visible">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="can-focus">False</property>
                         <property name="receives-default">False</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="on_btn_device_mountpoint_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -716,25 +868,38 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_create_playlists">
                     <property name="label" translatable="yes">Create playlists on device</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_checkbutton_create_playlists_toggled" swapped="no"/>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_device_playlists">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">Playlists Folder:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -745,6 +910,7 @@
                     <child>
                       <object class="GtkButton" id="btn_playlistfolder">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <property name="receives-default">False</property>
                         <signal name="clicked" handler="on_btn_playlist_folder_clicked" swapped="no"/>
                       </object>
@@ -755,24 +921,37 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_delete_using_playlists">
                     <property name="label" translatable="yes">Remove episodes deleted on device from gPodder</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel" id="label_on_sync">
                         <property name="visible">True</property>
-                        <property name="xalign">0</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">After syncing an episode:</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -783,6 +962,7 @@
                     <child>
                       <object class="GtkComboBox" id="combobox_on_sync">
                         <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                         <signal name="changed" handler="on_combobox_on_sync_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -792,26 +972,42 @@
                       </packing>
                     </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_skip_played_episodes">
                     <property name="label" translatable="yes">Only sync unplayed episodes</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">5</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_delete_deleted_episodes">
                     <property name="label" translatable="yes">Remove episodes deleted in gPodder from device</property>
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">6</property>
+                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="tab-label" translatable="yes">Devices</property>
                 <property name="position">4</property>
               </packing>
             </child>
@@ -820,38 +1016,6 @@
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">2</property>
-          </packing>
-        </child>
-        <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="action_area">
-            <property name="border_width">5</property>
-            <property name="layout_style">end</property>
-            <property name="spacing">6</property>
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkButton" id="button_advanced">
-                <property name="label" translatable="yes">Edit config</property>
-                <property name="visible">True</property>
-                <signal name="clicked" handler="on_button_advanced_clicked"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
-                <property name="visible">True</property>
-                <signal name="clicked" handler="on_button_close_clicked"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="pack_type">end</property>
           </packing>
         </child>
       </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -912,7 +912,7 @@
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <!-- n-columns=3 n-rows=5 -->
+                  <!-- n-columns=2 n-rows=3 -->
                   <object class="GtkGrid" id="table_video">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -951,7 +951,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">2</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
@@ -963,7 +963,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">2</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
@@ -975,7 +975,7 @@
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">4</property>
+                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
@@ -986,35 +986,8 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">4</property>
+                        <property name="top-attach">2</property>
                       </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
                     </child>
                   </object>
                   <packing>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -44,7 +44,7 @@
               <object class="GtkButton" id="button_advanced">
                 <property name="label" translatable="yes">Edit config</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <signal name="clicked" handler="on_button_advanced_clicked" swapped="no"/>
               </object>
@@ -58,7 +58,7 @@
               <object class="GtkButton" id="button_close">
                 <property name="label">gtk-close</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
@@ -80,7 +80,7 @@
         <child>
           <object class="GtkNotebook" id="notebook">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can-focus">True</property>
             <property name="border-width">6</property>
             <child>
               <object class="GtkBox" id="vbox_general">
@@ -204,7 +204,7 @@
                   <object class="GtkCheckButton" id="checkbutton_show_all_episodes">
                     <property name="label" translatable="yes">"All episodes" in podcast list</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -218,7 +218,7 @@
                   <object class="GtkCheckButton" id="checkbutton_podcast_sections">
                     <property name="label" translatable="yes">Use sections for podcast list</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -250,7 +250,7 @@
                   <object class="GtkCheckButton" id="checkbutton_enable">
                     <property name="label" translatable="yes">Synchronize subscriptions and episode actions</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_enabled_toggled" swapped="no"/>
@@ -431,7 +431,7 @@
                     <child>
                       <object class="GtkScale" id="hscale_update_interval">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can-focus">True</property>
                         <property name="is-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="adjustment">adjustment_update_interval</property>
@@ -486,7 +486,7 @@
                     <child>
                       <object class="GtkSpinButton" id="spinbutton_episode_limit">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can-focus">True</property>
                         <property name="adjustment">adjustment_episode_limit</property>
                       </object>
                       <packing>
@@ -565,7 +565,7 @@
                   <object class="GtkCheckButton" id="checkbutton_check_connection">
                     <property name="label" translatable="yes">Check connection before updating (if supported)</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -620,7 +620,7 @@
                     <child>
                       <object class="GtkScale" id="hscale_expiration">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can-focus">True</property>
                         <property name="is-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="adjustment">adjustment_expiration</property>
@@ -646,7 +646,7 @@
                   <object class="GtkCheckButton" id="checkbutton_expiration_unfinished">
                     <property name="label" translatable="yes">Remove played episodes even if unfinished</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -660,7 +660,7 @@
                   <object class="GtkCheckButton" id="checkbutton_expiration_unplayed">
                     <property name="label" translatable="yes">Also remove unplayed episodes</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -739,7 +739,7 @@
                     <child>
                       <object class="GtkButton" id="btn_filesystemMountpoint">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="hexpand">True</property>
                         <signal name="clicked" handler="on_btn_device_mountpoint_clicked" swapped="no"/>
@@ -760,7 +760,7 @@
                   <object class="GtkCheckButton" id="checkbutton_create_playlists">
                     <property name="label" translatable="yes">Create playlists on device</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_checkbutton_create_playlists_toggled" swapped="no"/>
@@ -792,7 +792,7 @@
                     <child>
                       <object class="GtkButton" id="btn_playlistfolder">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <signal name="clicked" handler="on_btn_playlist_folder_clicked" swapped="no"/>
                       </object>
@@ -813,7 +813,7 @@
                   <object class="GtkCheckButton" id="checkbutton_delete_using_playlists">
                     <property name="label" translatable="yes">Remove episodes deleted on device from gPodder</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -864,7 +864,7 @@
                   <object class="GtkCheckButton" id="checkbutton_skip_played_episodes">
                     <property name="label" translatable="yes">Only sync unplayed episodes</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>
@@ -878,7 +878,7 @@
                   <object class="GtkCheckButton" id="checkbutton_delete_deleted_episodes">
                     <property name="label" translatable="yes">Remove episodes deleted in gPodder from device</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="draw-indicator">True</property>
                   </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -130,7 +130,7 @@
                           <object class="GtkImage" id="image4">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="stock">gtk-edit</property>
+                            <property name="icon-name">document-edit-symbolic</property>
                           </object>
                         </child>
                       </object>
@@ -173,7 +173,7 @@
                           <object class="GtkImage" id="image3">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="stock">gtk-edit</property>
+                            <property name="icon-name">document-edit-symbolic</property>
                           </object>
                         </child>
                       </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -206,7 +206,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
-                    <property name="draw-indicator">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -220,7 +220,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
-                    <property name="draw-indicator">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -252,7 +252,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
-                    <property name="draw-indicator">False</property>
+                    <property name="draw-indicator">True</property>
                     <signal name="toggled" handler="on_enabled_toggled" swapped="no"/>
                   </object>
                   <packing>
@@ -567,7 +567,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
-                    <property name="draw-indicator">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -648,7 +648,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
-                    <property name="draw-indicator">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -662,7 +662,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="receives-default">False</property>
-                    <property name="draw-indicator">False</property>
+                    <property name="draw-indicator">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -229,6 +229,20 @@
                   </packing>
                 </child>
               </object>
+              <packing>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">General</property>
+              </object>
+              <packing>
+                <property name="tab-fill">False</property>
+                <property name="position">0</property>
+              </packing>
             </child>
             <child>
               <object class="GtkBox" id="vbox_video">
@@ -351,7 +365,18 @@
                 </child>
               </object>
               <packing>
-                <property name="position">1</property>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Video</property>
+              </object>
+              <packing>
+                <property name="position">5</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -388,7 +413,18 @@
                 </child>
               </object>
               <packing>
-                <property name="position">2</property>
+                <property name="position">6</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Extensions</property>
+              </object>
+              <packing>
+                <property name="position">6</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -540,6 +576,17 @@
               </object>
               <packing>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">gpodder.net</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -720,6 +767,17 @@
                 <property name="position">2</property>
               </packing>
             </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Updating</property>
+              </object>
+              <packing>
+                <property name="position">2</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkBox" id="vbox_downloads">
                 <property name="visible">True</property>
@@ -802,6 +860,17 @@
               </object>
               <packing>
                 <property name="position">3</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Clean-up</property>
+              </object>
+              <packing>
+                <property name="position">3</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
             <child>
@@ -1009,6 +1078,17 @@
               </object>
               <packing>
                 <property name="position">4</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Devices</property>
+              </object>
+              <packing>
+                <property name="position">4</property>
+                <property name="tab-fill">False</property>
               </packing>
             </child>
           </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -244,6 +244,7 @@
               <object class="GtkBox" id="mygpo_config">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="border-width">12</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -229,9 +229,6 @@
                   </packing>
                 </child>
               </object>
-              <packing>
-                <property name="position">0</property>
-              </packing>
             </child>
             <child type="tab">
               <object class="GtkLabel">
@@ -240,190 +237,6 @@
                 <property name="label" translatable="yes">General</property>
               </object>
               <packing>
-                <property name="tab-fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox_video">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="border-width">12</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <!-- n-columns=3 n-rows=5 -->
-                  <object class="GtkGrid" id="table_video">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="row-spacing">6</property>
-                    <property name="column-spacing">12</property>
-                    <child>
-                      <object class="GtkLabel" id="label_preferred_youtube_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Preferred YouTube format:</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBox" id="combobox_preferred_youtube_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="hexpand">True</property>
-                        <signal name="changed" handler="on_combobox_preferred_youtube_format_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_preferred_youtube_hls_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Preferred YouTube HLS format:</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBox" id="combobox_preferred_youtube_hls_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="hexpand">True</property>
-                        <signal name="changed" handler="on_combobox_preferred_youtube_hls_format_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_preferred_vimeo_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Preferred Vimeo format:</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkComboBox" id="combobox_preferred_vimeo_format">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <signal name="changed" handler="on_combobox_preferred_vimeo_format_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">5</property>
-              </packing>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Video</property>
-              </object>
-              <packing>
-                <property name="position">5</property>
-                <property name="tab-fill">False</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox_extensions">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="border-width">12</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">6</property>
-                <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow2">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="shadow-type">in</property>
-                    <child>
-                      <object class="GtkTreeView" id="treeviewExtensions">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="headers-visible">False</property>
-                        <property name="search-column">1</property>
-                        <signal name="button-release-event" handler="on_treeview_extension_button_released" swapped="no"/>
-                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection"/>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="position">6</property>
-              </packing>
-            </child>
-            <child type="tab">
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Extensions</property>
-              </object>
-              <packing>
-                <property name="position">6</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>
@@ -1088,6 +901,189 @@
               </object>
               <packing>
                 <property name="position">4</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox_video">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <!-- n-columns=3 n-rows=5 -->
+                  <object class="GtkGrid" id="table_video">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="row-spacing">6</property>
+                    <property name="column-spacing">12</property>
+                    <child>
+                      <object class="GtkLabel" id="label_preferred_youtube_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Preferred YouTube format:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="combobox_preferred_youtube_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <signal name="changed" handler="on_combobox_preferred_youtube_format_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_preferred_youtube_hls_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Preferred YouTube HLS format:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="combobox_preferred_youtube_hls_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="hexpand">True</property>
+                        <signal name="changed" handler="on_combobox_preferred_youtube_hls_format_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_preferred_vimeo_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Preferred Vimeo format:</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="combobox_preferred_vimeo_format">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <signal name="changed" handler="on_combobox_preferred_vimeo_format_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Video</property>
+              </object>
+              <packing>
+                <property name="position">5</property>
+                <property name="tab-fill">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox_extensions">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">12</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTreeView" id="treeviewExtensions">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-visible">False</property>
+                        <property name="search-column">1</property>
+                        <signal name="button-release-event" handler="on_treeview_extension_button_released" swapped="no"/>
+                        <signal name="popup-menu" handler="on_treeview_extension_show_context_menu" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="position">6</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Extensions</property>
+              </object>
+              <packing>
+                <property name="position">6</property>
                 <property name="tab-fill">False</property>
               </packing>
             </child>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -60,11 +60,10 @@
             </child>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
-                <property name="use-stock">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>
               <packing>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -39,6 +39,10 @@
           <object class="GtkButtonBox" id="action_area">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="margin-start">5</property>
+            <property name="margin-end">5</property>
+            <property name="margin-top">5</property>
+            <property name="margin-bottom">5</property>
             <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="button_advanced">

--- a/src/gpodder/gtkui/desktop/podcastdirectory.py
+++ b/src/gpodder/gtkui/desktop/podcastdirectory.py
@@ -99,6 +99,7 @@ class DirectoryProvidersModel(Gtk.ListStore):
 
 class gPodderPodcastDirectory(BuilderWidget):
     def new(self):
+        self.gPodderPodcastDirectory.set_transient_for(self.parent_widget)
         if hasattr(self, 'custom_title'):
             self.main_window.set_title(self.custom_title)
 

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -185,6 +185,7 @@ class gPodderPreferences(BuilderWidget):
     C_TOGGLE, C_LABEL, C_EXTENSION, C_SHOW_TOGGLE = list(range(4))
 
     def new(self):
+        self.gPodderPreferences.set_transient_for(self.parent_widget)
         for cb in (self.combo_audio_player_app, self.combo_video_player_app):
             cellrenderer = Gtk.CellRendererPixbuf()
             cb.pack_start(cellrenderer, False)


### PR DESCRIPTION
Split from #1129. Save the ui-file with Glade to regularize it, fix the collateral damage and remove deprecated GTK features.

Sets the required GTK version to max 3.16 everywhere and updates README.md to mention this.

Also sets 'transient-for' to parent in podcastdirectory, as that was broken in a previous commit.