### PR TITLE
Create partial file when reusing cancelled tasks.

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -693,6 +693,11 @@ class DownloadTask(object):
         # Store a reference to this task in the episode
         episode.download_task = self
 
+    def reuse(self):
+        if not os.path.exists(self.tempname):
+            # partial file was deleted when cancelled, recreate it
+            open(self.tempname, 'w').close()
+
     def notify_as_finished(self):
         if self.status == DownloadTask.DONE:
             if self._notification_shown:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -3117,6 +3117,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 for task in self.download_tasks_seen:
                     if episode.url == task.url:
                         task_exists = True
+                        task.reuse()
                         if task.status not in (task.DOWNLOADING, task.QUEUED):
                             if downloader:
                                 # replace existing task's download with forced one


### PR DESCRIPTION
The partial file for a cancelled task is deleted, but the task is not removed from progress list while other tasks are downloading. Downloading the cancelled episode again would reuse the existing task without creating a new partial file. This prevented resuming the download after restarting gPodder, and caused the youtube-dl extension to fail if used to re-download it.