### PR TITLE
Generate HTML episode description only when needed.

### DIFF
--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -261,7 +261,7 @@ class gPodderExtension:
         else:
             info['title'] = title
 
-        info['subtitle'] = episode.description
+        info['subtitle'] = episode._text_description
 
         if self.container.config.genre_tag is not None:
             info['genre'] = self.container.config.genre_tag

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -211,8 +211,6 @@ class YoutubeFeed(model.Feed):
         episodes = []
         for en in self._ie_result['entries']:
             guid = video_guid(en['id'])
-            description = util.remove_html_tags(en.get('description') or _('No description available'))
-            html_description = util.nice_html_description(en.get('thumbnail'), description)
             if en.get('ext'):
                 mime_type = util.mimetype_from_extension('.{}'.format(en['ext']))
             else:
@@ -225,8 +223,9 @@ class YoutubeFeed(model.Feed):
             ep = {
                 'title': en.get('title', guid),
                 'link': en.get('webpage_url'),
-                'description': description,
-                'description_html': html_description,
+                'episode_art_url': en.get('thumbnail'),
+                'description': util.remove_html_tags(en.get('description') or ''),
+                'description_html': '',
                 'url': en.get('webpage_url'),
                 'file_size': filesize,
                 'mime_type': mime_type,

--- a/src/gpodder/dbusproxy.py
+++ b/src/gpodder/dbusproxy.py
@@ -113,7 +113,7 @@ class DBusPodcastsProxy(dbus.service.Object):
         def episode_to_tuple(episode):
             title = safe_str(episode.title)
             url = safe_str(episode.url)
-            description = safe_first_line(episode.description)
+            description = safe_first_line(episode._text_description)
             filename = safe_str(episode.download_filename)
             file_type = safe_str(episode.file_type())
             is_new = (episode.state == gpodder.STATE_NORMAL and episode.is_new)

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -219,7 +219,7 @@ class gPodderShownotesText(gPodderShownotes):
         self.text_buffer.insert_at_cursor('\n')
         self.text_buffer.insert_with_tags_by_name(self.text_buffer.get_end_iter(), details, 'details')
         self.text_buffer.insert_at_cursor('\n\n')
-        for target, text in util.extract_hyperlinked_text(episode.description_html or episode.description):
+        for target, text in util.extract_hyperlinked_text(episode.html_description()):
             hyperlinks.append((self.text_buffer.get_char_count(), target))
             if target:
                 self.text_buffer.insert_with_tags_by_name(
@@ -349,13 +349,10 @@ class gPodderShownotesHTML(gPodderShownotes):
             'duration': episode.get_play_info_string()})
         header_html = _('<div id="gpodder-title">\n%(heading)s\n<p>%(subheading)s</p>\n<p>%(details)s</p></div>\n') \
             % dict(heading=heading, subheading=subheading, details=details)
-        description_html = episode.description_html
-        if not description_html:
-            description_html = re.sub(r'\n', '<br>\n', episode.description)
         # uncomment to prevent background override in html shownotes
         # self.manager.remove_all_style_sheets ()
         logger.debug("base uri: %s (chan:%s)", self._base_uri, episode.channel.url)
-        self.html_view.load_html(header_html + description_html, self._base_uri)
+        self.html_view.load_html(header_html + episode.html_description(), self._base_uri)
         # uncomment to show web inspector
         # self.html_view.get_inspector().show()
         self.episode = episode

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -368,8 +368,10 @@ class PodcastEpisode(PodcastModelObject):
         self.file_size = 0
         self.mime_type = 'application/octet-stream'
         self.guid = ''
+        self.episode_art_url = None
         self.description = ''
         self.description_html = ''
+        self.chapters = None
         self.link = ''
         self.published = 0
         self.download_filename = None
@@ -864,7 +866,8 @@ class PodcastEpisode(PodcastModelObject):
             return '-'
 
     def update_from(self, episode):
-        for k in ('title', 'url', 'description', 'description_html', 'link', 'published', 'guid', 'payment_url'):
+        for k in ('title', 'url', 'episode_art_url', 'description', 'description_html', 'chapters', 'link',
+                  'published', 'guid', 'payment_url'):
             setattr(self, k, getattr(episode, k))
         # Don't overwrite file size on downloaded episodes
         # See #648 refreshing a youtube podcast clears downloaded file size

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -28,6 +28,7 @@ import collections
 import datetime
 import glob
 import hashlib
+import json
 import logging
 import os
 import re
@@ -302,6 +303,9 @@ class PodcastEpisode(PodcastModelObject):
         episode.total_time = entry['total_time']
         episode.published = entry['published']
         episode.payment_url = entry['payment_url']
+        episode.chapters = None
+        if entry.get("chapters"):
+            episode.chapters = json.dumps(entry["chapters"])
 
         audio_available = any(enclosure['mime_type'].startswith('audio/') for enclosure in entry['enclosures'])
         video_available = any(enclosure['mime_type'].startswith('video/') for enclosure in entry['enclosures'])

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -167,7 +167,8 @@ class SoundcloudUser(object):
                 yield {
                     'title': track.get('title', track.get('permalink')) or _('Unknown track'),
                     'link': track.get('permalink_url') or 'https://soundcloud.com/' + self.username,
-                    'description': track.get('description') or _('No description available'),
+                    'description': util.remove_html_tags(track.get('description') or ''),
+                    'description_html': '',
                     'url': url,
                     'file_size': int(filesize),
                     'mime_type': filetype,

--- a/src/gpodder/query.py
+++ b/src/gpodder/query.py
@@ -46,7 +46,7 @@ class Matcher(object):
                     return (needle in haystack)
                 if needle in self._episode.title:
                     return True
-                return (needle in self._episode.description)
+                return (needle in self._episode._text_description)
 
             # case-insensitive search in haystack, or both title and description if no haystack
             def s(needle, haystack=None):
@@ -55,7 +55,7 @@ class Matcher(object):
                     return (needle in haystack.casefold())
                 if needle in self._episode.title.casefold():
                     return True
-                return (needle in self._episode.description.casefold())
+                return (needle in self._episode._text_description.casefold())
 
             # case-sensitive regular expression search in haystack, or both title and description if no haystack
             def R(needle, haystack=None):
@@ -64,7 +64,7 @@ class Matcher(object):
                     return regexp.search(haystack)
                 if regexp.search(self._episode.title):
                     return True
-                return regexp.search(self._episode.description)
+                return regexp.search(self._episode._text_description)
 
             # case-insensitive regular expression search in haystack, or both title and description if no haystack
             def r(needle, haystack=None):
@@ -73,7 +73,7 @@ class Matcher(object):
                     return regexp.search(haystack)
                 if regexp.search(self._episode.title):
                     return True
-                return regexp.search(self._episode.description)
+                return regexp.search(self._episode._text_description)
 
             return bool(eval(term, {'__builtins__': None, 'S': S, 's': s, 'R': R, 'r': r}, self))
         except Exception as e:
@@ -108,7 +108,7 @@ class Matcher(object):
         elif k == 'title':
             return episode.title
         elif k == 'description':
-            return episode.description
+            return episode._text_description
         elif k == 'since':
             return (datetime.datetime.now() - datetime.datetime.fromtimestamp(episode.published)).days
         elif k == 'age':
@@ -215,7 +215,7 @@ class EQL(object):
         if self._regex:
             return re.search(self._query, episode.title, self._flags) is not None
         elif self._string:
-            return self._query in episode.title.lower() or self._query in episode.description.lower()
+            return self._query in episode.title.lower() or self._query in episode._text_description.lower()
 
         return Matcher(episode).match(self._query)
 

--- a/src/gpodder/schema.py
+++ b/src/gpodder/schema.py
@@ -50,6 +50,8 @@ EpisodeColumns = (
     'last_playback',
     'payment_url',
     'description_html',
+    'episode_art_url',
+    'chapters',
 )
 
 PodcastColumns = (
@@ -72,7 +74,7 @@ PodcastColumns = (
     'cover_thumb',
 )
 
-CURRENT_VERSION = 7
+CURRENT_VERSION = 8
 
 
 # SQL commands to upgrade old database versions to new ones
@@ -112,6 +114,13 @@ UPGRADE_SQL = [
         ALTER TABLE episode ADD COLUMN description_html TEXT NOT NULL DEFAULT ''
         UPDATE episode SET description_html=description WHERE is_html(description)
         UPDATE episode SET description=remove_html_tags(description_html) WHERE is_html(description)
+        UPDATE podcast SET http_last_modified=NULL, http_etag=NULL
+        """),
+
+        # Version 8: Add episode thumbnail URL and chapters
+        (7, 8, """
+        ALTER TABLE episode ADD COLUMN episode_art_url TEXT NULL DEFAULT NULL
+        ALTER TABLE episode ADD COLUMN chapters TEXT NULL DEFAULT NULL
         UPDATE podcast SET http_last_modified=NULL, http_etag=NULL
         """),
 ]
@@ -172,7 +181,9 @@ def initialize_database(db):
         current_position_updated INTEGER NOT NULL DEFAULT 0,
         last_playback INTEGER NOT NULL DEFAULT 0,
         payment_url TEXT NULL DEFAULT NULL,
-        description_html TEXT NOT NULL DEFAULT ''
+        description_html TEXT NOT NULL DEFAULT '',
+        episode_art_url TEXT NULL DEFAULT NULL,
+        chapters TEXT NULL DEFAULT NULL
     )
     """)
 
@@ -299,6 +310,8 @@ def convert_gpodder2_db(old_db, new_db):
                 0,
                 None,
                 '',
+                None,
+                None,
         )
         new_db.execute("""
         INSERT INTO episode VALUES (%s)

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -396,7 +396,7 @@ class iPodDevice(Device):
             return False
 
         track = self.ipod.add_track(local_filename, episode.title, episode.channel.title,
-                util.remove_html_tags(episode.description), episode.url, episode.channel.url,
+                episode._text_description, episode.url, episode.channel.url,
                 episode.published, get_track_length(local_filename), episode.file_type() == 'audio')
 
         self.update_from_episode(track, episode, initial=True)


### PR DESCRIPTION
**WARNING: This patch changes the database schema and version. A backup will be created in your gPodder directory the first time you use this patch on an existing database.**

PR #1094 generated an HTML description for any episode that lacked one. That however increased the database size (almost double in worst case) because it was storing both text and html versions of each description. This fixes that by storing the episode thumbnail URL in the database and generating the HTML description only when shownotes are drawn.

The text description is now cleared for episodes with an HTML description. This further reduces database size for feeds that provide both. It also fixes an issue for feeds that provide different text and HTML descriptions, because the short description would show the text description and shownotes would show the HTML description. And EQL only searched the text descriptions, which might not match what the user sees in the shownotes.