### PR TITLE
Use youtube-dl or yt-dlp for the youtube-dl extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ PyPI. With this, you get a self-contained gPodder CLI codebase.
 - Clickable links in GTK UI show notes: html5lib
 - HTML show notes: WebKit2 gobject bindings
     (webkit2gtk, webkitgtk4 or gir1.2-webkit2-4.0 packages).
-- Better Youtube support (> 15 entries in feeds, download audio-only): youtube_dl
+- Better Youtube support (> 15 entries in feeds, download audio-only): youtube_dl or yt-dlp
 
 
 ### Build Dependencies

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -10,7 +10,10 @@ import re
 import sys
 import time
 
-import youtube_dl
+try:
+    import yt_dlp as youtube_dl
+except:
+    import youtube_dl
 from youtube_dl.utils import DownloadError, ExtractorError, sanitize_url
 
 import gpodder
@@ -25,13 +28,13 @@ logger = logging.getLogger(__name__)
 
 
 __title__ = 'Youtube-dl'
-__description__ = _('Manage Youtube subscriptions using youtube-dl (pip install youtube_dl)')
+__description__ = _('Manage Youtube subscriptions using youtube-dl or yt-dlp (pip install youtube_dl) or (pip install yt-dlp)')
 __only_for__ = 'gtk, cli'
 __authors__ = 'Eric Le Lay <elelay.fr:contact>'
 __doc__ = 'https://gpodder.github.io/docs/extensions/youtubedl.html'
 
 want_ytdl_version = '2021.02.04'
-want_ytdl_version_msg = _('Your version of youtube-dl %(have_version)s has known issues, please upgrade to %(want_version)s or newer.')
+want_ytdl_version_msg = _('Your version of youtube-dl/yt-dlp %(have_version)s has known issues, please upgrade to %(want_version)s or newer.')
 
 DefaultConfig = {
     # youtube-dl downloads and parses each video page to get informations about it, which is very slow.
@@ -262,6 +265,7 @@ class gPodderYoutubeDL(download.CustomDownloader):
         self._ydl_opts = {
             'cachedir': cachedir,
             'no_color': True,  # prevent escape codes in desktop notifications on errors
+            'noprogress': True,  # prevent progress bar from appearing in console
         }
         if gpodder.verbose:
             self._ydl_opts['verbose'] = True
@@ -406,7 +410,11 @@ class gPodderYoutubeDL(download.CustomDownloader):
                 self.regex_cache.insert(0, r)
                 return True
         with youtube_dl.YoutubeDL(self._ydl_opts) as ydl:
-            for ie in ydl._ies:
+            # youtube-dl returns a list, yt-dlp returns a dict
+            ies = ydl._ies
+            if type(ydl._ies) == dict:
+                ies = ydl._ies.values()
+            for ie in ies:
                 if ie.suitable(url) and ie.ie_key() not in self.ie_blacklist:
                     self.regex_cache.insert(0, ie._VALID_URL_RE)
                     return True

--- a/tools/mac-osx/release_on_mac.sh
+++ b/tools/mac-osx/release_on_mac.sh
@@ -69,8 +69,8 @@ cp -a "$checkout"/tools/mac-osx/make_cert_pem.py "$resources"/bin
 $run_pip install setuptools wheel
 $run_pip install podcastparser==0.6.7 mygpoclient==1.8 requests[socks]==2.25.1
 
-# install extension dependencies; no explicit version for youtube_dl
-$run_pip install mutagen==1.45.1 html5lib==1.1 youtube_dl
+# install extension dependencies; no explicit version for yt-dlp
+$run_pip install mutagen==1.45.1 html5lib==1.1 yt-dlp
 
 cd "$checkout"
 touch share/applications/gpodder{,-url-handler}.desktop

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -8,6 +8,6 @@ urllib3==1.26.5
 html5lib==1.1
 mutagen==1.45.1
 dbus-python
-youtube_dl
+yt-dlp
 # eyed3 is optional and pulls in a lot of dependencies, so disable by default
 # eyed3

--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -91,7 +91,7 @@ html5lib==1.1
 webencodings==0.5.1
 certifi==2021.5.30
 mutagen==1.45.1
-youtube_dl
+yt-dlp
 requests==2.25.1
 urllib3==1.26.5
 chardet==4.0.0


### PR DESCRIPTION
This changes the youtube-dl extension to use yt-dlp if installed. As of yt-dlp 2021.10.09, the progress bar appears in the console and needs `noprogress` to suppress.

- [x] The mac and windows builds need to install yt-dlp and its dependencies.

Closes #1176.