### PR TITLE
Do not try to rename the outtmpl file in the Youtube-DL extension.

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -86,14 +86,10 @@ class YoutubeCustomDownload(download.CustomDownload):
         """
         self._reporthook = reporthook
         # outtmpl: use given tempname by DownloadTask
-        # (escape % and $ because outtmpl used as a string template by youtube-dl)
-        outtmpl = tempname.replace('%', '%%').replace('$', '$$')
+        # (escape % because outtmpl used as a string template by youtube-dl)
+        outtmpl = tempname.replace('%', '%%')
         res = self._ytdl.fetch_video(self._url, outtmpl, self._my_hook)
-        if outtmpl != tempname:
-            if 'ext' in res and os.path.isfile(outtmpl + '.{}'.format(res['ext'])):
-                os.rename(outtmpl + '.{}'.format(res['ext']), tempname)
-            else:
-                os.rename(outtmpl, tempname)
+        # Renaming is not required because the escaped percent is not escaped in the output file.
         if 'duration' in res and res['duration']:
             self._episode.total_time = res['duration']
         headers = {}


### PR DESCRIPTION
The output file does not contain the escaped percents, resulting in a file not found if renamed.

Youtube-DL also does not use '$' and escaping it is not required. An episode title containing a '$' will produce a file containing two dollar signs, and is then renamed to a single dollar sign. But a channel name containing a dollar sign causes Youtube-DL to create a new channel directory, with two dollar signs, for the output file. This directory remains empty after gpodder moves the output file.

Both cases can be tested by renaming a channel to have '%$' and then downloading episodes with Youtube-DL.

Therefore, dollar signs should not be escaped and renaming outtmpl is not required as it will always match tempname, when assuming percents are unescaped.