### PR TITLE
Allow failed downloads to be cancelled from episodes list.

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -812,6 +812,7 @@ class DownloadTask(object):
         with self:
             if self.status == DownloadTask.CANCELLING:
                 self.status = DownloadTask.CANCELLED
+                self.__episode._download_error = None
                 self.delete_partial_files()
                 self.progress = 0.0
                 self.speed = 0.0
@@ -913,6 +914,7 @@ class DownloadTask(object):
         except DownloadCancelledException:
             logger.info('Download has been cancelled/paused: %s', self)
             if self.status == DownloadTask.CANCELLING:
+                self.__episode._download_error = None
                 self.delete_partial_files()
                 self.progress = 0.0
                 self.speed = 0.0

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2280,6 +2280,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
                                 can_resume = True
                             elif episode.download_task.status in (episode.download_task.QUEUED, episode.download_task.DOWNLOADING):
                                 can_pause = True
+                    elif episode.download_task is not None and episode.download_task.status == episode.download_task.FAILED:
+                        can_cancel = True
                     else:
                         streaming_possible |= self.streaming_possible(episode)
                         can_download = True


### PR DESCRIPTION
This not only removes the failed download from the progress list, but also removes the error icon from the episode list.