### PR TITLE
Set episode toolbar and menu actions.

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1966,7 +1966,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
             menu = Gtk.Menu()
 
-            (can_play, can_download, can_pause, can_cancel, can_delete, open_instead_of_play) = self.play_or_download()
+            (open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete) = self.play_or_download()
 
             if open_instead_of_play:
                 item = Gtk.ImageMenuItem(_('Open'))
@@ -2080,6 +2080,42 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 menu.popup(None, None, None, None, event.button, event.time)
 
             return True
+
+    def set_episode_actions(self, open_instead_of_play=False, can_play=False, can_download=False, can_pause=False, can_cancel=False,
+                            can_delete=False):
+        # play icon and label
+        if open_instead_of_play:
+            self.toolPlay.set_icon_name('document-open')
+            self.toolPlay.set_label(_('Open'))
+        else:
+            self.toolPlay.set_icon_name('media-playback-start')
+
+            episodes = self.get_selected_episodes()
+            downloaded = all(e.was_downloaded(and_exists=True) for e in episodes)
+            downloading = any(e.downloading for e in episodes)
+
+            if downloaded:
+                self.toolPlay.set_label(_('Play'))
+            elif downloading:
+                self.toolPlay.set_label(_('Preview'))
+            else:
+                self.toolPlay.set_label(_('Stream'))
+
+        # toolbar
+        self.toolPlay.set_sensitive(can_play)
+        self.toolDownload.set_sensitive(can_download)
+        self.toolPause.set_sensitive(can_pause)
+        self.toolCancel.set_sensitive(can_cancel)
+
+        # Episodes menu
+        self.play_action.set_enabled(can_play and not open_instead_of_play)
+        self.open_action.set_enabled(can_play and open_instead_of_play)
+        self.download_action.set_enabled(can_download)
+        self.pause_action.set_enabled(can_pause)
+        self.cancel_action.set_enabled(can_cancel)
+        self.delete_action.set_enabled(can_delete)
+        self.toggle_episode_new_action.set_enabled(can_play)
+        self.toggle_episode_lock_action.set_enabled(can_play)
 
     def set_title(self, new_title):
         self.default_title = new_title
@@ -2249,7 +2285,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.toolCancel.set_sensitive(True)
             return (False,) * 6
 
-        (can_play, can_download, can_pause, can_cancel, can_delete, open_instead_of_play) = (False,) * 6
+        (open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete) = (False,) * 6
 
         can_resume = False
 
@@ -2295,25 +2331,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
             can_play = streaming_possible or (can_play and not can_cancel and not can_download)
             can_delete = can_delete and not can_cancel
 
-        if open_instead_of_play:
-            self.toolPlay.set_icon_name('document-open')
-        else:
-            self.toolPlay.set_icon_name('media-playback-start')
-        self.toolPlay.set_sensitive(can_play)
-        self.toolDownload.set_sensitive(can_download)
-        self.toolPause.set_sensitive(can_pause)
-        self.toolCancel.set_sensitive(can_cancel)
+        self.set_episode_actions(open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete)
 
-        self.cancel_action.set_enabled(can_cancel)
-        self.download_action.set_enabled(can_download)
-        self.pause_action.set_enabled(can_pause)
-        self.open_action.set_enabled(can_play and open_instead_of_play)
-        self.play_action.set_enabled(can_play and not open_instead_of_play)
-        self.delete_action.set_enabled(can_delete)
-        self.toggle_episode_new_action.set_enabled(can_play)
-        self.toggle_episode_lock_action.set_enabled(can_play)
-
-        return (can_play, can_download, can_pause, can_cancel, can_delete, open_instead_of_play)
+        return (open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete)
 
     def on_cbMaxDownloads_toggled(self, widget, *args):
         self.spinMaxDownloads.set_sensitive(self.cbMaxDownloads.get_active())
@@ -3568,10 +3588,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 self.message_area.hide()
                 self.message_area = None
         else:
-            self.toolPlay.set_sensitive(False)
-            self.toolDownload.set_sensitive(False)
-            self.toolPause.set_sensitive(False)
-            self.toolCancel.set_sensitive(False)
+            # disable all episode actions
+            self.set_episode_actions()
 
     def on_treeChannels_row_activated(self, widget, path, *args):
         # double-click action of the podcast list or enter


### PR DESCRIPTION
Items in the Episode menu were not disabled when the progess tab was opened. This consolidates the enabling and disabling of buttons in the toolbar and items in the Episodes menu, and fixes that issue.

It also changes the label and icon for the toolbar play button to be Open, Play, Preview or Stream.

I haven't yet figured out how, but if possible, this new function could change the Play menu item label as well, and no longer need the Open menu item.