### PR TITLE
Show episodes without downloadable content.

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2805,16 +2805,22 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     # download older episodes first
                     episodes = list(Model.sort_episodes_by_pubdate(episodes))
 
-                if not episodes:
+                # Remove episodes without downloadable content
+                downloadable_episodes = [e for e in episodes if e.url]
+
+                if not downloadable_episodes:
                     # Nothing new here - but inform the user
                     self.pbFeedUpdate.set_fraction(1.0)
-                    self.pbFeedUpdate.set_text(_('No new episodes'))
+                    self.pbFeedUpdate.set_text(
+                        _('No new episodes with downloadable content') if episodes else _('No new episodes'))
                     self.feed_cache_update_cancelled = True
                     self.btnCancelFeedUpdate.show()
                     self.btnCancelFeedUpdate.set_sensitive(True)
                     self.update_action.set_enabled(True)
                     self.btnCancelFeedUpdate.set_image(Gtk.Image.new_from_icon_name('edit-clear', Gtk.IconSize.BUTTON))
                 else:
+                    episodes = downloadable_episodes
+
                     count = len(episodes)
                     # New episodes are available
                     self.pbFeedUpdate.set_fraction(1.0)

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -192,6 +192,7 @@ class EpisodeListModel(Gtk.ListStore):
         # Are we currently showing "all episodes"/section or a single channel?
         self._section_view = False
 
+        self.ICON_WEB_BROWSER = 'web-browser'
         self.ICON_AUDIO_FILE = 'audio-x-generic'
         self.ICON_VIDEO_FILE = 'video-x-generic'
         self.ICON_IMAGE_FILE = 'image-x-generic'
@@ -463,6 +464,12 @@ class EpisodeListModel(Gtk.ListStore):
             elif episode._download_error is not None:
                 tooltip.append(_('ERROR: %s') % episode._download_error)
                 status_icon = self.ICON_ERROR
+                if episode.state == gpodder.STATE_NORMAL and episode.is_new:
+                    view_show_downloaded = self._config.ui.gtk.episode_list.always_show_new
+                    view_show_unplayed = True
+            elif not episode.url:
+                tooltip.append(_('No downloadable content'))
+                status_icon = self.ICON_WEB_BROWSER
                 if episode.state == gpodder.STATE_NORMAL and episode.is_new:
                     view_show_downloaded = self._config.ui.gtk.episode_list.always_show_new
                     view_show_unplayed = True

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -351,7 +351,11 @@ class PodcastEpisode(PodcastModelObject):
         if link_has_media:
             return episode
 
-        return None
+        # The episode has no downloadable content.
+        # It is either a blog post or it links to a webpage with content accessible from shownotes title.
+        # Remove the URL so downloading will fail.
+        episode.url = ''
+        return episode
 
     def __init__(self, channel):
         self.parent = channel


### PR DESCRIPTION
Non-media RSS feeds only have a textual description and can't be subscribed to in gpodder. Some media feeds lack downloadable content and can only be accessed from the website. In both cases, gpodder removes the episodes without any feedback to the user as to why, making it appear to be a problem in gpodder.

This patch adds those episodes but prevents automatic download and displays a proper error when a manual download is attempted. The episodes also get a web browser icon to indicate they lack downloadable content. While not downloadable or transferable to media devices, gpodder can be used to notify the user when new episodes are available and they can be accessed by clicking through to the website.