### PR TITLE
Remove deprecated Gtk features from main gPodder window

### DIFF
--- a/share/gpodder/extensions/concatenate_videos.py
+++ b/share/gpodder/extensions/concatenate_videos.py
@@ -38,8 +38,8 @@ class gPodderExtension:
         dlg = Gtk.FileChooserDialog(title=_('Save video'),
                 parent=self.gpodder.get_dialog_parent(),
                 action=Gtk.FileChooserAction.SAVE)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        dlg.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+        dlg.add_button(_('_Save'), Gtk.ResponseType.OK)
 
         if dlg.run() == Gtk.ResponseType.OK:
             filename = dlg.get_filename()

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -20,7 +20,7 @@
     <property name="window-position">center</property>
     <signal name="delete-event" handler="on_gPodder_delete_event" swapped="no"/>
     <child>
-      <!-- n-columns=3 n-rows=3 -->
+      <!-- n-columns=1 n-rows=2 -->
       <object class="GtkGrid" id="vMain">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -127,7 +127,7 @@
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=3 -->
+          <!-- n-columns=1 n-rows=1 -->
           <object class="GtkGrid" id="hboxContainer">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -145,7 +145,7 @@
                     <property name="can-focus">True</property>
                     <property name="border-width">5</property>
                     <child>
-                      <!-- n-columns=3 n-rows=3 -->
+                      <!-- n-columns=1 n-rows=3 -->
                       <object class="GtkGrid" id="vboxChannelNavigator">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -182,7 +182,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=1 n-rows=1 -->
                           <object class="GtkGrid" id="hbox_search_podcasts">
                             <property name="can-focus">False</property>
                             <property name="column-spacing">6</property>
@@ -198,30 +198,6 @@
                                 <property name="top-attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -229,7 +205,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=1 n-rows=2 -->
                           <object class="GtkGrid" id="vbox42">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -249,7 +225,7 @@
                               </packing>
                             </child>
                             <child>
-                              <!-- n-columns=3 n-rows=3 -->
+                              <!-- n-columns=2 n-rows=1 -->
                               <object class="GtkGrid" id="hboxUpdateFeeds">
                                 <property name="can-focus">False</property>
                                 <property name="column-spacing">6</property>
@@ -284,77 +260,17 @@
                                     <property name="top-attach">0</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
                                 <property name="top-attach">1</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
                             <property name="top-attach">2</property>
                           </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -363,7 +279,7 @@
                       </packing>
                     </child>
                     <child>
-                      <!-- n-columns=3 n-rows=3 -->
+                      <!-- n-columns=1 n-rows=2 -->
                       <object class="GtkGrid" id="vbox_episode_list">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -401,7 +317,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=2 n-rows=1 -->
                           <object class="GtkGrid" id="hbox_search_episodes">
                             <property name="can-focus">False</property>
                             <property name="column-spacing">6</property>
@@ -428,53 +344,11 @@
                                 <property name="top-attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
                             <property name="top-attach">1</property>
                           </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
                         </child>
                       </object>
                       <packing>
@@ -495,7 +369,7 @@
                   </packing>
                 </child>
                 <child>
-                  <!-- n-columns=3 n-rows=3 -->
+                  <!-- n-columns=1 n-rows=2 -->
                   <object class="GtkGrid" id="vboxDownloadStatusWidgets">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -531,14 +405,14 @@
                       </packing>
                     </child>
                     <child>
-                      <!-- n-columns=3 n-rows=3 -->
+                      <!-- n-columns=3 n-rows=1 -->
                       <object class="GtkGrid" id="hboxDownloadSettings">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="border-width">5</property>
                         <property name="column-spacing">10</property>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=3 n-rows=1 -->
                           <object class="GtkGrid" id="hboxDownloadLimit">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -583,24 +457,6 @@
                                 <property name="top-attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -619,7 +475,7 @@
                           </packing>
                         </child>
                         <child>
-                          <!-- n-columns=3 n-rows=3 -->
+                          <!-- n-columns=2 n-rows=1 -->
                           <object class="GtkGrid" id="hboxDownloadRate">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -651,77 +507,17 @@
                                 <property name="top-attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
                           </object>
                           <packing>
                             <property name="left-attach">2</property>
                             <property name="top-attach">0</property>
                           </packing>
                         </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
                         <property name="top-attach">1</property>
                       </packing>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
                     </child>
                   </object>
                   <packing>
@@ -745,56 +541,11 @@
                 <property name="top-attach">0</property>
               </packing>
             </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
           </object>
           <packing>
             <property name="left-attach">0</property>
             <property name="top-attach">1</property>
           </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
         </child>
       </object>
     </child>

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -36,8 +36,7 @@
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Download</property>
-                <property name="use-underline">True</property>
-                <property name="stock-id">gtk-go-down</property>
+                <property name="icon-name">go-down</property>
                 <signal name="clicked" handler="on_download_selected_episodes" swapped="no"/>
               </object>
               <packing>
@@ -51,7 +50,8 @@
                 <property name="sensitive">False</property>
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
-                <property name="stock-id">gtk-media-play</property>
+                <property name="label" translatable="yes">Play</property>
+                <property name="icon-name">media-playback-start</property>
                 <signal name="clicked" handler="on_playback_selected_episodes" swapped="no"/>
               </object>
               <packing>
@@ -66,8 +66,7 @@
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Cancel</property>
-                <property name="use-underline">True</property>
-                <property name="stock-id">gtk-cancel</property>
+                <property name="icon-name">process-stop</property>
                 <signal name="clicked" handler="on_item_cancel_download_activate" swapped="no"/>
               </object>
               <packing>
@@ -91,7 +90,7 @@
                 <property name="can-focus">False</property>
                 <property name="action-name">app.preferences</property>
                 <property name="label" translatable="yes">Preferences</property>
-                <property name="stock-id">gtk-preferences</property>
+                <property name="icon-name">preferences-desktop</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -113,7 +112,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Quit</property>
-                <property name="stock-id">gtk-quit</property>
+                <property name="icon-name">application-exit</property>
                 <signal name="clicked" handler="on_gPodder_delete_event" swapped="no"/>
               </object>
               <packing>
@@ -190,9 +189,9 @@
                             <child>
                               <object class="GtkEntry" id="entry_search_podcasts">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>
-                                <property name="secondary-icon-stock">gtk-close</property>
+                                <property name="secondary-icon-name">edit-clear</property>
                               </object>
                               <packing>
                                 <property name="left-attach">0</property>
@@ -276,7 +275,7 @@
                                       <object class="GtkImage" id="image3209">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="stock">gtk-cancel</property>
+                                        <property name="icon-name">process-stop</property>
                                       </object>
                                     </child>
                                   </object>
@@ -383,7 +382,6 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="has-tooltip">True</property>
-                                <property name="rules-hint">True</property>
                                 <property name="enable-search">False</property>
                                 <property name="rubber-banding">True</property>
                                 <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
@@ -421,9 +419,9 @@
                             <child>
                               <object class="GtkEntry" id="entry_search_episodes">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can-focus">True</property>
                                 <property name="hexpand">True</property>
-                                <property name="secondary-icon-stock">gtk-close</property>
+                                <property name="secondary-icon-name">edit-clear</property>
                               </object>
                               <packing>
                                 <property name="left-attach">1</property>

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -1,54 +1,44 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <!--*- mode: xml -*-->
 <interface>
-  <!-- interface-requires gtk+ 3.10 -->
+  <requires lib="gtk+" version="3.16"/>
   <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">10240</property>
     <property name="lower">0.5</property>
-    <property name="page_increment">0</property>
-    <property name="step_increment">0.5</property>
-    <property name="page_size">0</property>
+    <property name="upper">10240</property>
+    <property name="step-increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
-    <property name="upper">16</property>
     <property name="lower">1</property>
-    <property name="page_increment">0</property>
-    <property name="step_increment">1</property>
-    <property name="page_size">0</property>
+    <property name="upper">16</property>
+    <property name="step-increment">1</property>
   </object>
   <object class="GtkApplicationWindow" id="gPodder">
     <property name="name">gPodder</property>
-    <property name="application">app</property>
-    <property name="visible">False</property>
+    <property name="can-focus">False</property>
     <property name="title">gPodder</property>
-    <property name="window_position">GTK_WIN_POS_CENTER</property>
-    <property name="modal">False</property>
-    <property name="destroy_with_parent">False</property>
-    <property name="skip_taskbar_hint">False</property>
-    <property name="skip_pager_hint">False</property>
-    <property name="type_hint">GDK_WINDOW_TYPE_HINT_NORMAL</property>
-    <property name="focus_on_map">True</property>
-    <property name="urgency_hint">False</property>
-    <signal handler="on_gPodder_delete_event" name="delete-event"/>
+    <property name="window-position">center</property>
+    <signal name="delete-event" handler="on_gPodder_delete_event" swapped="no"/>
     <child>
+      <!-- n-columns=3 n-rows=3 -->
       <object class="GtkGrid" id="vMain">
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkToolbar" id="toolbar">
             <property name="visible">True</property>
-            <property name="show_arrow">True</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkToolButton" id="toolDownload">
                 <property name="visible">True</property>
-                <property name="label" translatable="yes">Download</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-go-down</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">True</property>
                 <property name="sensitive">False</property>
-                <signal handler="on_download_selected_episodes" name="clicked"/>
+                <property name="can-focus">False</property>
+                <property name="is-important">True</property>
+                <property name="label" translatable="yes">Download</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-go-down</property>
+                <signal name="clicked" handler="on_download_selected_episodes" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -58,12 +48,11 @@
             <child>
               <object class="GtkToolButton" id="toolPlay">
                 <property name="visible">True</property>
-                <property name="stock_id">gtk-media-play</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">True</property>
                 <property name="sensitive">False</property>
-                <signal handler="on_playback_selected_episodes" name="clicked"/>
+                <property name="can-focus">False</property>
+                <property name="is-important">True</property>
+                <property name="stock-id">gtk-media-play</property>
+                <signal name="clicked" handler="on_playback_selected_episodes" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -73,14 +62,13 @@
             <child>
               <object class="GtkToolButton" id="toolCancel">
                 <property name="visible">True</property>
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-cancel</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">True</property>
                 <property name="sensitive">False</property>
-                <signal handler="on_item_cancel_download_activate" name="clicked"/>
+                <property name="can-focus">False</property>
+                <property name="is-important">True</property>
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="use-underline">True</property>
+                <property name="stock-id">gtk-cancel</property>
+                <signal name="clicked" handler="on_item_cancel_download_activate" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -90,8 +78,7 @@
             <child>
               <object class="GtkSeparatorToolItem" id="toolbutton3">
                 <property name="visible">True</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
+                <property name="can-focus">False</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -101,12 +88,10 @@
             <child>
               <object class="GtkToolButton" id="toolPreferences">
                 <property name="visible">True</property>
-                <property name="stock_id">gtk-preferences</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">False</property>
+                <property name="can-focus">False</property>
                 <property name="action-name">app.preferences</property>
                 <property name="label" translatable="yes">Preferences</property>
+                <property name="stock-id">gtk-preferences</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -116,8 +101,7 @@
             <child>
               <object class="GtkSeparatorToolItem" id="toolbutton2">
                 <property name="visible">True</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
+                <property name="can-focus">False</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -127,12 +111,10 @@
             <child>
               <object class="GtkToolButton" id="toolQuit">
                 <property name="visible">True</property>
-                <property name="stock_id">gtk-quit</property>
-                <property name="visible_horizontal">True</property>
-                <property name="visible_vertical">True</property>
-                <property name="is_important">False</property>
-                <signal handler="on_gPodder_delete_event" name="clicked"/>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Quit</property>
+                <property name="stock-id">gtk-quit</property>
+                <signal name="clicked" handler="on_gPodder_delete_event" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -140,349 +122,681 @@
               </packing>
             </child>
           </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
+          </packing>
         </child>
         <child>
+          <!-- n-columns=3 n-rows=3 -->
           <object class="GtkGrid" id="hboxContainer">
-            <property name="border_width">5</property>
             <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
+            <property name="border-width">5</property>
             <child>
               <object class="GtkNotebook" id="wNotebook">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="show_tabs">True</property>
-                <property name="show_border">True</property>
-                <property name="tab_pos">GTK_POS_TOP</property>
-                <property name="scrollable">False</property>
-                <property name="enable_popup">False</property>
-                <signal handler="on_wNotebook_switch_page" name="switch_page"/>
+                <property name="can-focus">True</property>
+                <signal name="switch-page" handler="on_wNotebook_switch_page" swapped="no"/>
                 <child>
                   <object class="GtkPaned" id="channelPaned">
-                    <property name="border_width">5</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="orientation">horizontal</property>
+                    <property name="can-focus">True</property>
+                    <property name="border-width">5</property>
                     <child>
+                      <!-- n-columns=3 n-rows=3 -->
                       <object class="GtkGrid" id="vboxChannelNavigator">
                         <property name="visible">True</property>
-                        <property name="row_spacing">5</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
+                        <property name="row-spacing">5</property>
                         <child>
                           <object class="GtkScrolledWindow" id="scrolledwindow6">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="vexpand">True</property>                            
-                            <property name="shadow_type">GTK_SHADOW_IN</property>
-                            <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                            <property name="can-focus">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="shadow-type">in</property>
                             <child>
                               <object class="GtkTreeView" id="treeChannels">
                                 <property name="name">treeChannels</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="headers_visible">False</property>
-                                <property name="rules_hint">False</property>
+                                <property name="can-focus">True</property>
                                 <property name="has-tooltip">True</property>
-                                <property name="reorderable">False</property>
-                                <property name="enable_search">True</property>
-                                <property name="fixed_height_mode">False</property>
-                                <property name="hover_selection">False</property>
-                                <property name="hover_expand">False</property>
-                                <signal handler="on_treeChannels_row_activated" name="row_activated"/>
-                                <signal handler="on_treeChannels_cursor_changed" name="cursor_changed"/>
-                                <signal handler="on_treeview_query_tooltip" name="query-tooltip"/>
-                                <signal handler="on_treeview_expose_event" name="draw"/>
-                                <signal handler="on_treeview_button_pressed" name="button-press-event"/>
-                                <signal handler="on_treeview_podcasts_button_released" name="button-release-event"/>
+                                <property name="headers-visible">False</property>
+                                <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
+                                <signal name="button-release-event" handler="on_treeview_podcasts_button_released" swapped="no"/>
+                                <signal name="cursor-changed" handler="on_treeChannels_cursor_changed" swapped="no"/>
+                                <signal name="draw" handler="on_treeview_expose_event" swapped="no"/>
+                                <signal name="query-tooltip" handler="on_treeview_query_tooltip" swapped="no"/>
+                                <signal name="row-activated" handler="on_treeChannels_row_activated" swapped="no"/>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hbox_search_podcasts">
-                            <property name="column_spacing">6</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">6</property>
                             <child>
                               <object class="GtkEntry" id="entry_search_podcasts">
-                                <property name="hexpand">True</property>
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="hexpand">True</property>
                                 <property name="secondary-icon-stock">gtk-close</property>
                               </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkGrid" id="vbox42">
-                            <property name="visible">True</property>
-                            <property name="orientation">vertical</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkButton" id="btnUpdateFeeds">
-                                <property name="label" translatable="yes">Check for new episodes</property>
-                                <property name="can_focus">True</property>
-                                <property name="focus_on_click">True</property>
-                                <property name="action-name">win.update</property>
-                                <property name="hexpand">True</property>
-                              </object>
                               <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
                               </packing>
                             </child>
                             <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <!-- n-columns=3 n-rows=3 -->
+                          <object class="GtkGrid" id="vbox42">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="hexpand">True</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkButton" id="btnUpdateFeeds">
+                                <property name="label" translatable="yes">Check for new episodes</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="action-name">win.update</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <!-- n-columns=3 n-rows=3 -->
                               <object class="GtkGrid" id="hboxUpdateFeeds">
-                                <property name="column_spacing">6</property>
-                                <property name="orientation">horizontal</property>
+                                <property name="can-focus">False</property>
+                                <property name="column-spacing">6</property>
                                 <child>
                                   <object class="GtkProgressBar" id="pbFeedUpdate">
+                                    <property name="can-focus">False</property>
                                     <property name="hexpand">True</property>
-                                    <property name="pulse_step">0.10000000149</property>
+                                    <property name="pulse-step">0.10000000149</property>
                                     <property name="show-text">True</property>
-                                    <property name="ellipsize">PANGO_ELLIPSIZE_MIDDLE</property>
+                                    <property name="ellipsize">middle</property>
                                   </object>
                                   <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="btnCancelFeedUpdate">
-                                    <property name="can_focus">True</property>
-                                    <property name="focus_on_click">True</property>
-                                    <signal handler="on_btnCancelFeedUpdate_clicked" name="clicked"/>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <signal name="clicked" handler="on_btnCancelFeedUpdate_clicked" swapped="no"/>
                                     <child>
                                       <object class="GtkImage" id="image3209">
                                         <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
                                         <property name="stock">gtk-cancel</property>
-                                        <property name="icon_size">4</property>
                                       </object>
                                     </child>
                                   </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">1</property>
                               </packing>
                             </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
-                        <property name="shrink">False</property>
                         <property name="resize">False</property>
+                        <property name="shrink">False</property>
                       </packing>
                     </child>
                     <child>
+                      <!-- n-columns=3 n-rows=3 -->
                       <object class="GtkGrid" id="vbox_episode_list">
                         <property name="visible">True</property>
-                        <property name="row_spacing">6</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
+                        <property name="row-spacing">6</property>
                         <child>
                           <object class="GtkScrolledWindow" id="scrollAvailable">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                            <property name="shadow_type">GTK_SHADOW_IN</property>
-                            <property name="hexpand">True</property>                            
-                            <property name="vexpand">True</property>                            
-                            <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
+                            <property name="can-focus">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="shadow-type">in</property>
                             <child>
                               <object class="GtkTreeView" id="treeAvailable">
                                 <property name="name">treeAvailable</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="headers_visible">True</property>
-                                <property name="rules_hint">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="has-tooltip">True</property>
+                                <property name="rules-hint">True</property>
+                                <property name="enable-search">False</property>
                                 <property name="rubber-banding">True</property>
-                                <property name="reorderable">False</property>
-                                <property name="enable_search">False</property>
-                                <property name="fixed_height_mode">False</property>
-                                <property name="hover_selection">False</property>
-                                <property name="hover_expand">False</property>
-                                <signal handler="on_treeAvailable_row_activated" name="row_activated"/>
-                                <signal handler="on_treeview_query_tooltip" name="query-tooltip"/>
-                                <signal handler="on_treeview_expose_event" name="draw"/>
-                                <signal handler="on_treeview_button_pressed" name="button-press-event"/>
-                                <signal handler="on_treeview_episodes_button_released" name="button-release-event"/>
+                                <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
+                                <signal name="button-release-event" handler="on_treeview_episodes_button_released" swapped="no"/>
+                                <signal name="draw" handler="on_treeview_expose_event" swapped="no"/>
+                                <signal name="query-tooltip" handler="on_treeview_query_tooltip" swapped="no"/>
+                                <signal name="row-activated" handler="on_treeAvailable_row_activated" swapped="no"/>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection"/>
+                                </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hbox_search_episodes">
-                            <property name="column_spacing">6</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label_search_episodes">
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Filter:</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkEntry" id="entry_search_episodes">
-                                <property name="hexpand">True</property>
                                 <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="hexpand">True</property>
                                 <property name="secondary-icon-stock">gtk-close</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="resize">True</property>
+                        <property name="shrink">False</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <child type="tab">
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Podcasts</property>
+                  </object>
+                  <packing>
+                    <property name="tab-fill">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <!-- n-columns=3 n-rows=3 -->
+                  <object class="GtkGrid" id="vboxDownloadStatusWidgets">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="border-width">5</property>
+                    <property name="orientation">vertical</property>
+                    <property name="row-spacing">5</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow-type">in</property>
+                        <child>
+                          <object class="GtkTreeView" id="treeDownloads">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="headers-visible">False</property>
+                            <property name="reorderable">True</property>
+                            <property name="rubber-banding">True</property>
+                            <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
+                            <signal name="button-release-event" handler="on_treeview_downloads_button_released" swapped="no"/>
+                            <signal name="draw" handler="on_treeview_expose_event" swapped="no"/>
+                            <signal name="row-activated" handler="on_treeDownloads_row_activated" swapped="no"/>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
                             </child>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="shrink">False</property>
-                        <property name="resize">True</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
-                  </object>
-                  <packing>
-                    <property name="tab_expand">False</property>
-                    <property name="tab_fill">True</property>
-                  </packing>
-                </child>
-                <child type="tab">
-                  <object class="GtkLabel" id="label2">
-                    <property name="visible">True</property>
-                    <property name="label" translatable="yes">Podcasts</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkGrid" id="vboxDownloadStatusWidgets">
-                    <property name="border_width">5</property>
-                    <property name="visible">True</property>
-                    <property name="row_spacing">5</property>
-                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="hscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="vscrollbar_policy">GTK_POLICY_AUTOMATIC</property>
-                        <property name="shadow_type">GTK_SHADOW_IN</property>
-                        <property name="window_placement">GTK_CORNER_TOP_LEFT</property>
-                        <child>
-                          <object class="GtkTreeView" id="treeDownloads">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="headers_visible">False</property>
-                            <property name="rules_hint">False</property>
-                            <property name="rubber-banding">True</property>
-                            <property name="reorderable">True</property>
-                            <property name="enable_search">True</property>
-                            <property name="fixed_height_mode">False</property>
-                            <property name="hover_selection">False</property>
-                            <property name="hover_expand">False</property>
-                            <signal handler="on_treeDownloads_row_activated" name="row_activated"/>
-                            <signal handler="on_treeview_expose_event" name="draw"/>
-                            <signal handler="on_treeview_button_pressed" name="button-press-event"/>
-                            <signal handler="on_treeview_downloads_button_released" name="button-release-event"/>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
+                      <!-- n-columns=3 n-rows=3 -->
                       <object class="GtkGrid" id="hboxDownloadSettings">
-                        <property name="border_width">5</property>
                         <property name="visible">True</property>
-                        <property name="column_spacing">10</property>
-                        <property name="orientation">horizontal</property>
+                        <property name="can-focus">False</property>
+                        <property name="border-width">5</property>
+                        <property name="column-spacing">10</property>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hboxDownloadLimit">
                             <property name="visible">True</property>
-                            <property name="column_spacing">5</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">5</property>
                             <child>
                               <object class="GtkCheckButton" id="cbLimitDownloads">
                                 <property name="label" translatable="yes">Limit rate to</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_cbLimitDownloads_toggled"/>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_cbLimitDownloads_toggled" swapped="no"/>
                               </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spinLimitDownloads">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="invisible_char">&#x25CF;</property>
-                                <property name="climb_rate">1</property>
-                                <property name="digits">1</property>
+                                <property name="can-focus">True</property>
+                                <property name="invisible-char">●</property>
                                 <property name="adjustment">adjustment1</property>
+                                <property name="climb-rate">1</property>
+                                <property name="digits">1</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="labelLimitRate">
                                 <property name="visible">True</property>
-                                <property name="xalign">0</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">KiB/s</property>
+                                <property name="xalign">0</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="DownloadSettingsSpacer">
                             <property name="visible">True</property>
-                            <property name="hexpand">True</property>                            
+                            <property name="can-focus">False</property>
+                            <property name="hexpand">True</property>
                           </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
                         </child>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="hboxDownloadRate">
                             <property name="visible">True</property>
-                            <property name="column_spacing">5</property>
-                            <property name="orientation">horizontal</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">5</property>
                             <child>
                               <object class="GtkCheckButton" id="cbMaxDownloads">
                                 <property name="label" translatable="yes">Limit downloads to</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_cbMaxDownloads_toggled"/>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_cbMaxDownloads_toggled" swapped="no"/>
                               </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spinMaxDownloads">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="invisible_char">&#x25CF;</property>
-                                <property name="climb_rate">1</property>
+                                <property name="can-focus">True</property>
+                                <property name="invisible-char">●</property>
                                 <property name="adjustment">adjustment2</property>
+                                <property name="climb-rate">1</property>
                               </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="tab_expand">False</property>
-                    <property name="tab_fill">True</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child type="tab">
                   <object class="GtkLabel" id="labelDownloads">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Progress</property>
-                    <property name="use_underline">False</property>
-                    <property name="use_markup">False</property>
-                    <property name="wrap">False</property>
-                    <property name="selectable">False</property>
-                    <property name="width_chars">-1</property>
-                    <property name="single_line_mode">False</property>
                   </object>
+                  <packing>
+                    <property name="position">1</property>
+                    <property name="tab-fill">False</property>
+                  </packing>
                 </child>
               </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
           </object>
           <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">1</property>
           </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
     </child>

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -202,7 +202,7 @@ class gPodderApplication(Gtk.Application):
     def on_about(self, action, param):
         dlg = Gtk.Dialog(_('About gPodder'), self.window.gPodder,
                 Gtk.DialogFlags.MODAL)
-        dlg.add_button(Gtk.STOCK_CLOSE, Gtk.ResponseType.OK).show()
+        dlg.add_button(_('_Close'), Gtk.ResponseType.OK).show()
         dlg.set_resizable(True)
 
         bg = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6, margin=16)

--- a/src/gpodder/gtkui/base.py
+++ b/src/gpodder/gtkui/base.py
@@ -50,9 +50,6 @@ class GtkBuilderWidget(object):
         if parent is not None:
             self.builder.expose_object('parent_widget', parent)
         self.builder.set_translation_domain(textdomain)
-        if hasattr(self, '_builder_expose'):
-            for (key, value) in list(self._builder_expose.items()):
-                self.builder.expose_object(key, value)
 
         # print >>sys.stderr, 'Creating new from file', self.__class__.__name__
 
@@ -67,6 +64,9 @@ class GtkBuilderWidget(object):
 
         self.builder.connect_signals(self)
         self.set_attributes()
+        if hasattr(self, '_gtk_properties'):
+            for ((gobj, prop), val) in self._gtk_properties.items():
+                getattr(self, gobj).set_property(prop, val)
 
         self.new()
 

--- a/src/gpodder/gtkui/desktop/channel.py
+++ b/src/gpodder/gtkui/desktop/channel.py
@@ -112,7 +112,7 @@ class gPodderChannel(BuilderWidget):
 
     def on_button_add_section_clicked(self, widget):
         text = self.show_text_edit_dialog(_('Add section'), _('New section:'),
-            affirmative_text=Gtk.STOCK_ADD)
+            affirmative_text=_('_Add'))
 
         if text is not None:
             for index, (section,) in enumerate(self.section_list):
@@ -146,8 +146,8 @@ class gPodderChannel(BuilderWidget):
             title=_('Select new podcast cover artwork'),
             parent=self.gPodderChannel,
             action=Gtk.FileChooserAction.OPEN)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        dlg.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+        dlg.add_button(_('_Open'), Gtk.ResponseType.OK)
 
         if dlg.run() == Gtk.ResponseType.OK:
             url = dlg.get_uri()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -671,8 +671,8 @@ class gPodderPreferences(BuilderWidget):
         fs = Gtk.FileChooserDialog(title=_('Select folder for mount point'),
                 action=Gtk.FileChooserAction.SELECT_FOLDER)
         fs.set_local_only(False)
-        fs.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        fs.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        fs.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+        fs.add_button(_('_Open'), Gtk.ResponseType.OK)
 
         fs.set_uri(self.btn_filesystemMountpoint.get_label() or "")
         if fs.run() == Gtk.ResponseType.OK:
@@ -689,8 +689,8 @@ class gPodderPreferences(BuilderWidget):
         fs = Gtk.FileChooserDialog(title=_('Select folder for playlists'),
                 action=Gtk.FileChooserAction.SELECT_FOLDER)
         fs.set_local_only(False)
-        fs.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        fs.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        fs.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+        fs.add_button(_('_Open'), Gtk.ResponseType.OK)
 
         device_folder = util.new_gio_file(self._config.device_sync.device_folder)
         playlists_folder = device_folder.resolve_relative_path(self._config.device_sync.playlists.folder)

--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -155,7 +155,7 @@ class UserAppsReader(object):
         self.apps.append(UserApplication(
             _('Default application'), 'default',
             ';'.join((mime + '/*' for mime in self.mimetypes)),
-            Gtk.STOCK_OPEN))
+            'document-open'))
 
     def add_separator(self):
         self.apps.append(UserApplication(

--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -65,7 +65,7 @@ class DownloadStatusModel(Gtk.ListStore):
         # Set up stock icon IDs for tasks
         self._status_ids = collections.defaultdict(lambda: None)
         self._status_ids[download.DownloadTask.DOWNLOADING] = 'go-down'
-        self._status_ids[download.DownloadTask.DONE] = Gtk.STOCK_APPLY
+        self._status_ids[download.DownloadTask.DONE] = 'object-select-symbolic'
         self._status_ids[download.DownloadTask.FAILED] = 'dialog-error'
         self._status_ids[download.DownloadTask.CANCELLING] = 'media-playback-stop'
         self._status_ids[download.DownloadTask.CANCELLED] = 'media-playback-stop'

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -127,11 +127,11 @@ class BuilderWidget(GtkBuilderWidget):
         return response == Gtk.ResponseType.YES
 
     def show_text_edit_dialog(self, title, prompt, text=None, empty=False,
-            is_url=False, affirmative_text=Gtk.STOCK_OK):
+            is_url=False, affirmative_text=_('_OK')):
         dialog = Gtk.Dialog(title, self.get_dialog_parent(),
             Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT)
 
-        dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        dialog.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
         dialog.add_button(affirmative_text, Gtk.ResponseType.OK)
 
         dialog.set_default_size(300, -1)
@@ -267,8 +267,8 @@ class BuilderWidget(GtkBuilderWidget):
             initial_directory = os.path.expanduser('~')
 
         dlg = Gtk.FileChooserDialog(title=title, parent=self.main_window, action=Gtk.FileChooserAction.SELECT_FOLDER)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        dlg.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+        dlg.add_button(_('_Save'), Gtk.ResponseType.OK)
 
         dlg.set_do_overwrite_confirmation(True)
         dlg.set_current_folder(initial_directory)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2839,8 +2839,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         if downloading:
             dialog = Gtk.MessageDialog(self.gPodder, Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.NONE)
-            dialog.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-            quit_button = dialog.add_button(Gtk.STOCK_QUIT, Gtk.ResponseType.CLOSE)
+            dialog.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+            quit_button = dialog.add_button(_('_Quit'), Gtk.ResponseType.CLOSE)
 
             title = _('Quit gPodder')
             message = _('You are downloading episodes. You can resume downloads the next time you start gPodder. Do you want to quit now?')
@@ -3419,8 +3419,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             dlg = Gtk.FileChooserDialog(title=_('Import from OPML'),
                     parent=self.main_window,
                     action=Gtk.FileChooserAction.OPEN)
-            dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-            dlg.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+            dlg.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+            dlg.add_button(_('_Open'), Gtk.ResponseType.OK)
             dlg.set_filter(self.get_opml_filter())
             response = dlg.run()
             filename = None
@@ -3447,8 +3447,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         dlg = Gtk.FileChooserDialog(title=_('Export to OPML'),
                                     parent=self.gPodder,
                                     action=Gtk.FileChooserAction.SAVE)
-        dlg.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
-        dlg.add_button(Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        dlg.add_button(_('_Cancel'), Gtk.ResponseType.CANCEL)
+        dlg.add_button(_('_Save'), Gtk.ResponseType.OK)
         dlg.set_filter(self.get_opml_filter())
         response = dlg.run()
         if response == Gtk.ResponseType.OK:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2262,9 +2262,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
             can_delete = not can_cancel
 
         if open_instead_of_play:
-            self.toolPlay.set_stock_id(Gtk.STOCK_OPEN)
+            self.toolPlay.set_icon_name('document-open')
         else:
-            self.toolPlay.set_stock_id(Gtk.STOCK_MEDIA_PLAY)
+            self.toolPlay.set_icon_name('media-playback-start')
         self.toolPlay.set_sensitive(can_play)
         self.toolDownload.set_sensitive(can_download)
         self.toolCancel.set_sensitive(can_cancel)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -89,7 +89,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.extensions_actions = []
         self._search_podcasts = None
         self._search_episodes = None
-        BuilderWidget.__init__(self, None, _builder_expose={'app': app})
+        BuilderWidget.__init__(self, None,
+            _gtk_properties={('gPodder', 'application'): app})
 
         self.last_episode_date_refresh = None
         self.refresh_episode_dates()

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -196,7 +196,7 @@ class EpisodeListModel(Gtk.ListStore):
         self.ICON_VIDEO_FILE = 'video-x-generic'
         self.ICON_IMAGE_FILE = 'image-x-generic'
         self.ICON_GENERIC_FILE = 'text-x-generic'
-        self.ICON_DOWNLOADING = Gtk.STOCK_GO_DOWN
+        self.ICON_DOWNLOADING = 'go-down'
         self.ICON_DELETED = 'edit-delete'
         self.ICON_ERROR = 'dialog-error'
 

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -31,7 +31,7 @@ from gpodder.gtkui.draw import (draw_text_box_centered, get_background_color,
 import gi  # isort:skip
 gi.require_version('Gdk', '3.0')  # isort:skip
 gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import Gdk, Gtk, Pango  # isort:skip
+from gi.repository import Gdk, Gio, GLib, Gtk, Pango  # isort:skip
 
 
 _ = gpodder.gettext
@@ -418,8 +418,8 @@ class gPodderShownotesHTML(gPodderShownotes):
             decision.use()
             return False
 
-    def on_open_in_browser(self, action):
-        util.open_website(action.url)
+    def on_open_in_browser(self, action, var):
+        util.open_website(var.get_string())
 
     def on_authenticate(self, view, request):
         if request.is_retry():
@@ -449,10 +449,10 @@ class gPodderShownotesHTML(gPodderShownotes):
             return False
 
     def create_open_item(self, name, label, url):
-        action = Gtk.Action.new(name, label, None, Gtk.STOCK_OPEN)
-        action.url = url
+        action = Gio.SimpleAction.new(name, GLib.VariantType.new('s'))
         action.connect('activate', self.on_open_in_browser)
-        return WebKit2.ContextMenuItem.new(action)
+        var = GLib.Variant.new_string(url)
+        return WebKit2.ContextMenuItem.new_from_gaction(action, label, var)
 
     def get_stylesheet(self):
         if self.stylesheet is None:


### PR DESCRIPTION
The remaining changes from #1129.

 * Replaces Gtk.Action in gPodderShownotesHTML with Gio.SimpleAction
 * Replaces GtkStock items with standard icon names and string labels in gpodder.ui and rest of the code
 * Regularizes gpodder.ui by saving with Glade and removing deprecated features, also removes extra placeholders in GtkGrids
 * Implements a way of setting Gtk properties in ui-file objects which is compatible with Glade

