### PR TITLE
YoutubeDL partial file fixes

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -99,18 +99,16 @@ class YoutubeCustomDownload(download.CustomDownload):
             # See #673 when merging multiple formats, the extension is appended to the tempname
             # by YoutubeDL resulting in empty .partial file + .partial.mp4 exists
             # and #796 .mkv is chosen by ytdl sometimes
-            tempstat = os.stat(tempname)
-            if not tempstat.st_size:
-                for try_ext in (dot_ext, ".mp4", ".m4a", ".webm", ".mkv"):
-                    tempname_with_ext = tempname + try_ext
-                    if os.path.isfile(tempname_with_ext):
-                        logger.debug('Youtubedl downloaded to "%s" instead of "%s", moving',
-                                     os.path.basename(tempname_with_ext),
-                                     os.path.basename(tempname))
-                        os.remove(tempname)
-                        os.rename(tempname_with_ext, tempname)
-                        dot_ext = try_ext
-                        break
+            for try_ext in (dot_ext, ".mp4", ".m4a", ".webm", ".mkv"):
+                tempname_with_ext = tempname + try_ext
+                if os.path.isfile(tempname_with_ext):
+                    logger.debug('Youtubedl downloaded to "%s" instead of "%s", moving',
+                                 os.path.basename(tempname_with_ext),
+                                 os.path.basename(tempname))
+                    os.remove(tempname)
+                    os.rename(tempname_with_ext, tempname)
+                    dot_ext = try_ext
+                    break
             ext_filetype = mimetype_from_extension(dot_ext)
             if ext_filetype:
                 # Youtube weba formats have a webm extension and get a video/webm mime-type

--- a/src/gpodder/common.py
+++ b/src/gpodder/common.py
@@ -40,6 +40,8 @@ def clean_up_downloads(delete_partial=False):
 
     if delete_partial:
         temporary_files += glob.glob('%s/*/*.partial' % gpodder.downloads)
+        # YoutubeDL creates .partial.* files for adaptive formats
+        temporary_files += glob.glob('%s/*/*.partial.*' % gpodder.downloads)
 
     for tempfile in temporary_files:
         util.delete_file(tempfile)
@@ -53,7 +55,7 @@ def find_partial_downloads(channels, start_progress_callback, progress_callback,
     progress_callback - A callback(title, progress) when an episode was found
     finish_progress_callback - A callback(resumable_episodes) when finished
     """
-    # Look for partial file downloads
+    # Look for partial file downloads, ignoring .partial.* files created by YoutubeDL
     partial_files = glob.glob(os.path.join(gpodder.downloads, '*', '*.partial'))
     count = len(partial_files)
     resumable_episodes = []


### PR DESCRIPTION
The first patch fixes an issue caused by yt-dlp that results in a truncated download and a partial file containing the full download which must be manually renamed or deleted outside of gPodder.

The second patch cleans up YoutubeDL partial files after cancelling a download.