### PR TITLE
Fix warnings

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -379,7 +379,7 @@ class gPodderCli(object):
                 podcast.rename(title)
             podcast.save()
         except Exception as e:
-            logger.warn('Cannot subscribe: %s', e, exc_info=True)
+            logger.warning('Cannot subscribe: %s', e, exc_info=True)
             if hasattr(e, 'strerror'):
                 self._error(e.strerror)
             else:

--- a/share/gpodder/extensions/audio_converter.py
+++ b/share/gpodder/extensions/audio_converter.py
@@ -133,7 +133,7 @@ class gPodderExtension:
             logger.info('Converted audio file to %(format)s.' % {'format': new_extension})
             gpodder.user_extensions.on_notification_show(_('File converted'), episode.title)
         else:
-            logger.warn('Error converting audio file: %s / %s', stdout, stderr)
+            logger.warning('Error converting audio file: %s / %s', stdout, stderr)
             gpodder.user_extensions.on_notification_show(_('Conversion failed'), episode.title)
 
     def _convert_episodes(self, episodes):

--- a/share/gpodder/extensions/command_on_download.py
+++ b/share/gpodder/extensions/command_on_download.py
@@ -45,7 +45,7 @@ class gPodderExtension:
     def read_episode_info(self, episode):
         filename = episode.local_filename(create=False, check_only=True)
         if filename is None:
-            logger.warn("%s: missing episode filename", __title__)
+            logger.warning("%s: missing episode filename", __title__)
             return None
         info = {
             'filename': filename,
@@ -74,4 +74,4 @@ class gPodderExtension:
         if proc.returncode == 0:
             logger.info("%s succeeded", command)
         else:
-            logger.warn("%s run with exit code %i", command, proc.returncode)
+            logger.warning("%s run with exit code %i", command, proc.returncode)

--- a/share/gpodder/extensions/enqueue_in_mediaplayer.py
+++ b/share/gpodder/extensions/enqueue_in_mediaplayer.py
@@ -72,7 +72,7 @@ class Win32Player(Player):
             self.command = win32_read_registry_key(self.command)
             return True
         except Exception as e:
-            logger.warn('Win32 player not found: %s (%s)', self.command, e)
+            logger.warning('Win32 player not found: %s (%s)', self.command, e)
 
         return False
 

--- a/share/gpodder/extensions/mpris-listener.py
+++ b/share/gpodder/extensions/mpris-listener.py
@@ -255,10 +255,10 @@ class MPRISDBusReceiver(object):
                        invalidated_properties, path=None, sender=None):
         if interface_name != self.INTERFACE_MPRIS:
             if interface_name not in self.OTHER_MPRIS_INTERFACES:
-                logger.warn('unexpected interface: %s, props=%r', interface_name, list(changed_properties.keys()))
+                logger.warning('unexpected interface: %s, props=%r', interface_name, list(changed_properties.keys()))
             return
         if sender is None:
-            logger.warn('No sender associated to D-Bus signal, please report a bug')
+            logger.warning('No sender associated to D-Bus signal, please report a bug')
             return
 
         collected_info = {}

--- a/share/gpodder/extensions/normalize_audio.py
+++ b/share/gpodder/extensions/normalize_audio.py
@@ -105,7 +105,7 @@ class gPodderExtension:
             gpodder.user_extensions.on_notification_show(_('File normalized'),
                     episode.title)
         else:
-            logger.warn('normalize-audio failed: %s / %s', stdout, stderr)
+            logger.warning('normalize-audio failed: %s / %s', stdout, stderr)
 
     def convert_episodes(self, episodes):
         for episode in episodes:

--- a/share/gpodder/extensions/rm_ogg_cover.py
+++ b/share/gpodder/extensions/rm_ogg_cover.py
@@ -97,4 +97,4 @@ class gPodderExtension:
                 logger.info('Removed cover art from OGG file: %s', filename)
                 ogg.save()
         except Exception as e:
-            logger.warn('Failed to remove OGG cover: %s', e, exc_info=True)
+            logger.warning('Failed to remove OGG cover: %s', e, exc_info=True)

--- a/share/gpodder/extensions/taskbar_progress.py
+++ b/share/gpodder/extensions/taskbar_progress.py
@@ -176,7 +176,7 @@ class gPodderExtension:
         if self.window_handle is None:
             if not self.restart_warning:
                 return
-            logger.warn("No window handle available, a restart max fix this")
+            logger.warning("No window handle available, a restart max fix this")
             self.restart_warning = False
             return
         if 0 < progress < 1:

--- a/share/gpodder/extensions/ted_subtitles.py
+++ b/share/gpodder/extensions/ted_subtitles.py
@@ -60,7 +60,7 @@ class gPodderExtension(object):
         try:
             response = util.urlopen(url).read()
         except Exception as e:
-            logger.warn("subtitle url returned error %s", e)
+            logger.warning("subtitle url returned error %s", e)
             return ''
         return response
 
@@ -105,7 +105,7 @@ class gPodderExtension(object):
             with open(srt_filename, 'w+') as srtFile:
                 srtFile.write(sub.encode("utf-8"))
         except Exception as e:
-            logger.warn("Can't write srt file: %s", e)
+            logger.warning("Can't write srt file: %s", e)
 
     def on_episode_delete(self, episode, filename):
         srt_filename = self.get_srt_filename(filename)

--- a/share/gpodder/extensions/video_converter.py
+++ b/share/gpodder/extensions/video_converter.py
@@ -114,7 +114,7 @@ class gPodderExtension:
             logger.info('Converted video file to %(format)s.' % {'format': self.config.output_format})
             gpodder.user_extensions.on_notification_show(_('File converted'), episode.title)
         else:
-            logger.warn('Error converting video file: %s / %s', stdout, stderr)
+            logger.warning('Error converting video file: %s / %s', stdout, stderr)
             gpodder.user_extensions.on_notification_show(_('Conversion failed'), episode.title)
 
     def _convert_episodes(self, episodes):

--- a/src/gpodder/common.py
+++ b/src/gpodder/common.py
@@ -87,7 +87,7 @@ def find_partial_downloads(channels, start_progress_callback, progress_callback,
                 break
 
         for f in partial_files:
-            logger.warn('Partial file without episode: %s', f)
+            logger.warning('Partial file without episode: %s', f)
             util.delete_file(f)
 
     # never delete partial: either we can't clean them up because we offer to

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -319,7 +319,7 @@ class Config(object):
         if callback not in self.__observers:
             self.__observers.append(callback)
         else:
-            logger.warn('Observer already added: %s', repr(callback))
+            logger.warning('Observer already added: %s', repr(callback))
 
     def remove_observer(self, callback):
         """
@@ -328,7 +328,7 @@ class Config(object):
         if callback in self.__observers:
             self.__observers.remove(callback)
         else:
-            logger.warn('Observer not added: %s', repr(callback))
+            logger.warning('Observer not added: %s', repr(callback))
 
     def all_keys(self):
         return self.__json_config._keys_iter()
@@ -376,7 +376,7 @@ class Config(object):
                 data = open(self.__filename, 'rt').read()
                 new_keys_added = self.__json_config._restore(data)
             except:
-                logger.warn('Cannot parse config file: %s',
+                logger.warning('Cannot parse config file: %s',
                         self.__filename, exc_info=True)
                 new_keys_added = False
 

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -373,7 +373,8 @@ class Config(object):
 
         if os.path.exists(self.__filename):
             try:
-                data = open(self.__filename, 'rt').read()
+                with open(self.__filename, 'rt') as f:
+                    data = f.read()
                 new_keys_added = self.__json_config._restore(data)
             except:
                 logger.warning('Cannot parse config file: %s',

--- a/src/gpodder/coverart.py
+++ b/src/gpodder/coverart.py
@@ -91,7 +91,7 @@ class CoverDownloader(object):
                     raise ValueError(msg)
                 data = response.content
             except Exception as e:
-                logger.warn('Cover art download failed: %s', e)
+                logger.warning('Cover art download failed: %s', e)
                 return self._fallback_filename(title)
 
             try:
@@ -113,7 +113,7 @@ class CoverDownloader(object):
 
                 return filename + extension
             except Exception as e:
-                logger.warn('Cannot save cover art', exc_info=True)
+                logger.warning('Cannot save cover art', exc_info=True)
 
         # Fallback to cover art based on the podcast title
         return self._fallback_filename(title)

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -258,7 +258,7 @@ class DownloadURLOpener:
                 if current_size > 0:
                     headers['Range'] = 'bytes=%s-' % (current_size)
             except:
-                logger.warn('Cannot resume download: %s', filename, exc_info=True)
+                logger.warning('Cannot resume download: %s', filename, exc_info=True)
                 tfp = None
                 current_size = 0
 
@@ -292,7 +292,7 @@ class DownloadURLOpener:
                     tfp.close()
                     tfp = open(filename, 'wb')
                     current_size = 0
-                    logger.warn('Cannot resume: Invalid Content-Range (RFC2616).')
+                    logger.warning('Cannot resume: Invalid Content-Range (RFC2616).')
 
             result = headers, resp.url
             bs = 1024 * 8

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -367,7 +367,7 @@ class ExtensionManager(object):
                     'enabled' if new_enabled else 'disabled')
             container.set_enabled(new_enabled)
             if new_enabled and not container.enabled:
-                logger.warn('Could not enable extension: %s',
+                logger.warning('Could not enable extension: %s',
                         container.error)
                 self.core.config.extensions.enabled = [x
                         for x in self.core.config.extensions.enabled

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -242,7 +242,8 @@ class ExtensionContainer(object):
             return {}
 
         encoding = util.guess_encoding(filename)
-        extension_py = open(filename, "r", encoding=encoding).read()
+        with open(filename, "r", encoding=encoding) as f:
+            extension_py = f.read()
         metadata = dict(re.findall(r"__([a-z_]+)__ = '([^']+)'", extension_py))
 
         # Support for using gpodder.gettext() as _ to localize text

--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -206,7 +206,7 @@ class Fetcher(object):
                     self.fetch(ad._resolved_url, etag=None, modified=None, autodiscovery=False, **kwargs)
                     return Result(NEW_LOCATION, ad._resolved_url)
                 except Exception as e:
-                    logger.warn('Feed autodiscovery failed', exc_info=True)
+                    logger.warning('Feed autodiscovery failed', exc_info=True)
 
             # Second, try to resolve the URL
             new_url = self._resolve_url(url)

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -172,7 +172,7 @@ class gPodderApplication(Gtk.Application):
 
             self.bus_name = dbus.service.BusName(gpodder.dbus_bus_name, bus=gpodder.dbus_session_bus)
         except dbus.exceptions.DBusException as dbe:
-            logger.warn('Cannot get "on the bus".', exc_info=True)
+            logger.warning('Cannot get "on the bus".', exc_info=True)
             dlg = Gtk.MessageDialog(None, Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR,
                    Gtk.ButtonsType.CLOSE, _('Cannot start gPodder'))
             dlg.format_secondary_markup(_('D-Bus error: %s') % (str(dbe),))

--- a/src/gpodder/gtkui/desktop/podcastdirectory.py
+++ b/src/gpodder/gtkui/desktop/podcastdirectory.py
@@ -89,7 +89,7 @@ class DirectoryProvidersModel(Gtk.ListStore):
             try:
                 pixbuf = GdkPixbuf.Pixbuf.new_from_file(os.path.join(gpodder.images_folder, provider.icon)) if provider.icon else None
             except Exception as e:
-                logger.warn('Could not load icon: %s (%s)', provider.icon or '-', e)
+                logger.warning('Could not load icon: %s (%s)', provider.icon or '-', e)
                 pixbuf = None
             self.append((Pango.Weight.NORMAL, provider.name, pixbuf, provider))
 
@@ -203,7 +203,7 @@ class gPodderPodcastDirectory(BuilderWidget):
                 try:
                     tags = [(t.tag, t.weight) for t in provider.get_tags()]
                 except Exception as e:
-                    logger.warn('Got exception while loading tags: %s', e)
+                    logger.warning('Got exception while loading tags: %s', e)
                     tags = []
 
                 @util.idle_add
@@ -251,7 +251,7 @@ class gPodderPodcastDirectory(BuilderWidget):
             try:
                 podcasts = callback()
             except Exception as e:
-                logger.warn('Got exception while loading podcasts: %s', e)
+                logger.warning('Got exception while loading podcasts: %s', e)
                 podcasts = []
 
             @util.idle_add
@@ -263,7 +263,7 @@ class gPodderPodcastDirectory(BuilderWidget):
                 if original_provider == self.current_provider:
                     self.podcasts_model.load(podcasts or [])
                 else:
-                    logger.warn('Ignoring update from old thread')
+                    logger.warning('Ignoring update from old thread')
 
                 self.en_query.set_sensitive(True)
                 self.bt_search.set_sensitive(True)

--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -177,7 +177,7 @@ class UserAppsReader(object):
                         caption, cmdline,
                         ';'.join(typ + '/*' for typ in types), None))
                 except Exception as e:
-                    logger.warn('Parse HKEY error: %s (%s)', hkey, e)
+                    logger.warning('Parse HKEY error: %s (%s)', hkey, e)
 
         for dir in userappsdirs:
             if os.path.exists(dir):

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1840,8 +1840,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def save_episodes_as_file(self, episodes):
         def do_save_episode(copy_from, copy_to):
             if os.path.exists(copy_to):
-                logger.warn(copy_from)
-                logger.warn(copy_to)
+                logger.warning(copy_from)
+                logger.warning(copy_to)
                 title = _('File already exists')
                 d = {'filename': os.path.basename(copy_to)}
                 message = _('A file named "%(filename)s" already exists. Do you want to replace it?') % d
@@ -1850,7 +1850,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             try:
                 shutil.copyfile(copy_from, copy_to)
             except (OSError, IOError) as e:
-                logger.warn('Error copying from %s to %s: %r', copy_from, copy_to, e, exc_info=True)
+                logger.warning('Error copying from %s to %s: %r', copy_from, copy_to, e, exc_info=True)
                 folder, filename = os.path.split(copy_to)
                 # Remove characters not supported by VFAT (#282)
                 new_filename = re.sub(r"[\"*/:<>?\\|]", "_", filename)
@@ -1889,7 +1889,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                         msg = _('Error saving to local folder: %(error)r.\n'
                                 'Would you like to continue?') % dict(error=e)
                         if not self.show_confirmation(msg, _('Error saving to local folder')):
-                            logger.warn("Save to Local Folder cancelled following error")
+                            logger.warning("Save to Local Folder cancelled following error")
                             break
                     else:
                         self.notification(_('Error saving to local folder: %(error)r') % dict(error=e),
@@ -3551,7 +3551,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             up_to_date, version, released, days = util.get_update_info()
         except Exception as e:
             if silent:
-                logger.warn('Could not check for updates.', exc_info=True)
+                logger.warning('Could not check for updates.', exc_info=True)
             else:
                 title = _('Could not check for updates')
                 message = _('Please try again later.')

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -743,7 +743,7 @@ class PodcastListModel(Gtk.ListStore):
                 return None
             return pixbuf
         except Exception as e:
-            logger.warn('Could not load cached cover art for %s', channel.url, exc_info=True)
+            logger.warning('Could not load cached cover art for %s', channel.url, exc_info=True)
             channel.cover_thumb = None
             channel.save()
             return None

--- a/src/gpodder/gtkui/services.py
+++ b/src/gpodder/gtkui/services.py
@@ -118,7 +118,7 @@ class CoverDownloader(ObservableService):
         try:
             pixbuf = GdkPixbuf.Pixbuf.new_from_file(filename)
         except Exception as e:
-            logger.warn('Cannot load cover art', exc_info=True)
+            logger.warning('Cannot load cover art', exc_info=True)
         if pixbuf is None and filename.startswith(channel.cover_file):
             logger.info('Deleting broken cover: %s', filename)
             util.delete_file(filename)
@@ -126,7 +126,7 @@ class CoverDownloader(ObservableService):
             try:
                 pixbuf = GdkPixbuf.Pixbuf.new_from_file(filename)
             except Exception as e:
-                logger.warn('Corrupt cover art on server, deleting', exc_info=True)
+                logger.warning('Corrupt cover art on server, deleting', exc_info=True)
                 util.delete_file(filename)
 
         if async_mode:

--- a/src/gpodder/log.py
+++ b/src/gpodder/log.py
@@ -61,7 +61,7 @@ def setup(verbose=True, quiet=False):
             try:
                 os.makedirs(logging_directory)
             except:
-                logger.warn('Cannot create output directory: %s',
+                logger.warning('Cannot create output directory: %s',
                         logging_directory)
                 return False
 
@@ -77,7 +77,7 @@ def setup(verbose=True, quiet=False):
                 try:
                     os.remove(old_logfile)
                 except:
-                    logger.warn('Cannot purge logfile: %s', exc_info=True)
+                    logger.warning('Cannot purge logfile: %s', exc_info=True)
 
         root = logging.getLogger()
         logfile = os.path.join(logging_directory, logging_basename)

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -161,7 +161,7 @@ class PodcastParserFeed(Feed):
                 num_duplicate_guids += 1
                 channel._update_error = ('Discarded {} episode(s) with non-unique GUID, contact the podcast publisher to fix this issue.'
                         .format(num_duplicate_guids))
-                logger.warn('Discarded episode with non-unique GUID, contact the podcast publisher to fix this issue. [%s] [%s]',
+                logger.warning('Discarded episode with non-unique GUID, contact the podcast publisher to fix this issue. [%s] [%s]',
                         channel.title, episode.title)
                 continue
 
@@ -660,7 +660,7 @@ class PodcastEpisode(PodcastModelObject):
         if not check_only and (force_update or not self.download_filename):
             # Avoid and catch gPodder bug 1440 and similar situations
             if template == '':
-                logger.warn('Empty template. Report this podcast URL %s',
+                logger.warning('Empty template. Report this podcast URL %s',
                         self.channel.url)
                 template = None
 
@@ -673,7 +673,7 @@ class PodcastEpisode(PodcastModelObject):
 
             if 'redirect' in episode_filename and template is None:
                 # This looks like a redirection URL - force URL resolving!
-                logger.warn('Looks like a redirection to me: %s', self.url)
+                logger.warning('Looks like a redirection to me: %s', self.url)
                 url = util.get_real_url(self.channel.authenticate_url(self.url))
                 logger.info('Redirection resolved to: %s', url)
                 episode_filename, _ = util.filename_from_url(url)
@@ -716,7 +716,7 @@ class PodcastEpisode(PodcastModelObject):
                     # call it from the downloading code before saving the file
                     logger.info('Choosing new filename: %s', new_file_name)
                 else:
-                    logger.warn('%s exists or %s does not', new_file_name, old_file_name)
+                    logger.warning('%s exists or %s does not', new_file_name, old_file_name)
                 logger.info('Updating filename of %s to "%s".', self.url, wanted_filename)
             elif self.download_filename is None:
                 logger.info('Setting download filename: %s', wanted_filename)
@@ -787,7 +787,7 @@ class PodcastEpisode(PodcastModelObject):
         try:
             return datetime.datetime.fromtimestamp(self.published).strftime('%H%M')
         except:
-            logger.warn('Cannot format pubtime: %s', self.title, exc_info=True)
+            logger.warning('Cannot format pubtime: %s', self.title, exc_info=True)
             return '0000'
 
     def playlist_title(self):
@@ -942,7 +942,7 @@ class PodcastChannel(PodcastModelObject):
             logger.debug('Strategy for %s changed to %s', self.title, caption)
             self.download_strategy = download_strategy
         else:
-            logger.warn('Cannot set strategy to %d', download_strategy)
+            logger.warning('Cannot set strategy to %d', download_strategy)
 
     def rewrite_url(self, new_url):
         new_url = util.normalize_feed_url(new_url)
@@ -1036,7 +1036,7 @@ class PodcastChannel(PodcastModelObject):
                         break
 
             if not found and not util.is_system_file(filename):
-                logger.warn('Unknown external file: %s', filename)
+                logger.warning('Unknown external file: %s', filename)
 
     @classmethod
     def sort_key(cls, podcast):

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -445,7 +445,7 @@ class MygPoClient(object):
 
     def flush(self, now=False):
         if not self.can_access_webservice():
-            logger.warn('Flush requested, but sync disabled.')
+            logger.warning('Flush requested, but sync disabled.')
             return
 
         if self._worker_thread is None or now:
@@ -512,7 +512,7 @@ class MygPoClient(object):
                 raise
 
             except Exception as e:
-                logger.warn('Exception while polling for episodes.', exc_info=True)
+                logger.warning('Exception while polling for episodes.', exc_info=True)
 
             # Step 2: Upload Episode actions
 
@@ -534,7 +534,7 @@ class MygPoClient(object):
             return True
 
         except (MissingCredentials, mygpoclient.http.Unauthorized):
-            logger.warn('Invalid credentials. Disabling gpodder.net.')
+            logger.warning('Invalid credentials. Disabling gpodder.net.')
             self._config.mygpo.enabled = False
             return False
 
@@ -599,7 +599,7 @@ class MygPoClient(object):
             return True
 
         except (MissingCredentials, mygpoclient.http.Unauthorized):
-            logger.warn('Invalid credentials. Disabling gpodder.net.')
+            logger.warning('Invalid credentials. Disabling gpodder.net.')
             self._config.mygpo.enabled = False
             return False
 
@@ -616,7 +616,7 @@ class MygPoClient(object):
             return True
 
         except (MissingCredentials, mygpoclient.http.Unauthorized):
-            logger.warn('Invalid credentials. Disabling gpodder.net.')
+            logger.warning('Invalid credentials. Disabling gpodder.net.')
             self._config.mygpo.enabled = False
             return False
 
@@ -632,7 +632,7 @@ class MygPoClient(object):
             devices = self._client.get_devices()
 
         except (MissingCredentials, mygpoclient.http.Unauthorized):
-            logger.warn('Invalid credentials. Disabling gpodder.net.')
+            logger.warning('Invalid credentials. Disabling gpodder.net.')
             self._config.mygpo.enabled = False
             raise
 

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -147,7 +147,7 @@ class SoundcloudUser(object):
             total_count = len(json_tracks)
 
             if len(tracks) == 0 and total_count > 0:
-                logger.warn("Download of all %i %s of user %s is disabled" %
+                logger.warning("Download of all %i %s of user %s is disabled" %
                             (total_count, feed, self.username))
             else:
                 logger.info("%i/%i downloadable tracks for user %s %s feed" %

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -94,15 +94,15 @@ def get_track_length(filename):
             # Notify user on eyed3 success if mplayer failed.
             # A warning is used to make it visible in gpo or on console.
             if attempted:
-                logger.warn('eyed3.mp3 successfully determined length: %s', filename)
+                logger.warning('eyed3.mp3 successfully determined length: %s', filename)
             return length
         except Exception:
             logger.error('eyed3.mp3 could not determine length: %s', filename, exc_info=True)
             attempted = True
 
     if not attempted:
-        logger.warn('Could not determine length: %s', filename)
-        logger.warn('Please install MPlayer or the eyed3.mp3 module for track length detection.')
+        logger.warning('Could not determine length: %s', filename)
+        logger.warning('Please install MPlayer or the eyed3.mp3 module for track length detection.')
 
     return int(60 * 60 * 1000 * 3)
     # Default is three hours (to be on the safe side)
@@ -608,7 +608,7 @@ class MP3PlayerDevice(Device):
         needed = util.calculate_size(from_file)
         free = self.get_free_space()
         if free == -1:
-            logger.warn('Cannot determine free disk space on device')
+            logger.warning('Cannot determine free disk space on device')
         elif needed > free:
             d = {'path': self.destination, 'free': util.format_filesize(free), 'need': util.format_filesize(needed)}
             message = _('Not enough space in %(path)s: %(free)s available, but need at least %(need)s')

--- a/src/gpodder/syncui.py
+++ b/src/gpodder/syncui.py
@@ -255,7 +255,7 @@ class gPodderSyncUI(object):
                                             try:
                                                 episodes_to_delete.append(episode_dict[episode_filename])
                                             except KeyError as ioe:
-                                                logger.warn('Episode %s, removed from device has already been deleted from gpodder',
+                                                logger.warning('Episode %s, removed from device has already been deleted from gpodder',
                                                             episode_filename)
                     # delete all episodes from gpodder (will prompt user)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -90,7 +90,7 @@ N_ = gpodder.ngettext
 try:
     locale.setlocale(locale.LC_ALL, '')
 except Exception as e:
-    logger.warn('Cannot set locale (%s)', e, exc_info=True)
+    logger.warning('Cannot set locale (%s)', e, exc_info=True)
 
 # Native filesystem encoding detection
 encoding = sys.getfilesystemencoding()
@@ -198,7 +198,7 @@ def make_directory(path):
     except GLib.Error as err:
         # The sync might be multithreaded, so directories can be created by other threads
         if not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.EXISTS):
-            logger.warn('Could not create directory %s: %s', path.get_uri(), err.message)
+            logger.warning('Could not create directory %s: %s', path.get_uri(), err.message)
             return False
 
     return True
@@ -404,9 +404,9 @@ def calculate_size(path):
                 try:
                     sum += calculate_size(os.path.join(path, item))
                 except:
-                    logger.warn('Cannot get size for %s', path, exc_info=True)
+                    logger.warning('Cannot get size for %s', path, exc_info=True)
         except:
-            logger.warn('Cannot access %s', path, exc_info=True)
+            logger.warning('Cannot access %s', path, exc_info=True)
 
         return sum
 
@@ -430,7 +430,7 @@ def file_modification_datetime(filename):
         timestamp = s[stat.ST_MTIME]
         return datetime.datetime.fromtimestamp(timestamp)
     except:
-        logger.warn('Cannot get mtime for %s', filename, exc_info=True)
+        logger.warning('Cannot get mtime for %s', filename, exc_info=True)
         return None
 
 
@@ -457,7 +457,7 @@ def file_modification_timestamp(filename):
         s = os.stat(filename)
         return s[stat.ST_MTIME]
     except:
-        logger.warn('Cannot get modification timestamp for %s', filename)
+        logger.warning('Cannot get modification timestamp for %s', filename)
         return -1
 
 
@@ -548,10 +548,10 @@ def format_date(timestamp):
     try:
         timestamp_date = time.localtime(timestamp)[:3]
     except ValueError as ve:
-        logger.warn('Cannot convert timestamp', exc_info=True)
+        logger.warning('Cannot convert timestamp', exc_info=True)
         return None
     except TypeError as te:
-        logger.warn('Cannot convert timestamp', exc_info=True)
+        logger.warning('Cannot convert timestamp', exc_info=True)
         return None
 
     if timestamp_date == today:
@@ -562,7 +562,7 @@ def format_date(timestamp):
     try:
         diff = int((time.time() - timestamp) / seconds_in_a_day)
     except:
-        logger.warn('Cannot convert "%s" to date.', timestamp, exc_info=True)
+        logger.warning('Cannot convert "%s" to date.', timestamp, exc_info=True)
         return None
 
     try:
@@ -1111,7 +1111,7 @@ def object_string_formatter(s, **kwargs):
                     to_s = str(getattr(o, attr))
                     result = result.replace(from_s, to_s)
                 except:
-                    logger.warn('Replace of "%s" failed for "%s".', attr, s)
+                    logger.warning('Replace of "%s" failed for "%s".', attr, s)
 
     return result
 
@@ -1977,7 +1977,7 @@ def connection_available():
             return online
 
     except Exception as e:
-        logger.warn('Cannot get connection status: %s', e, exc_info=True)
+        logger.warning('Cannot get connection status: %s', e, exc_info=True)
         # When we can't determine the connection status, act as if we're online (bug 1730)
         return True
 


### PR DESCRIPTION
The logger.warn() calls don't generate warnings but apparently shouldn't be used. The other two patches fix a bunch of warnings thrown when `warnings.simplefilter('default')` is used. There are many more warnings that will be slowly fixed over time.