### PR TITLE
Allow ctrl-C to cancel episode downloads.

### DIFF
--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -123,6 +123,7 @@
         <item>
           <attribute name="action">win.cancel</attribute>
           <attribute name="label" translatable="yes">Cancel</attribute>
+          <attribute name="accel">&lt;Primary&gt;c</attribute>
         </item>
         <item>
           <attribute name="action">win.delete</attribute>


### PR DESCRIPTION
^C is unused and represents cancel in most apps.

Many of the accelerators don't make much sense (^L to subscribe), or are bound to seldomly used actions, while common actions (download, pause and lock) lack one. Should we make ^V download (looks like a down pointing arrow, and ^D toggles description which I don't understand why that needs an accelerator)? ^Z could pause because 'zzz' for sleep, and ^P and ^S are already taken. Lock could use ^A which makes sense for 'archive', but I think there was discussion about one day renaming it to lock everywhere in the UI. Thoughts?