### PR TITLE
Refactor play_or_download() progress tab action code.

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -485,20 +485,20 @@ class PodcastEpisode(PodcastModelObject):
         """
         return not self.was_downloaded(and_exists=True) and (
             not self.download_task
-            or self.download_task.status in (self.download_task.PAUSING, self.download_task.PAUSED, self.download_task.FAILED))
+            or self.download_task.can_queue()
+            or self.download_task.status == self.download_task.PAUSING)
 
     def can_pause(self):
         """
         gPodder.on_pause_selected_episodes() filters selection with this method.
         """
-        return self.download_task and self.download_task.status in (self.download_task.QUEUED, self.download_task.DOWNLOADING)
+        return self.download_task and self.download_task.can_pause()
 
     def can_cancel(self):
         """
         DownloadTask.cancel() only cancels the following tasks.
         """
-        return self.download_task and self.download_task.status in \
-            (self.download_task.DOWNLOADING, self.download_task.QUEUED, self.download_task.PAUSED, self.download_task.FAILED)
+        return self.download_task and self.download_task.can_cancel()
 
     def can_delete(self):
         """

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -779,6 +779,12 @@ class SyncTask(download.DownloadTask):
 
     episode = property(fget=__get_episode)
 
+    def can_queue(self):
+        return self.status in (self.CANCELLED, self.PAUSED, self.FAILED)
+
+    def can_pause(self):
+        return self.status in (self.DOWNLOADING, self.QUEUED)
+
     def pause(self):
         with self:
             # Pause a queued download
@@ -787,6 +793,9 @@ class SyncTask(download.DownloadTask):
             # Request pause of a running download
             elif self.status == self.DOWNLOADING:
                 self.status = self.PAUSING
+
+    def can_cancel(self):
+        return self.status in (self.DOWNLOADING, self.QUEUED, self.PAUSED, self.FAILED)
 
     def cancel(self):
         with self:
@@ -800,6 +809,9 @@ class SyncTask(download.DownloadTask):
             elif self.status == self.DOWNLOADING:
                 self.status = self.CANCELLING
                 self.device.cancel()
+
+    def can_remove(self):
+        return self.status in (self.CANCELLED, self.FAILED, self.DONE)
 
     def removed_from_list(self):
         if self.status != self.DONE:


### PR DESCRIPTION
Fixes an issue with the toolbar cancel button turning off and on when entering the progress tab, even though it can't cancel anything until a selection is made.

Properly cancels failed tasks manually removed from progress tab. Not cancelling would leave the error icon and prevent downloading or cancelling.

The download, pause and cancel actions in toolbar and Episodes menu can now be used to control downloads in the progress tab. The delete menu item in Episodes menu removes the download from list. This also allows keyboard accelerators to be used, such as the Delete key for removing tasks. Accelerators for cancel, and maybe download/pause, should added in a future PR.

The progress tab context menu now has the same ordering as the other menus.