### PR TITLE
Added logic to trim away leading/trailing whitespaces in user-clipboard auto-inputted urls  

### DIFF
--- a/src/gpodder/gtkui/interface/addpodcast.py
+++ b/src/gpodder/gtkui/interface/addpodcast.py
@@ -49,9 +49,10 @@ class gPodderAddPodcast(BuilderWidget):
             clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
 
             def receive_clipboard_text(clipboard, text, second_try):
-                # Heuristic: If there is a space in the clipboard
-                # text, assume it's some arbitrary text, and no URL
-                if text is not None and ' ' not in text:
+                # Heuristic: If space is present in clipboard text
+                # normalize_feed_url will either fix to valid url or
+                # return None if URL cannot be validated  
+                if text is not None:
                     url = util.normalize_feed_url(text)
                     if url is not None:
                         self.entry_url.set_text(url)
@@ -72,7 +73,7 @@ class gPodderAddPodcast(BuilderWidget):
 
     def receive_clipboard_text(self, clipboard, text, data=None):
         if text is not None:
-            self.entry_url.set_text(text)
+            self.entry_url.set_text(text).strip()
         else:
             self.show_message(_('Nothing to paste.'), _('Clipboard is empty'))
 

--- a/src/gpodder/gtkui/interface/addpodcast.py
+++ b/src/gpodder/gtkui/interface/addpodcast.py
@@ -51,7 +51,7 @@ class gPodderAddPodcast(BuilderWidget):
             def receive_clipboard_text(clipboard, text, second_try):
                 # Heuristic: If space is present in clipboard text
                 # normalize_feed_url will either fix to valid url or
-                # return None if URL cannot be validated  
+                # return None if URL cannot be validated
                 if text is not None:
                     url = util.normalize_feed_url(text)
                     if url is not None:

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -247,6 +247,14 @@ def normalize_feed_url(url):
     """
     if not url or len(url) < 8:
         return None
+    
+    # Removes leading and/or trailing whitespaces - if url contains whitespaces 
+    # in between after str.strip() -> conclude invalid url & return None  
+    url = url.strip()
+    if ' ' in url:
+        return None
+        
+    
 
     # This is a list of prefixes that you can use to minimize the amount of
     # keystrokes that you have to use.
@@ -267,7 +275,7 @@ def normalize_feed_url(url):
 
     # Assume HTTP for URLs without scheme
     if '://' not in url:
-        url = 'http://' + url
+        url = f'http://{url}'  
 
     scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -73,16 +73,14 @@ logger = logging.getLogger(__name__)
 try:
     import html5lib
 except ImportError:
-    error_message = "html5lib was not found, fall-back to HTMLParser"
-    logger.warning(f'{error_message}', stack_info=True)
+    logger.warning("html5lib was not found, fall-back to HTMLParser")
     html5lib = None
 
 if gpodder.ui.win32:
     try:
         import gpodder.utilwin32ctypes as win32file
     except ImportError:
-        error_message = 'Running on Win32: utilwin32ctypes cannot be loaded'
-        logger.warning(f'{error_message}', stack_info=True)
+        logger.warning('Running on Win32: utilwin32ctypes cannot be loaded')
         win32file = None
 
 _ = gpodder.gettext
@@ -275,7 +273,7 @@ def normalize_feed_url(url):
 
     # Assume HTTP for URLs without scheme
     if '://' not in url:
-        url = f'http://{url}'
+        url = 'http://' + url
 
     scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -73,14 +73,16 @@ logger = logging.getLogger(__name__)
 try:
     import html5lib
 except ImportError:
-    logger.warn('html5lib not found, falling back to HTMLParser')
+    error_message = "html5lib was not found, fall-back to HTMLParser"
+    logger.warning(f'{error_message}', stack_info=True)
     html5lib = None
 
 if gpodder.ui.win32:
     try:
         import gpodder.utilwin32ctypes as win32file
     except ImportError:
-        logger.warn('Running on Win32 but utilwin32ctypes can\'t be loaded.')
+        error_message = 'Running on Win32: utilwin32ctypes cannot be loaded'
+        logger.warning(f'{error_message}', stack_info=True)
         win32file = None
 
 _ = gpodder.gettext
@@ -247,14 +249,12 @@ def normalize_feed_url(url):
     """
     if not url or len(url) < 8:
         return None
-    
-    # Removes leading and/or trailing whitespaces - if url contains whitespaces 
-    # in between after str.strip() -> conclude invalid url & return None  
+
+    # Removes leading and/or trailing whitespaces - if url contains whitespaces
+    # in between after str.strip() -> conclude invalid url & return None
     url = url.strip()
     if ' ' in url:
         return None
-        
-    
 
     # This is a list of prefixes that you can use to minimize the amount of
     # keystrokes that you have to use.
@@ -275,7 +275,7 @@ def normalize_feed_url(url):
 
     # Assume HTTP for URLs without scheme
     if '://' not in url:
-        url = f'http://{url}'  
+        url = f'http://{url}'
 
     scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
 


### PR DESCRIPTION
# Added logic to trim away leading/trailing whitespaces in user-clipboard auto-inputted urls  
### Type: feat 

Tested against current gpodder-installed executable for correct/desired 
behaviour. simplified receive_clipboard_text method of class
gPodderAddPodcast in addpodcast.py -- 

Resolves: #520 
