### PR TITLE
Fix youtube-dl re-download after a failed download

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -624,10 +624,9 @@ class DownloadTask(object):
         with self:
             # Cancelling directly is allowed if the task isn't currently downloading
             if self.status in (self.QUEUED, self.PAUSED, self.FAILED):
-                self.status = self.CANCELLED
-                # Call run, so the partial file gets deleted
+                self.status = self.CANCELLING
+                # Call run, so the partial file gets deleted, and task recycled
                 self.run()
-                self.recycle()
             # Otherwise request cancellation
             elif self.status == self.DOWNLOADING:
                 self.status = self.CANCELLING

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -953,10 +953,6 @@ class DownloadTask(object):
                 self.status = DownloadTask.FAILED
                 self.__episode._download_error = self.error_message
 
-                # Delete empty partial files, they prevent streaming after a download failure (live stream)
-                if util.calculate_size(self.filename) == 0:
-                    util.delete_file(self.tempname)
-
             # cancelled/paused -- update state to mark it as safe to manipulate this task again
             elif self.status == DownloadTask.PAUSING:
                 self.status = DownloadTask.PAUSED

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2125,6 +2125,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
         for episode in episodes:
             episode._download_error = None
 
+            if episode.download_task is not None and episode.download_task.status == episode.download_task.FAILED:
+                # Cancel failed task and remove from progress list
+                episode.download_task.cancel()
+                self.cleanup_downloads()
+
             player = self.episode_player(episode)
 
             try:


### PR DESCRIPTION
First patch fixes cancelling so it actually removes partial file. Second patch reverts part of #1044 and fixes #1147.