### PR TITLE
youtube_dl.is_supported_url(): Don't fail on None

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -399,6 +399,8 @@ class gPodderYoutubeDL(download.CustomDownloader):
         return None
 
     def is_supported_url(self, url):
+        if url is None:
+            return False
         if self.regex_cache[0].match(url) is not None:
             return True
         for r in self.regex_cache[1:]:


### PR DESCRIPTION
RSS episodes which have no media and have an empty or non-existing link element cause an exception in youtube_dl.is_supported_url(). In this case None is passed as the url argument.

This patch makes is_supported_url() return False when url is None.