### PR TITLE
Open error dialog if user tries to use not-installed xdg-open

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2187,7 +2187,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         if 'default' in groups:
             for filename in groups['default']:
                 logger.debug('Opening with system default: %s', filename)
-                util.gui_open(filename)
+                util.gui_open(filename, gui=self)
             del groups['default']
 
         # For each type now, go and create play commands


### PR DESCRIPTION
Currently trying to use default player xdg-open when it's not installed
will only cause messages on the console, which might not be visible to
the user. This PR creates an alert box in this case.

Fixes #1003.