### PR TITLE
iPod support restored using ctypes and libgpod

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ PyPI. With this, you get a self-contained gPodder CLI codebase.
 - Size detection on Windows: PyWin32
 - Native OS X support: ige-mac-integration
 - MP3 Player Sync Support: python-eyed3 (0.7 or newer)
-- iPod Sync Support: python-gpod
+- iPod Sync Support: libgpod (tested with 0.8.3)
 - Clickable links in GTK UI show notes: html5lib
 - HTML show notes: WebKit2 gobject bindings
     (webkit2gtk, webkitgtk4 or gir1.2-webkit2-4.0 packages).

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -660,7 +660,8 @@ class gPodderPreferences(BuilderWidget):
             self.toggle_playlist_interface(False)
             self.checkbutton_delete_using_playlists.set_sensitive(False)
             self.combobox_on_sync.set_sensitive(False)
-            self.checkbutton_skip_played_episodes.set_sensitive(False)
+            self.checkbutton_skip_played_episodes.set_sensitive(True)
+            self.checkbutton_delete_deleted_episodes.set_sensitive(True)
 
             children = self.btn_filesystemMountpoint.get_children()
             if children:

--- a/src/gpodder/libgpod_ctypes.py
+++ b/src/gpodder/libgpod_ctypes.py
@@ -1,0 +1,428 @@
+#
+# -*- coding: utf-8 -*-
+#
+# gPodder - A media aggregator and podcast client
+# Copyright (c) 2005-2022 The gPodder Team
+#
+# gPodder is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# gPodder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# libgpod_ctypes: Minimalistic ctypes-based bindings for libgpod
+# (Just enough coverage to get podcast syncing working again...)
+# Thomas Perl <m@thp.io>, May 2022
+#
+
+
+import ctypes
+import logging
+import os
+import struct
+
+logger = logging.getLogger(__name__)
+
+
+# libgpod, for iTunesDB access
+libgpod = ctypes.CDLL('libgpod.so.4')
+
+# glib, for g_strdup() and g_free()
+libglib = ctypes.CDLL('libglib-2.0.so.0')
+
+
+# glib/gtypes.h: typedef gint   gboolean;
+gboolean = ctypes.c_int
+
+# glib/gstrfuncs.h: gchar *g_strdup(const gchar *str);
+libglib.g_strdup.argtypes = (ctypes.c_char_p,)
+# Note: This MUST be c_void_p, so that the glib-allocated buffer will
+# be preserved when assigning to track member variables. The reason
+# for this is that Python ctypes tries to be helpful and converts a
+# c_char_p restype to a Python bytes object, which will be different
+# from the memory returned by g_strdup(). For track properties, the
+# values will be free'd indirectly by itdb_free() later.
+libglib.g_strdup.restype = ctypes.c_void_p
+
+# glib/gmem.h: void g_free(gpointer mem);
+libglib.g_free.argtypes = (ctypes.c_void_p,)
+libglib.g_free.restype = None
+
+# XXX: Can we always assume time_t is 64-bit these days?
+time_t = ctypes.c_int64
+
+
+# glib/glist.h: struct _GList
+class GList(ctypes.Structure):
+    ...
+
+
+GList._fields_ = [
+    ('data', ctypes.c_void_p),
+    ('next', ctypes.POINTER(GList)),
+    ('prev', ctypes.POINTER(GList)),
+]
+
+
+# gpod/itdb.h
+class Itdb_iTunesDB(ctypes.Structure):
+    _fields_ = [
+        ('tracks', ctypes.POINTER(GList)),
+        # ...
+    ]
+
+
+# gpod/itdb.h: struct _Itdb_Playlist
+class Itdb_Playlist(ctypes.Structure):
+    _fields_ = [
+        ('itdb', ctypes.POINTER(Itdb_iTunesDB)),
+        ('name', ctypes.c_char_p),
+        ('type', ctypes.c_uint8),
+        ('flag1', ctypes.c_uint8),
+        ('flag2', ctypes.c_uint8),
+        ('flag3', ctypes.c_uint8),
+        ('num', ctypes.c_int),
+        ('members', ctypes.POINTER(GList)),
+        # ...
+    ]
+
+
+# gpod/itdb.h
+class Itdb_Chapterdata(ctypes.Structure):
+    ...
+
+
+# gpod/itdb.h
+class Itdb_Track(ctypes.Structure):
+    _fields_ = [
+        ('itdb', ctypes.POINTER(Itdb_iTunesDB)),
+        ('title', ctypes.c_char_p),
+        ('ipod_path', ctypes.c_char_p),
+        ('album', ctypes.c_char_p),
+        ('artist', ctypes.c_char_p),
+        ('genre', ctypes.c_char_p),
+        ('filetype', ctypes.c_char_p),
+        ('comment', ctypes.c_char_p),
+        ('category', ctypes.c_char_p),
+        ('composer', ctypes.c_char_p),
+        ('grouping', ctypes.c_char_p),
+        ('description', ctypes.c_char_p),
+        ('podcasturl', ctypes.c_char_p),
+        ('podcastrss', ctypes.c_char_p),
+        ('chapterdata', ctypes.POINTER(Itdb_Chapterdata)),
+        ('subtitle', ctypes.c_char_p),
+        ('tvshow', ctypes.c_char_p),
+        ('tvepisode', ctypes.c_char_p),
+        ('tvnetwork', ctypes.c_char_p),
+        ('albumartist', ctypes.c_char_p),
+        ('keywords', ctypes.c_char_p),
+        ('sort_artist', ctypes.c_char_p),
+        ('sort_title', ctypes.c_char_p),
+        ('sort_album', ctypes.c_char_p),
+        ('sort_albumartist', ctypes.c_char_p),
+        ('sort_composer', ctypes.c_char_p),
+        ('sort_tvshow', ctypes.c_char_p),
+        ('id', ctypes.c_uint32),
+        ('size', ctypes.c_uint32),
+        ('tracklen', ctypes.c_int32),
+        ('cd_nr', ctypes.c_int32),
+        ('cds', ctypes.c_int32),
+        ('track_nr', ctypes.c_int32),
+        ('bitrate', ctypes.c_int32),
+        ('samplerate', ctypes.c_uint16),
+        ('samplerate_low', ctypes.c_uint16),
+        ('year', ctypes.c_int32),
+        ('volume', ctypes.c_int32),
+        ('soundcheck', ctypes.c_uint32),
+        ('soundcheck', ctypes.c_uint32),
+        ('time_added', time_t),
+        ('time_modified', time_t),
+        ('time_played', time_t),
+        ('bookmark_time', ctypes.c_uint32),
+        ('rating', ctypes.c_uint32),
+        ('playcount', ctypes.c_uint32),
+        ('playcount2', ctypes.c_uint32),
+        ('recent_playcount', ctypes.c_uint32),
+        ('transferred', gboolean),
+        ('BPM', ctypes.c_int16),
+        ('app_rating', ctypes.c_uint8),
+        ('type1', ctypes.c_uint8),
+        ('type2', ctypes.c_uint8),
+        ('compilation', ctypes.c_uint8),
+        ('starttime', ctypes.c_uint32),
+        ('stoptime', ctypes.c_uint32),
+        ('checked', ctypes.c_uint8),
+        ('dbid', ctypes.c_uint64),
+        ('drm_userid', ctypes.c_uint32),
+        ('visible', ctypes.c_uint32),
+        ('filetype_marker', ctypes.c_uint32),
+        ('artwork_count', ctypes.c_uint16),
+        ('artwork_size', ctypes.c_uint32),
+        ('samplerate2', ctypes.c_float),
+        ('unk126', ctypes.c_uint16),
+        ('unk132', ctypes.c_uint32),
+        ('time_released', time_t),
+        ('unk144', ctypes.c_uint16),
+        ('explicit_flag', ctypes.c_uint16),
+        ('unk148', ctypes.c_uint32),
+        ('unk152', ctypes.c_uint32),
+        ('skipcount', ctypes.c_uint32),
+        ('recent_skipcount', ctypes.c_uint32),
+        ('last_skipped', ctypes.c_uint32),
+        ('has_artwork', ctypes.c_uint8),
+        ('skip_when_shuffling', ctypes.c_uint8),
+        ('remember_playback_position', ctypes.c_uint8),
+        ('flag4', ctypes.c_uint8),
+        ('dbid2', ctypes.c_uint64),
+        ('lyrics_flag', ctypes.c_uint8),
+        ('movie_flag', ctypes.c_uint8),
+        ('mark_unplayed', ctypes.c_uint8),
+        ('unk179', ctypes.c_uint8),
+        ('unk180', ctypes.c_uint32),
+        ('pregap', ctypes.c_uint32),
+        ('samplecount', ctypes.c_uint64),
+        ('unk196', ctypes.c_uint32),
+        ('postgap', ctypes.c_uint32),
+        ('unk204', ctypes.c_uint32),
+        ('mediatype', ctypes.c_uint32),
+        # ...
+    ]
+
+
+# gpod/itdb.h: Itdb_iTunesDB *itdb_parse (const gchar *mp, GError **error);
+libgpod.itdb_parse.argtypes = (ctypes.c_char_p, ctypes.c_void_p)
+libgpod.itdb_parse.restype = ctypes.POINTER(Itdb_iTunesDB)
+
+# gpod/itdb.h: Itdb_Playlist *itdb_playlist_podcasts (Itdb_iTunesDB *itdb);
+libgpod.itdb_playlist_podcasts.argtypes = (ctypes.POINTER(Itdb_iTunesDB),)
+libgpod.itdb_playlist_podcasts.restype = ctypes.POINTER(Itdb_Playlist)
+
+# gpod/itdb.h: Itdb_Playlist *itdb_playlist_mpl (Itdb_iTunesDB *itdb);
+libgpod.itdb_playlist_mpl.argtypes = (ctypes.POINTER(Itdb_iTunesDB),)
+libgpod.itdb_playlist_mpl.restype = ctypes.POINTER(Itdb_Playlist)
+
+# gpod/itdb.h: gboolean itdb_write (Itdb_iTunesDB *itdb, GError **error);
+libgpod.itdb_write.argtypes = (ctypes.POINTER(Itdb_iTunesDB), ctypes.c_void_p)
+libgpod.itdb_write.restype = gboolean
+
+# gpod/itdb.h: guint32 itdb_playlist_tracks_number (Itdb_Playlist *pl);
+libgpod.itdb_playlist_tracks_number.argtypes = (ctypes.POINTER(Itdb_Playlist),)
+libgpod.itdb_playlist_tracks_number.restype = ctypes.c_uint32
+
+# gpod/itdb.h: gchar *itdb_filename_on_ipod (Itdb_Track *track);
+libgpod.itdb_filename_on_ipod.argtypes = (ctypes.POINTER(Itdb_Track),)
+# Needs to be c_void_p, because the returned pointer-to-memory must be free'd with g_free() after use.
+libgpod.itdb_filename_on_ipod.restype = ctypes.c_void_p
+
+# gpod/itdb.h: Itdb_Track *itdb_track_new (void);
+libgpod.itdb_track_new.argtypes = ()
+libgpod.itdb_track_new.restype = ctypes.POINTER(Itdb_Track)
+
+# gpod/itdb.h: void itdb_track_add (Itdb_iTunesDB *itdb, Itdb_Track *track, gint32 pos);
+libgpod.itdb_track_add.argtypes = (ctypes.POINTER(Itdb_iTunesDB), ctypes.POINTER(Itdb_Track), ctypes.c_int32)
+libgpod.itdb_track_add.restype = None
+
+# gpod/itdb.h: void itdb_playlist_add_track (Itdb_Playlist *pl, Itdb_Track *track, gint32 pos);
+libgpod.itdb_playlist_add_track.argtypes = (ctypes.POINTER(Itdb_Playlist), ctypes.POINTER(Itdb_Track), ctypes.c_int32)
+libgpod.itdb_playlist_add_track.restype = None
+
+# gpod/itdb.h: gboolean itdb_cp_track_to_ipod (Itdb_Track *track, const gchar *filename, GError **error);
+libgpod.itdb_cp_track_to_ipod.argtypes = (ctypes.POINTER(Itdb_Track), ctypes.c_char_p, ctypes.c_void_p)
+libgpod.itdb_cp_track_to_ipod.restype = gboolean
+
+# gpod/itdb.h: time_t itdb_time_host_to_mac (time_t time);
+libgpod.itdb_time_host_to_mac.argtypes = (time_t,)
+libgpod.itdb_time_host_to_mac.restype = time_t
+
+# gpod/itdb.h: void itdb_playlist_remove_track (Itdb_Playlist *pl, Itdb_Track *track);
+libgpod.itdb_playlist_remove_track.argtypes = (ctypes.POINTER(Itdb_Playlist), ctypes.POINTER(Itdb_Track))
+libgpod.itdb_playlist_remove_track.restype = None
+
+# gpod/itdb.h: void itdb_track_remove (Itdb_Track *track);
+libgpod.itdb_track_remove.argtypes = (ctypes.POINTER(Itdb_Track),)
+libgpod.itdb_track_remove.restype = None
+
+# gpod/itdb.h: void itdb_free (Itdb_iTunesDB *itdb);
+libgpod.itdb_free.argtypes = (ctypes.POINTER(Itdb_iTunesDB),)
+libgpod.itdb_free.restype = None
+
+
+# gpod/itdb.h
+ITDB_MEDIATYPE_AUDIO = (1 << 0)
+ITDB_MEDIATYPE_MOVIE = (1 << 1)
+ITDB_MEDIATYPE_PODCAST = (1 << 2)
+ITDB_MEDIATYPE_VIDEO_PODCAST = (ITDB_MEDIATYPE_MOVIE | ITDB_MEDIATYPE_PODCAST)
+
+
+def glist_foreach(ptr_to_glist, item_type):
+    cur = ptr_to_glist
+    while cur:
+        yield ctypes.cast(cur[0].data, item_type)
+        if not cur[0].next:
+            break
+        cur = cur[0].next
+
+
+class iPodTrack(object):
+    def __init__(self, db, track):
+        self.db = db
+        self.track = track
+
+        self.episode_title = track[0].title.decode()
+        self.podcast_title = track[0].album.decode()
+
+        self.podcast_url = track[0].podcasturl.decode()
+        self.podcast_rss = track[0].podcastrss.decode()
+
+        self.playcount = track[0].playcount
+        self.bookmark_time = track[0].bookmark_time
+
+        # This returns a newly-allocated string, so we have to juggle the memory
+        # around a bit and take a copy of the string before free'ing it again.
+        filename_ptr = libgpod.itdb_filename_on_ipod(track)
+        if filename_ptr:
+            self.filename_on_ipod = ctypes.string_at(filename_ptr).decode()
+            libglib.g_free(filename_ptr)
+        else:
+            self.filename_on_ipod = None
+
+    def __repr__(self):
+        return f'iPodTrack(episode={self.episode_title}, podcast={self.podcast_title})'
+
+    def initialize_bookmark(self, is_new, bookmark_time):
+        self.track[0].mark_unplayed = 0x02 if is_new else 0x01
+        self.track[0].bookmark_time = int(bookmark_time)
+
+    def remove_from_device(self):
+        libgpod.itdb_playlist_remove_track(self.db.podcasts_playlist, self.track)
+        libgpod.itdb_playlist_remove_track(self.db.master_playlist, self.track)
+
+        # This frees the memory pointed-to by the track object
+        libgpod.itdb_track_remove(self.track)
+
+        self.track = None
+
+        # Don't forget to write the database on close
+        self.db.modified = True
+
+        if self.filename_on_ipod is not None:
+            try:
+                os.unlink(self.filename_on_ipod)
+            except Exception as e:
+                logger.info('Could not delete podcast file from iPod', exc_info=True)
+
+
+class iPodDatabase(object):
+    def __init__(self, mountpoint):
+        self.mountpoint = mountpoint
+        self.itdb = libgpod.itdb_parse(mountpoint.encode(), None)
+
+        if not self.itdb:
+            raise ValueError(f'iTunesDB not found at {self.mountpoint}')
+
+        logger.info('iTunesDB: %s', self.itdb)
+
+        self.modified = False
+
+        self.podcasts_playlist = libgpod.itdb_playlist_podcasts(self.itdb)
+        self.master_playlist = libgpod.itdb_playlist_mpl(self.itdb)
+
+        self.tracks = [iPodTrack(self, track)
+                       for track in glist_foreach(self.podcasts_playlist[0].members, ctypes.POINTER(Itdb_Track))]
+
+    def get_podcast_tracks(self):
+        return self.tracks
+
+    def add_track(self, filename, episode_title, podcast_title, description, podcast_url, podcast_rss,
+            published_timestamp, track_length, is_audio):
+        track = libgpod.itdb_track_new()
+
+        track[0].title = libglib.g_strdup(episode_title.encode())
+        track[0].album = libglib.g_strdup(podcast_title.encode())
+        track[0].artist = libglib.g_strdup(podcast_title.encode())
+        track[0].description = libglib.g_strdup(description.encode())
+        track[0].podcasturl = libglib.g_strdup(podcast_url.encode())
+        track[0].podcastrss = libglib.g_strdup(podcast_rss.encode())
+        track[0].tracklen = track_length
+        track[0].size = os.path.getsize(filename)
+        track[0].time_released = libgpod.itdb_time_host_to_mac(published_timestamp)
+
+        if is_audio:
+            track[0].filetype = libglib.g_strdup(b'mp3')
+            track[0].mediatype = ITDB_MEDIATYPE_PODCAST
+        else:
+            track[0].filetype = libglib.g_strdup(b'm4v')
+            track[0].mediatype = ITDB_MEDIATYPE_VIDEO_PODCAST
+
+        # Start at the beginning, and add "unplayed" bullet
+        track[0].bookmark_time = 0
+        track[0].mark_unplayed = 0x02
+
+        # from set_podcast_flags()
+        track[0].remember_playback_position = 0x01
+        track[0].skip_when_shuffling = 0x01
+        track[0].flag1 = 0x02
+        track[0].flag2 = 0x01
+        track[0].flag3 = 0x01
+        track[0].flag4 = 0x01
+
+        libgpod.itdb_track_add(self.itdb, track, -1)
+
+        libgpod.itdb_playlist_add_track(self.podcasts_playlist, track, -1)
+        libgpod.itdb_playlist_add_track(self.master_playlist, track, -1)
+
+        copied = libgpod.itdb_cp_track_to_ipod(track, filename.encode(), None)
+        logger.info('Copy result: %r', copied)
+        self.modified = True
+
+        self.tracks.append(iPodTrack(self, track))
+        return self.tracks[-1]
+
+    def __del__(self):
+        # If we hit the finalizer without closing the iTunesDB properly,
+        # just free the memory, but don't write out any modifications.
+        self.close(write=False)
+
+    def close(self, write=True):
+        if self.itdb:
+            if self.modified and write:
+                result = libgpod.itdb_write(self.itdb, None)
+                logger.info('Close result: %r', result)
+                self.modified = False
+
+            libgpod.itdb_free(self.itdb)
+            self.itdb = None
+
+
+if __name__ == '__main__':
+    import argparse
+    import textwrap
+
+    parser = argparse.ArgumentParser(description='Dump podcasts in iTunesDB via libgpod')
+    parser.add_argument('mountpoint', type=str, help='Path to mounted iPod storage')
+
+    args = parser.parse_args()
+
+    ipod = iPodDatabase(args.mountpoint)
+
+    for track in ipod.get_podcast_tracks():
+        print(textwrap.dedent(f"""
+        Episode:     {track.episode_title}
+        Podcast:     {track.podcast_title}
+        Episode URL: {track.podcast_url}
+        Podcast URL: {track.podcast_rss}
+        Play count:  {track.playcount}
+        Bookmark:    {track.bookmark_time/1000:.0f} seconds
+        Filename:    {track.filename_on_ipod}
+        """).rstrip())
+
+    ipod.close()

--- a/src/gpodder/libgpod_ctypes.py
+++ b/src/gpodder/libgpod_ctypes.py
@@ -65,6 +65,7 @@ else:
     # there have been efforts to establish 64-bit time_t on 32-bit Linux:
     # https://linux.slashdot.org/story/20/02/15/0247201/linux-is-ready-for-the-end-of-time
     # https://www.gnu.org/software/libc/manual/html_node/64_002dbit-time-symbol-handling.html
+    logger.info('libgpod may cause issues if time_t is 64-bit on your 32-bit system.')
     time_t = ctypes.c_int32
 
 

--- a/src/gpodder/libgpod_ctypes.py
+++ b/src/gpodder/libgpod_ctypes.py
@@ -57,8 +57,15 @@ libglib.g_strdup.restype = ctypes.c_void_p
 libglib.g_free.argtypes = (ctypes.c_void_p,)
 libglib.g_free.restype = None
 
-# XXX: Can we always assume time_t is 64-bit these days?
-time_t = ctypes.c_int64
+# See also: https://github.com/python/cpython/issues/92869
+if ctypes.sizeof(ctypes.c_void_p) == ctypes.sizeof(ctypes.c_int64):
+    time_t = ctypes.c_int64
+else:
+    # On 32-bit systems, time_t is historically 32-bit, but due to Y2K38
+    # there have been efforts to establish 64-bit time_t on 32-bit Linux:
+    # https://linux.slashdot.org/story/20/02/15/0247201/linux-is-ready-for-the-end-of-time
+    # https://www.gnu.org/software/libc/manual/html_node/64_002dbit-time-symbol-handling.html
+    time_t = ctypes.c_int32
 
 
 # glib/glist.h: struct _GList

--- a/src/gpodder/libgpod_ctypes.py
+++ b/src/gpodder/libgpod_ctypes.py
@@ -296,7 +296,7 @@ class iPodTrack(object):
             self.filename_on_ipod = None
 
     def __repr__(self):
-        return f'iPodTrack(episode={self.episode_title}, podcast={self.podcast_title})'
+        return 'iPodTrack(episode={}, podcast={})'.format(self.episode_title, self.podcast_title)
 
     def initialize_bookmark(self, is_new, bookmark_time):
         self.track[0].mark_unplayed = 0x02 if is_new else 0x01
@@ -327,7 +327,7 @@ class iPodDatabase(object):
         self.itdb = libgpod.itdb_parse(mountpoint.encode(), None)
 
         if not self.itdb:
-            raise ValueError(f'iTunesDB not found at {self.mountpoint}')
+            raise ValueError('iTunesDB not found at {}'.format(self.mountpoint))
 
         logger.info('iTunesDB: %s', self.itdb)
 

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -181,7 +181,7 @@ class SyncTrack(object):
         self.__dict__.update(kwargs)
 
     def __repr__(self):
-        return f'SyncTrack(title={self.title}, podcast={self.podcast})'
+        return 'SyncTrack(title={}, podcast={})'.format(self.title, self.podcast)
 
     @property
     def playcount_str(self):

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -48,8 +48,9 @@ _ = gpodder.gettext
 
 gpod_available = True
 try:
-    import gpod
+    from gpodder import libgpod_ctypes
 except:
+    logger.info('iPod sync not available', exc_info=True)
     gpod_available = False
 
 mplayer_available = True if util.find_command('mplayer') is not None else False
@@ -58,6 +59,7 @@ eyed3mp3_available = True
 try:
     import eyed3.mp3
 except:
+    logger.info('eyeD3 MP3 not available', exc_info=True)
     eyed3mp3_available = False
 
 
@@ -88,7 +90,7 @@ def get_track_length(filename):
             logger.error('MPlayer could not determine length: %s', filename, exc_info=True)
             attempted = True
 
-    if eyd3mp3_available:
+    if eyed3mp3_available:
         try:
             length = int(eyed3.mp3.Mp3AudioFile(filename).info.time_secs * 1000)
             # Notify user on eyed3 success if mplayer failed.
@@ -160,7 +162,6 @@ class SyncTrack(object):
     Keyword arguments needed:
         playcount (How often has the track been played?)
         podcast (Which podcast is this track from? Or: Folder name)
-        released (The release date of the episode)
 
     If any of these fields is unknown, it should not be
     passed to the function (the values will default to None
@@ -175,10 +176,12 @@ class SyncTrack(object):
         # Set some (possible) keyword arguments to default values
         self.playcount = 0
         self.podcast = None
-        self.released = None
 
         # Convert keyword arguments to object attributes
         self.__dict__.update(kwargs)
+
+    def __repr__(self):
+        return f'SyncTrack(title={self.title}, podcast={self.podcast})'
 
     @property
     def playcount_str(self):
@@ -227,7 +230,9 @@ class Device(services.ObservableService):
                     self._config.device_sync.skip_played_episodes)
             wrong_type = track.file_type() not in self.allowed_types
 
-            if does_not_exist or exclude_played or wrong_type:
+            if does_not_exist:
+                tracklist.remove(track)
+            elif exclude_played or wrong_type:
                 logger.info('Excluding %s from sync', track.title)
                 tracklist.remove(track)
 
@@ -250,15 +255,6 @@ class Device(services.ObservableService):
 
         if done_callback:
             done_callback()
-
-    def remove_tracks(self, tracklist):
-        for idx, track in enumerate(tracklist):
-            if self.cancelled:
-                return False
-            self.notify('progress', idx, len(tracklist))
-            self.remove_track(track)
-
-        return True
 
     def get_all_tracks(self):
         pass
@@ -292,8 +288,8 @@ class iPodDevice(Device):
         self.mountpoint = self._config.device_sync.device_folder
         self.download_status_model = download_status_model
         self.download_queue_manager = download_queue_manager
-        self.itdb = None
-        self.podcast_playlist = None
+
+        self.ipod = None
 
     def get_free_space(self):
         # Reserve 10 MiB for iTunesDB writing (to be on the safe side)
@@ -307,144 +303,85 @@ class iPodDevice(Device):
     def open(self):
         Device.open(self)
         if not gpod_available:
-            logger.error('Please install the gpod module to sync with an iPod device.')
+            logger.error('Please install libgpod 0.8.3 to sync with an iPod device.')
             return False
         if not os.path.isdir(self.mountpoint):
             return False
 
         self.notify('status', _('Opening iPod database'))
-        self.itdb = gpod.itdb_parse(self.mountpoint, None)
-        if self.itdb is None:
+        self.ipod = libgpod_ctypes.iPodDatabase(self.mountpoint)
+
+        if not self.ipod.itdb or not self.ipod.podcasts_playlist or not self.ipod.master_playlist:
             return False
 
-        self.itdb.mountpoint = self.mountpoint
-        self.podcasts_playlist = gpod.itdb_playlist_podcasts(self.itdb)
-        self.master_playlist = gpod.itdb_playlist_mpl(self.itdb)
+        self.notify('status', _('iPod opened'))
 
-        if self.podcasts_playlist:
-            self.notify('status', _('iPod opened'))
+        # build the initial tracks_list
+        self.tracks_list = self.get_all_tracks()
 
-            # build the initial tracks_list
-            self.tracks_list = self.get_all_tracks()
-
-            return True
-        else:
-            return False
+        return True
 
     def close(self):
-        if self.itdb is not None:
+        if self.ipod is not None:
             self.notify('status', _('Saving iPod database'))
-            gpod.itdb_write(self.itdb, None)
-            self.itdb = None
-
-            if self._config.ipod_write_gtkpod_extended:
-                self.notify('status', _('Writing extended gtkpod database'))
-                itunes_folder = os.path.join(self.mountpoint, 'iPod_Control', 'iTunes')
-                ext_filename = os.path.join(itunes_folder, 'iTunesDB.ext')
-                idb_filename = os.path.join(itunes_folder, 'iTunesDB')
-                if os.path.exists(ext_filename) and os.path.exists(idb_filename):
-                    try:
-                        db = gpod.ipod.Database(self.mountpoint)
-                        gpod.gtkpod.parse(ext_filename, db, idb_filename)
-                        gpod.gtkpod.write(ext_filename, db, idb_filename)
-                        db.close()
-                    except:
-                        logger.error('Error writing iTunesDB.ext')
-                else:
-                    logger.warning('Could not find %s or %s.',
-                            ext_filename, idb_filename)
+            self.ipod.close()
+            self.ipod = None
 
         Device.close(self)
         return True
 
-    def update_played_or_delete(self, channel, episodes, delete_from_db):
-        """
-        Check whether episodes on ipod are played and update as played
-        and delete if required.
-        """
-        for episode in episodes:
-            track = self.episode_on_device(episode)
-            if track:
-                gtrack = track.libgpodtrack
-                if gtrack.playcount > 0:
-                    if delete_from_db and not gtrack.rating:
-                        logger.info('Deleting episode from db %s', gtrack.title)
-                        channel.delete_episode(episode)
-                    else:
-                        logger.info('Marking episode as played %s', gtrack.title)
-
-    def purge(self):
-        for track in gpod.sw_get_playlist_tracks(self.podcasts_playlist):
-            if gpod.itdb_filename_on_ipod(track) is None:
-                logger.info('Episode has no file: %s', track.title)
-                # self.remove_track_gpod(track)
-            elif track.playcount > 0 and not track.rating:
-                logger.info('Purging episode: %s', track.title)
-                self.remove_track_gpod(track)
-
     def get_all_tracks(self):
         tracks = []
-        for track in gpod.sw_get_playlist_tracks(self.podcasts_playlist):
-            filename = gpod.itdb_filename_on_ipod(track)
+        for track in self.ipod.get_podcast_tracks():
+            filename = track.filename_on_ipod
 
             if filename is None:
-                # This can happen if the episode is deleted on the device
-                logger.info('Episode has no file: %s', track.title)
-                self.remove_track_gpod(track)
-                continue
+                length = 0
+                modified = ''
+            else:
+                length = util.calculate_size(filename)
+                timestamp = util.file_modification_timestamp(filename)
+                modified = util.format_date(timestamp)
 
-            length = util.calculate_size(filename)
-            timestamp = util.file_modification_timestamp(filename)
-            modified = util.format_date(timestamp)
-            try:
-                released = gpod.itdb_time_mac_to_host(track.time_released)
-                released = util.format_date(released)
-            except ValueError as ve:
-                # timestamp out of range for platform time_t (bug 418)
-                logger.info('Cannot convert track time: %s', ve)
-                released = 0
-
-            t = SyncTrack(track.title, length, modified,
-                    modified_sort=timestamp,
-                    libgpodtrack=track,
+            t = SyncTrack(track.episode_title, length, modified,
+                    ipod_track=track,
                     playcount=track.playcount,
-                    released=released,
-                    podcast=track.artist)
+                    podcast=track.podcast_title)
             tracks.append(t)
         return tracks
 
+    def episode_on_device(self, episode):
+        return next((track for track in self.tracks_list
+                     if track.ipod_track.podcast_rss == episode.channel.url and
+                     track.ipod_track.podcast_url == episode.url), None)
+
     def remove_track(self, track):
         self.notify('status', _('Removing %s') % track.title)
-        self.remove_track_gpod(track.libgpodtrack)
-
-    def remove_track_gpod(self, track):
-        filename = gpod.itdb_filename_on_ipod(track)
-
+        logger.info('Removing track from iPod: %r', track.title)
+        track.ipod_track.remove_from_device()
         try:
-            gpod.itdb_playlist_remove_track(self.podcasts_playlist, track)
-        except:
-            logger.info('Track %s not in playlist', track.title)
+            self.tracks_list.remove(next((sync_track for sync_track in self.tracks_list
+                                          if sync_track.ipod_track == track), None))
+        except ValueError:
+            ...
 
-        gpod.itdb_track_unlink(track)
-        util.delete_file(filename)
-
-    def add_track(self, episode, reporthook=None):
+    def add_track(self, task, reporthook=None):
+        episode = task.episode
         self.notify('status', _('Adding %s') % episode.title)
-        tracklist = gpod.sw_get_playlist_tracks(self.podcasts_playlist)
-        podcasturls = [track.podcasturl for track in tracklist]
+        tracklist = self.ipod.get_podcast_tracks()
+        episode_urls = [track.podcast_url for track in tracklist]
 
-        if episode.url in podcasturls:
+        if episode.url in episode_urls:
             # Mark as played on iPod if played locally (and set podcast flags)
-            self.set_podcast_flags(tracklist[podcasturls.index(episode.url)], episode)
+            self.update_from_episode(tracklist[episode_urls.index(episode.url)], episode)
             return True
 
-        original_filename = episode.local_filename(create=False)
+        local_filename = episode.local_filename(create=False)
         # The file has to exist, if we ought to transfer it, and therefore,
         # local_filename(create=False) must never return None as filename
-        assert original_filename is not None
-        local_filename = original_filename
+        assert local_filename is not None
 
-        if util.calculate_size(original_filename) > self.get_free_space():
+        if util.calculate_size(local_filename) > self.get_free_space():
             logger.error('Not enough space on %s, sync aborted...', self.mountpoint)
             d = {'episode': episode.title, 'mountpoint': self.mountpoint}
             message = _('Error copying %(episode)s: Not enough free space on %(mountpoint)s')
@@ -452,69 +389,38 @@ class iPodDevice(Device):
             self.cancelled = True
             return False
 
-        local_filename = episode.local_filename(create=False)
-
         (fn, extension) = os.path.splitext(local_filename)
         if extension.lower().endswith('ogg'):
+            # XXX: Proper file extension/format support check for iPod
             logger.error('Cannot copy .ogg files to iPod.')
             return False
 
-        track = gpod.itdb_track_new()
+        track = self.ipod.add_track(local_filename, episode.title, episode.channel.title,
+                util.remove_html_tags(episode.description), episode.url, episode.channel.url,
+                episode.published, get_track_length(local_filename), episode.file_type() == 'audio')
 
-        # Add release time to track if episode.published has a valid value
-        if episode.published > 0:
-            try:
-                # libgpod>= 0.5.x uses a new timestamp format
-                track.time_released = gpod.itdb_time_host_to_mac(int(episode.published))
-            except:
-                # old (pre-0.5.x) libgpod versions expect mactime, so
-                # we're going to manually build a good mactime timestamp here :)
-                #
-                # + 2082844800 for unixtime => mactime (1970 => 1904)
-                track.time_released = int(episode.published + 2082844800)
+        self.update_from_episode(track, episode, initial=True)
 
-        track.title = str(episode.title)
-        track.album = str(episode.channel.title)
-        track.artist = str(episode.channel.title)
-        track.description = str(util.remove_html_tags(episode.description))
-
-        track.podcasturl = str(episode.url)
-        track.podcastrss = str(episode.channel.url)
-
-        track.tracklen = get_track_length(local_filename)
-        track.size = os.path.getsize(local_filename)
-
-        if episode.file_type() == 'audio':
-            track.filetype = 'mp3'
-            track.mediatype = 0x00000004
-        elif episode.file_type() == 'video':
-            track.filetype = 'm4v'
-            track.mediatype = 0x00000006
-
-        self.set_podcast_flags(track, episode)
-
-        gpod.itdb_track_add(self.itdb, track, -1)
-        gpod.itdb_playlist_add_track(self.master_playlist, track, -1)
-        gpod.itdb_playlist_add_track(self.podcasts_playlist, track, -1)
-        copied = gpod.itdb_cp_track_to_ipod(track, str(local_filename), None)
         reporthook(episode.file_size, 1, episode.file_size)
-
-        # If the file has been converted, delete the temporary file here
-        if local_filename != original_filename:
-            util.delete_file(local_filename)
 
         return True
 
-    def set_podcast_flags(self, track, episode):
-        try:
-            # Set several flags for to podcast values
-            track.remember_playback_position = 0x01
-            track.flag1 = 0x02
-            track.flag2 = 0x01
-            track.flag3 = 0x01
-            track.flag4 = 0x01
-        except:
-            logger.warning('Seems like your python-gpod is out-of-date.')
+    def update_from_episode(self, track, episode, *, initial=False):
+        if initial:
+            # Set the initial bookmark on the device based on what we have locally
+            track.initialize_bookmark(episode.is_new, episode.current_position * 1000)
+        else:
+            # Copy updated status from iPod
+            if track.playcount > 0:
+                episode.is_new = False
+
+            if track.bookmark_time > 0:
+                logger.info('Playback position from iPod: %s', util.format_time(track.bookmark_time / 1000))
+                episode.is_new = False
+                episode.current_position = int(track.bookmark_time / 1000)
+                episode.current_position_updated = time.time()
+
+            episode.save()
 
 
 class MP3PlayerDevice(Device):
@@ -645,7 +551,6 @@ class MP3PlayerDevice(Device):
         modified = util.format_date(timestamp.tv_sec)
 
         t = SyncTrack(title, info.get_size(), modified,
-                modified_sort=timestamp,
                 filename=file.get_uri(),
                 podcast=podcast_name)
         tracks.append(t)


### PR DESCRIPTION
Debian/Ubuntu [haven't built](http://changelogs.ubuntu.com/changelogs/pool/main/libg/libgpod/libgpod_0.8.3-16build1/changelog) the Python bindings for libgpod for a while now (presumably as part of the Python 2 -> Python 3 transition, but I haven't investigated more than this):

```

libgpod (0.8.3-14) unstable; urgency=medium

...

  [ Andrey Rahmatullin ]
  * Drop the Python subpackage.

 -- Andrey Rahmatullin <wrar@debian.org>  Wed, 21 Aug 2019 22:31:15 +0500
 ```

This leaves users without an "easy" way to use iPod sync support, even on Linux.

Apart from that, I noticed that even with `python-gpod` installed, the iPod sync support is probably just broken at the moment.

This patch re-introduces "classic" iPod support using libgpod (which is still available in distros) directly using Python's ctypes FFI module to interact with the C library. It also cleans up some things in `src/gpodder/sync.py` that were unused/dead code.

This actually does more than previous incarnations of iPod support in gPodder ever did:

- "New" status and bookmark position (resume point) on iPod is restored from `current_position` of the episode
- On the next sync, updated bookmark values from the iPod are synchronized to the episode's `current_position`

This means that when listening to an episode on an iPod, and later syncing, the playback position (bookmark) is reflected in gPodder's UI. Deleting episodes on the iPod that have been deleted in gPodder has also been tested and works.

The other great thing about this change is, if we ever get to build `libgpod` and its dependencies for Windows and/or macOS, iPod syncing would work for those devices as well (`libgpod` is basically just writing files on the filesystem for "classic" iPods, nothing magical there).

I tried to be careful not to introduce use-after-free and memory leak bugs, and tried to document the pitfalls I ran into, but there might still be some issues lurking (`valgrind` is mostly happy, though). A "proper" C extension module for Python might be the way to go, but this ctypes-based solution doesn't require development headers or even a compiler (and trying to get the SWIG-based Python bindings re-enabled in Linux distros might be more effort than what it's worth).