### PR TITLE
Undelete deleted episodes when a download is attempted.

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -3113,6 +3113,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
             logger.debug('Downloading episode: %s', episode.title)
             if not episode.was_downloaded(and_exists=True):
                 episode._download_error = None
+                if episode.state == gpodder.STATE_DELETED:
+                    episode.state = gpodder.STATE_NORMAL
+                    episode.save()
                 task_exists = False
                 for task in self.download_tasks_seen:
                     if episode.url == task.url:


### PR DESCRIPTION
In the event of a download failure, the error icon will properly display, and the episode will remain undeleted after a restart for another download attempt.