### PR TITLE
Paused episode icon

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -776,7 +776,8 @@ class DownloadTask(object):
                     time.sleep(delay)
 
     def recycle(self):
-        self.episode.download_task = None
+        if self.status not in (self.FAILED, self.PAUSED):
+            self.episode.download_task = None
 
     def set_episode_download_task(self):
         if not self.episode.download_task:

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -378,11 +378,21 @@ class EpisodeListModel(Gtk.ListStore):
         view_show_unplayed = False
         icon_theme = Gtk.IconTheme.get_default()
 
-        if episode.downloading:
-            tooltip.append('%s %d%%' % (_('Downloading'),
-                int(episode.download_task.progress * 100)))
+        task = episode.download_task
 
-            index = int(self.PROGRESS_STEPS * episode.download_task.progress)
+        if task is not None and task.status in (task.PAUSING, task.PAUSED):
+            tooltip.append('%s %d%%' % (_('Paused'),
+                int(task.progress * 100)))
+
+            status_icon = 'media-playback-pause'
+
+            view_show_downloaded = True
+            view_show_unplayed = True
+        elif episode.downloading:
+            tooltip.append('%s %d%%' % (_('Downloading'),
+                int(task.progress * 100)))
+
+            index = int(self.PROGRESS_STEPS * task.progress)
             status_icon = 'gpodder-progress-%d' % index
 
             view_show_downloaded = True


### PR DESCRIPTION
This changes the download progress icon to a paused icon when an episode is in the pausing or paused states.

@blushingpenguin Will it cause any issues to not recycle the paused task?