### PR TITLE
Fix #864 add undownload checkbox in delete episode confirm dialog

### DIFF
--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -115,16 +115,27 @@ class BuilderWidget(GtkBuilderWidget):
         else:
             gpodder.user_extensions.on_notification_show(title, message)
 
-    def show_confirmation(self, message, title=None):
+    def show_confirmation_extended(self, message, title=None, checkbox=None, default_checked=False):
         dlg = Gtk.MessageDialog(self.main_window, Gtk.DialogFlags.MODAL, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO)
         if title:
             dlg.set_title(str(title))
             dlg.set_markup('<span weight="bold" size="larger">%s</span>\n\n%s' % (title, message))
         else:
             dlg.set_markup('<span weight="bold" size="larger">%s</span>' % (message))
+        if checkbox:
+            cb = Gtk.CheckButton.new_with_label(checkbox)
+            cb.set_active(default_checked)
+            dlg.get_message_area().pack_end(cb, False, False, 0)
+        dlg.show_all()
         response = dlg.run()
+        checked = checkbox and cb.get_active()
         dlg.destroy()
-        return response == Gtk.ResponseType.YES
+        return dict(confirmed=response == Gtk.ResponseType.YES, checked=checked)
+
+    def show_confirmation(self, message, title=None, checkbox=None, default_checked=False):
+        return self.show_confirmation_extended(
+            message, title=title,
+            checkbox=checkbox, default_checked=default_checked)["confirmed"]
 
     def show_text_edit_dialog(self, title, prompt, text=None, empty=False,
             is_url=False, affirmative_text=_('_OK')):

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -133,10 +133,9 @@ class BuilderWidget(GtkBuilderWidget):
         dlg.destroy()
         return dict(confirmed=response == Gtk.ResponseType.YES, checked=checked)
 
-    def show_confirmation(self, message, title=None, checkbox=None, default_checked=False):
+    def show_confirmation(self, message, title=None):
         return self.show_confirmation_extended(
-            message, title=title,
-            checkbox=checkbox, default_checked=default_checked)["confirmed"]
+            message, title=title)["confirmed"]
 
     def show_text_edit_dialog(self, title, prompt, text=None, empty=False,
             is_url=False, affirmative_text=_('_OK')):

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -126,6 +126,7 @@ class BuilderWidget(GtkBuilderWidget):
             cb = Gtk.CheckButton.new_with_label(checkbox)
             cb.set_active(default_checked)
             dlg.get_message_area().pack_end(cb, False, False, 0)
+            dlg.get_widget_for_response(Gtk.ResponseType.NO).grab_focus()
         dlg.show_all()
         response = dlg.run()
         checked = checkbox and cb.get_active()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2946,7 +2946,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         message = self.format_delete_message(message, episodes, 5, 60)
 
         if confirm:
-            undownloadable = len([e.can_undownload() for e in episodes])
+            undownloadable = len([e for e in episodes if e.can_undownload()])
             if undownloadable:
                 checkbox = N_("Mark episode as new to allow downloading again",
                               "Mark episodes as new to allow downloading again",

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2948,8 +2948,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         if confirm:
             undownloadable = len([e for e in episodes if e.can_undownload()])
             if undownloadable:
-                checkbox = N_("Mark episode as new to allow downloading again",
-                              "Mark episodes as new to allow downloading again",
+                checkbox = N_("Mark downloaded episodes as new, after deletion, to allow downloading again",
+                              "Mark downloaded episodes as new, after deletion, to allow downloading again",
                               undownloadable)
             else:
                 checkbox = None

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2986,11 +2986,13 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 progress.on_progress(idx / len(episodes))
                 if not episode.archive:
                     progress.on_message(episode.title)
+                    # ep_undownload must be computed before delete_from_disk
+                    ep_undownload = undownload and episode.can_undownload()
                     episode.delete_from_disk()
                     episode_urls.add(episode.url)
                     channel_urls.add(episode.channel.url)
                     episodes_status_update.append(episode)
-                    if undownload:
+                    if ep_undownload:
                         # Undelete and mark episode as new
                         episode.state = gpodder.STATE_NORMAL
                         episode.is_new = True

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -500,6 +500,12 @@ class PodcastEpisode(PodcastModelObject):
         """
         return self.download_task and self.download_task.can_cancel()
 
+    def can_undownload(self):
+        """
+        gPodder.on_btnUndownload_clicked() filters selection with this method.
+        """
+        return self.was_downloaded(and_exists=True) and not self.archive
+
     def can_delete(self):
         """
         gPodder.delete_episode_list() filters out locked episodes, and cancels all unlocked tasks in selection.


### PR DESCRIPTION
Closes #864.
Alternative to #868: add a checkbox to the episode delete confirm dialog.

+ more discoverable, more space to explain what undownload does to the user
- users using it routinely will have 2 actions (delete, then check undownload) instead of 1 (undownload)

@auouymous what do you think?

The wording can be improved...