### PR TITLE
Allow toggling lock of any locked or undeleted episode.

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -507,6 +507,13 @@ class PodcastEpisode(PodcastModelObject):
         return self.state != gpodder.STATE_DELETED and not self.archive and (
             not self.download_task or self.download_task.status == self.download_task.FAILED)
 
+    def can_lock(self):
+        """
+        gPodder.on_item_toggle_lock_activate() unlocks deleted episodes and toggles all others.
+        Locked episodes can always be unlocked.
+        """
+        return self.state != gpodder.STATE_DELETED or self.archive
+
     def check_is_new(self):
         return (self.state == gpodder.STATE_NORMAL and self.is_new and
                 not self.downloading)


### PR DESCRIPTION
This allows undownloaded episodes to be locked with both menus and guarantees both menus remain consistent.