### PR TITLE
gPodderExportToLocalFolder: Use GtkDialog.add_buttons()

### DIFF
--- a/share/gpodder/ui/gtk/gpodderexporttolocalfolder.ui
+++ b/share/gpodder/ui/gtk/gpodderexporttolocalfolder.ui
@@ -15,7 +15,7 @@
     <property name="window-position">center-on-parent</property>
     <property name="type-hint">dialog</property>
     <property name="action">save</property>
-    <property name="do-overwrite-confirmation">True</property>
+    <property name="do-overwrite-confirmation">False</property>
     <property name="extra-widget">allsamefolder</property>
     <property name="preview-widget-active">False</property>
     <property name="use-preview-label">False</property>
@@ -29,36 +29,10 @@
             <property name="can-focus">False</property>
             <property name="layout-style">end</property>
             <child>
-              <object class="GtkButton" id="btnCancel">
-                <property name="label" translatable="yes">_Cancel</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="use-underline">True</property>
-                <signal name="clicked" handler="on_btnCancel_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
+              <placeholder/>
             </child>
             <child>
-              <object class="GtkButton" id="btnOK">
-                <property name="label" translatable="yes">_Save</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="can-default">True</property>
-                <property name="has-default">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-underline">True</property>
-                <signal name="clicked" handler="on_btnOK_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
+              <placeholder/>
             </child>
           </object>
           <packing>
@@ -69,9 +43,5 @@
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="-6">btnCancel</action-widget>
-      <action-widget response="-3">btnOK</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/src/gpodder/gtkui/desktop/exportlocal.py
+++ b/src/gpodder/gtkui/desktop/exportlocal.py
@@ -32,17 +32,12 @@ class gPodderExportToLocalFolder(BuilderWidget):
     """ Export to Local Folder UI: file dialog + checkbox to save all to same folder """
     def new(self):
         self.gPodderExportToLocalFolder.set_transient_for(self.parent_widget)
+        self.RES_CANCEL = -6
+        self.RES_SAVE = -3
+        self.gPodderExportToLocalFolder.add_buttons("_Cancel", self.RES_CANCEL,
+                                                    "_Save", self.RES_SAVE)
         self._config.connect_gtk_window(self.gPodderExportToLocalFolder,
                                         'export_to_local_folder', True)
-        self._ok = False
-        self.gPodderExportToLocalFolder.hide()
-
-    def on_btnOK_clicked(self, widget):
-        self._ok = True
-        self.gPodderExportToLocalFolder.hide()
-
-    def on_btnCancel_clicked(self, widget):
-        self.gPodderExportToLocalFolder.hide()
 
     def save_as(self, initial_directory, filename, remaining=0):
         """
@@ -64,9 +59,9 @@ class gPodderExportToLocalFolder(BuilderWidget):
             initial_directory = os.path.expanduser('~')
         self.gPodderExportToLocalFolder.set_current_folder(initial_directory)
         self.gPodderExportToLocalFolder.set_current_name(filename)
-        self._ok = False
-        self.gPodderExportToLocalFolder.run()
-        notCancelled = self._ok
+        res = self.gPodderExportToLocalFolder.run()
+        self.gPodderExportToLocalFolder.hide()
+        notCancelled = (res == self.RES_SAVE)
         allRemainingDefault = self.allsamefolder.get_active()
         if notCancelled:
             folder = self.gPodderExportToLocalFolder.get_current_folder()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1828,9 +1828,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
             if os.path.exists(copy_to):
                 logger.warn(copy_from)
                 logger.warn(copy_to)
-                title = _('File already exist')
+                title = _('File already exists')
                 d = {'filename': os.path.basename(copy_to)}
-                message = _('A file named "%(filename)s" already exist. Do you want to replace it?') % d
+                message = _('A file named "%(filename)s" already exists. Do you want to replace it?') % d
                 if not self.show_confirmation(message, title):
                     return
             try:


### PR DESCRIPTION
Currently the gPodderExportToLocalFolder dialog adds the OK and Cancel buttons to the action area explicitly in the ui-file. This causes Gtk warnings on systems which are configured to have dialog the buttons in the window headerbar.

The correct way is to add the buttons with GtkDialog.add_buttons() method, which places the buttons either to the header bar or the action area depending on system settings.

Also fix strings in the 'File already exists' confirmation dialog.