### PR TITLE
Gtk UI: Handle links in HTML shownotes

### DIFF
--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -411,8 +411,9 @@ class gPodderShownotesHTML(gPodderShownotes):
             if req.get_uri() in (self._base_uri, 'about:blank'):
                 decision.use()
             else:
-                logger.debug("refusing to go to %s (base URI=%s)", req.get_uri(), self._base_uri)
+                # Avoid opening the page inside the WebView and open in the browser instead
                 decision.ignore()
+                util.open_website(req.get_uri())
             return False
         else:
             decision.use()


### PR DESCRIPTION
Noticed that in HTML shownotes, clicking links (with left mouse button) does nothing. Hook up the handler to open the link in the default web browser. Add a UI confirmation dialog when clicking links in shownotes (both text and HTML) before opening the browser. This can be disabled by setting the advanced config option `ui.gtk.shownotes_confirm_open_browser` to `False`, in which case clicking the link will immediately open the browser.