### PR TITLE
Replace context menus with GtkPopovers

### DIFF
--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -180,7 +180,7 @@
                                 <property name="has-tooltip">True</property>
                                 <property name="headers-visible">False</property>
                                 <signal name="button-press-event" handler="on_treeview_button_pressed" swapped="no"/>
-                                <signal name="button-release-event" handler="on_treeview_podcasts_button_released" swapped="no"/>
+                                <signal name="button-release-event" handler="on_treeview_channels_button_released" swapped="no"/>
                                 <signal name="cursor-changed" handler="on_treeChannels_cursor_changed" swapped="no"/>
                                 <signal name="draw" handler="on_treeview_expose_event" swapped="no"/>
                                 <signal name="query-tooltip" handler="on_treeview_query_tooltip" swapped="no"/>

--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -45,6 +45,21 @@
               </packing>
             </child>
             <child>
+              <object class="GtkToolButton" id="toolForceDownload">
+                <property name="visible">False</property>
+                <property name="sensitive">False</property>
+                <property name="can-focus">False</property>
+                <property name="is-important">True</property>
+                <property name="label" translatable="yes">Start download now</property>
+                <property name="icon-name">document-save-symbolic</property>
+                <signal name="clicked" handler="on_force_download_selected_episodes" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkToolButton" id="toolDownload">
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>

--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -261,9 +261,35 @@
   </menu>
   <menu id="channels-context">
     <section>
+      <attribute name="display-hint">horizontal-buttons</attribute>
       <item>
         <attribute name="action">win.updateChannel</attribute>
         <attribute name="label" translatable="yes">Update channel</attribute>
+        <attribute name="verb-icon">view-refresh-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.editChannel</attribute>
+        <attribute name="label" translatable="yes">Channel settings</attribute>
+        <attribute name="verb-icon">preferences-other-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.removeChannel</attribute>
+        <attribute name="label" translatable="yes">Delete channel</attribute>
+        <attribute name="verb-icon">edit-delete-symbolic</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.updateChannel</attribute>
+        <attribute name="label" translatable="yes">Update channel</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.editChannel</attribute>
+        <attribute name="label" translatable="yes">Channel settings</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.removeChannel</attribute>
+        <attribute name="label" translatable="yes">Delete channel</attribute>
       </item>
     </section>
     <section>
@@ -285,19 +311,29 @@
         <attribute name="action">win.refreshImage</attribute>
         <attribute name="label" translatable="yes">Refresh image</attribute>
       </item>
-      <item>
-        <attribute name="action">win.removeChannel</attribute>
-        <attribute name="label" translatable="yes">Delete channel</attribute>
-      </item>
     </section>
-    <section>
-      <item>
-        <attribute name="action">win.editChannel</attribute>
-        <attribute name="label" translatable="yes">Channel settings</attribute>
-      </item>
-    </section>
+    <!-- Extensions -->
   </menu>
   <menu id="episodes-context">
+    <section>
+      <attribute name="display-hint">horizontal-buttons</attribute>
+      <item>
+        <attribute name="action">win.play</attribute>
+        <attribute name="label" translatable="yes">Play</attribute>
+        <attribute name="verb-icon">media-playback-start-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.download</attribute>
+        <attribute name="label" translatable="yes">Download</attribute>
+        <attribute name="verb-icon">document-save-symbolic</attribute>
+      </item>
+      <!-- Cancel -->
+      <item>
+        <attribute name="action">win.delete</attribute>
+        <attribute name="label" translatable="yes">Delete</attribute>
+        <attribute name="verb-icon">edit-delete-symbolic</attribute>
+      </item>
+    </section>
     <section>
       <item>
         <attribute name="action">win.play</attribute>
@@ -351,6 +387,24 @@
     </item>
   </menu>
   <menu id="downloads-context">
+    <section>
+      <attribute name="display-hint">horizontal-buttons</attribute>
+      <item>
+        <attribute name="action">win.download</attribute>
+        <attribute name="label" translatable="yes">Start download now</attribute>
+        <attribute name="verb-icon">document-save-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.pause</attribute>
+        <attribute name="label" translatable="yes">Pause</attribute>
+        <attribute name="verb-icon">media-playback-pause-symbolic</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.cancel</attribute>
+        <attribute name="label" translatable="yes">Cancel</attribute>
+        <attribute name="verb-icon">process-stop-symbolic</attribute>
+      </item>
+    </section>
     <section>
       <item>
         <attribute name="action">win.download</attribute>

--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -259,5 +259,128 @@
       </submenu>
     </submenu>
   </menu>
+  <menu id="channels-context">
+    <section>
+      <item>
+        <attribute name="action">win.updateChannel</attribute>
+        <attribute name="label" translatable="yes">Update channel</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.openChannelDownloadFolder</attribute>
+        <attribute name="label" translatable="yes">Open download folder</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.markEpisodesAsOld</attribute>
+        <attribute name="label" translatable="yes">Mark episodes as old</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.channelAutoArchive</attribute>
+        <attribute name="label" translatable="yes">Archive all episodes</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.refreshImage</attribute>
+        <attribute name="label" translatable="yes">Refresh image</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.removeChannel</attribute>
+        <attribute name="label" translatable="yes">Delete channel</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.editChannel</attribute>
+        <attribute name="label" translatable="yes">Channel settings</attribute>
+      </item>
+    </section>
+  </menu>
+  <menu id="episodes-context">
+    <section>
+      <item>
+        <attribute name="action">win.play</attribute>
+        <attribute name="label" translatable="yes">Play</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.download</attribute>
+        <attribute name="label" translatable="yes">Download</attribute>
+      </item>
+      <!-- Cancel -->
+      <item>
+        <attribute name="action">win.delete</attribute>
+        <attribute name="label" translatable="yes">Delete</attribute>
+      </item>
+    </section>
+    <!-- Extensions -->
+    <!-- Send To -->
+    <section>
+      <item>
+        <attribute name="action">win.episodeNew</attribute>
+        <attribute name="label" translatable="yes">New</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.episodeLock</attribute>
+        <attribute name="label" translatable="yes">Archive</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.toggleShownotes</attribute>
+        <attribute name="label" translatable="yes">Episode details</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.openEpisodeDownloadFolder</attribute>
+        <attribute name="label" translatable="yes">Open download folder</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.selectChannel</attribute>
+        <attribute name="label" translatable="yes">Select channel</attribute>
+      </item>
+    </section>
+  </menu>
+  <menu id="episodes-context-sendto">
+    <item>
+      <attribute name="action">win.saveEpisodes</attribute>
+      <attribute name="label" translatable="yes">Local folder</attribute>
+    </item>
+    <item>
+      <attribute name="action">win.bluetoothEpisodes</attribute>
+      <attribute name="label" translatable="yes">Bluetooth device</attribute>
+    </item>
+  </menu>
+  <menu id="downloads-context">
+    <section>
+      <item>
+        <attribute name="action">win.download</attribute>
+        <attribute name="label" translatable="yes">Start download now</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.pause</attribute>
+        <attribute name="label" translatable="yes">Pause</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.cancel</attribute>
+        <attribute name="label" translatable="yes">Cancel</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.moveUp</attribute>
+        <attribute name="label" translatable="yes">Move up</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.moveDown</attribute>
+        <attribute name="label" translatable="yes">Move down</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.remove</attribute>
+        <attribute name="label" translatable="yes">Remove from list</attribute>
+      </item>
+    </section>
+  </menu>
 </interface>
 <!-- :noTabs=true:tabSize=2:indentSize=2: -->

--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -390,7 +390,7 @@
     <section>
       <attribute name="display-hint">horizontal-buttons</attribute>
       <item>
-        <attribute name="action">win.download</attribute>
+        <attribute name="action">win.forceDownload</attribute>
         <attribute name="label" translatable="yes">Start download now</attribute>
         <attribute name="verb-icon">document-save-symbolic</attribute>
       </item>

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -122,6 +122,7 @@ class gPodderApplication(Gtk.Application):
 
         builder = Gtk.Builder()
         builder.set_translation_domain(gpodder.textdomain)
+        self.builder = builder
 
         menu_filename = None
         for ui_folder in gpodder.ui_folders:

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -345,3 +345,35 @@ class TreeViewHelper(object):
 
             return (x, y, True)
         return position_func
+
+    @staticmethod
+    def get_popup_rectangle(treeview, event, column=0):
+        """
+        :return: Gdk.Rectangle to pass to Gtk.Popover.set_pointing_to()
+
+        If event is given, return a zero-width and height rectangle with the
+        event coordinates. If event is None, get the area of the column in the
+        first selected treeview row.
+
+        Used for instance when the popup trigger is the Menu key: It will
+        position the popover on top of the column on the selected row, even if
+        the mouse is elsewhere
+        """
+        if event is not None:
+            area = Gdk.Rectangle()
+            area.x, area.y = treeview.convert_bin_window_to_widget_coords(event.x, event.y)
+            return area
+
+        # If there's a selection, place the popup menu on top of
+        # the first-selected row and given column (otherwise in the top left corner)
+        selection = treeview.get_selection()
+        model, paths = selection.get_selected_rows()
+        if paths:
+            path = paths[0]
+            area = treeview.get_cell_area(path, treeview.get_column(column))
+        else:
+            area = Gdk.Rectangle()  # x, y, width, height are all 0
+
+        area.x, area.y = treeview.convert_bin_window_to_widget_coords(area.x, area.y)
+
+        return area

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -757,13 +757,13 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         return event.button == 3
 
-    def on_treeview_podcasts_button_released(self, treeview, event):
+    def on_treeview_channels_button_released(self, treeview, event):
         if event.window != treeview.get_bin_window():
             return False
 
         return self.treeview_channels_show_context_menu(event)
 
-    def on_treeview_podcasts_long_press(self, gesture, x, y, treeview):
+    def on_treeview_channels_long_press(self, gesture, x, y, treeview):
         ev = Dummy(x=x, y=y, button=3)
         return self.treeview_channels_show_context_menu(ev)
 
@@ -842,7 +842,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         lp = Gtk.GestureLongPress.new(self.treeChannels)
         lp.set_touch_only(True)
         lp.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
-        lp.connect("pressed", self.on_treeview_podcasts_long_press, self.treeChannels)
+        lp.connect("pressed", self.on_treeview_channels_long_press, self.treeChannels)
         setattr(self.treeChannels, "long-press-gesture", lp)
 
         # Set up type-ahead find for the podcast list

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2363,6 +2363,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     can_pause, can_cancel, can_delete, can_lock)
         else:
             (can_queue, can_pause, can_cancel, can_remove) = (False,) * 4
+            can_force = True
 
             selection = self.treeDownloads.get_selection()
             if selection.count_selected_rows() > 0:
@@ -2378,14 +2379,19 @@ class gPodder(BuilderWidget, dbus.service.Object):
                         logger.error('Invalid task at path %s', str(path))
                         continue
 
+                    if task.status != download.DownloadTask.QUEUED:
+                        can_force = False
+
                     # These values should only ever be set, never unset them once set.
                     # Actions filter tasks using these methods.
                     can_queue = can_queue or task.can_queue()
                     can_pause = can_pause or task.can_pause()
                     can_cancel = can_cancel or task.can_cancel()
                     can_remove = can_remove or task.can_remove()
+            else:
+                can_force = False
 
-            self.set_episode_actions(False, False, can_queue, can_pause, can_cancel, can_remove, False, False)
+            self.set_episode_actions(False, False, can_queue or can_force, can_pause, can_cancel, can_remove, False, False)
 
             return (False, False, False, can_queue, can_pause, can_cancel,
                     can_remove, False)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2161,8 +2161,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.episodes_popover.show()
             return True
 
-    def set_episode_actions(self, open_instead_of_play=False, can_play=False, can_download=False, can_pause=False, can_cancel=False,
-                            can_delete=False, can_lock=False, is_episode_selected=False):
+    def set_episode_actions(self, open_instead_of_play=False, can_play=False, can_force=False, can_download=False,
+                            can_pause=False, can_cancel=False, can_delete=False, can_lock=False, is_episode_selected=False):
         episodes = self.get_selected_episodes() if is_episode_selected else []
 
         # play icon and label
@@ -2184,6 +2184,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         # toolbar
         self.toolPlay.set_sensitive(can_play)
+        self.toolForceDownload.set_visible(can_force)
+        self.toolForceDownload.set_sensitive(can_force)
+        self.toolDownload.set_visible(not can_force)
         self.toolDownload.set_sensitive(can_download)
         self.toolPause.set_sensitive(can_pause)
         self.toolCancel.set_sensitive(can_cancel)
@@ -2191,7 +2194,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Episodes menu
         self.play_action.set_enabled(can_play and not open_instead_of_play)
         self.open_action.set_enabled(can_play and open_instead_of_play)
-        self.download_action.set_enabled(can_download)
+        self.download_action.set_enabled(can_force or can_download)
         self.pause_action.set_enabled(can_pause)
         self.cancel_action.set_enabled(can_cancel)
         self.delete_action.set_enabled(can_delete)
@@ -2374,7 +2377,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     can_delete = can_delete or episode.can_delete()
                     can_lock = can_lock or episode.can_lock()
 
-            self.set_episode_actions(open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete, can_lock,
+            self.set_episode_actions(open_instead_of_play, can_play, False, can_download, can_pause, can_cancel, can_delete, can_lock,
                                     selection.count_selected_rows() > 0)
 
             return (open_instead_of_play, can_play, can_preview, can_download,
@@ -2409,7 +2412,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             else:
                 can_force = False
 
-            self.set_episode_actions(False, False, can_queue or can_force, can_pause, can_cancel, can_remove, False, False)
+            self.set_episode_actions(False, False, can_force, can_queue, can_pause, can_cancel, can_remove, False, False)
 
             return (False, False, False, can_queue, can_pause, can_cancel,
                     can_remove, False)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -376,6 +376,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             # Episodes
             ('play', self.on_playback_selected_episodes),
             ('open', self.on_playback_selected_episodes),
+            ('forceDownload', self.on_force_download_selected_episodes),
             ('download', self.on_download_selected_episodes),
             ('pause', self.on_pause_selected_episodes),
             ('cancel', self.on_item_cancel_download_activate),
@@ -410,6 +411,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Episodes
         self.play_action = g.lookup_action('play')
         self.open_action = g.lookup_action('open')
+        self.force_download_action = g.lookup_action('forceDownload')
         self.download_action = g.lookup_action('download')
         self.pause_action = g.lookup_action('pause')
         self.cancel_action = g.lookup_action('cancel')
@@ -1897,7 +1899,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             vsec.remove(0)
             dsec.remove(0)
             if can_force:
-                insert_menuitem(0, _('Start download now'), 'win.download', 'document-save-symbolic')
+                insert_menuitem(0, _('Start download now'), 'win.forceDownload', 'document-save-symbolic')
             else:
                 insert_menuitem(0, _('Download'), 'win.download', 'document-save-symbolic')
 
@@ -3867,6 +3869,15 @@ class gPodder(BuilderWidget, dbus.service.Object):
                                model.get_value(model.get_iter(path),
                                DownloadStatusModel.C_TASK)) for path in paths]
             self._for_each_task_set_status(selected_tasks, download.DownloadTask.QUEUED)
+
+    def on_force_download_selected_episodes(self, action_or_widget, param=None):
+        if self.wNotebook.get_current_page() == 1:
+            selection = self.treeDownloads.get_selection()
+            (model, paths) = selection.get_selected_rows()
+            selected_tasks = [(Gtk.TreeRowReference.new(model, path),
+                               model.get_value(model.get_iter(path),
+                               DownloadStatusModel.C_TASK)) for path in paths]
+            self._for_each_task_set_status(selected_tasks, download.DownloadTask.QUEUED, True)
 
     def on_pause_selected_episodes(self, action_or_widget, param=None):
         if self.wNotebook.get_current_page() == 0:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2026,34 +2026,6 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         util.run_in_background(lambda: convert_and_send_thread(episodes_to_copy))
 
-    def _add_sub_menu(self, menu, label):
-        root_item = Gtk.MenuItem(label)
-        menu.append(root_item)
-        sub_menu = Gtk.Menu()
-        root_item.set_submenu(sub_menu)
-        return sub_menu
-
-    def _submenu_item_activate_hack(self, item, callback, *args):
-        # See http://stackoverflow.com/questions/5221326/submenu-item-does-not-call-function-with-working-solution
-        # Note that we can't just call the callback on button-press-event, as
-        # it might be blocking (see http://gpodder.org/bug/1778), so we run
-        # this in the GUI thread at a later point in time (util.idle_add).
-        # Also, we also have to connect to the activate signal, as this is the
-        # only signal that is fired when keyboard navigation is used.
-
-        # It can happen that both (button-release-event and activate) signals
-        # are fired, and we must avoid calling the callback twice. We do this
-        # using a semaphore and only acquiring (but never releasing) it, making
-        # sure that the util.idle_add() call below is only ever called once.
-        only_once = threading.Semaphore(1)
-
-        def handle_event(item, event=None):
-            if only_once.acquire(False):
-                util.idle_add(callback, *args)
-
-        item.connect('button-press-event', handle_event)
-        item.connect('activate', handle_event)
-
     def treeview_available_show_context_menu(self, treeview, event=None):
         model, paths = self.treeview_handle_context_menu_click(treeview, event)
         if not paths:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -823,6 +823,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.gPodder, extmenu, 'channel_context_action_')
         self.channels_popover = Gtk.Popover.new_from_model(self.treeChannels, menu)
         self.channels_popover.set_position(Gtk.PositionType.BOTTOM)
+        self.channels_popover.connect(
+            'closed', lambda popover: self.allow_tooltips(True))
 
         # Set up type-ahead find for the podcast list
         def on_key_press(treeview, event):
@@ -958,6 +960,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         menu.insert_section(2, None, self.sendto_menu)
         self.episodes_popover = Gtk.Popover.new_from_model(self.treeAvailable, menu)
         self.episodes_popover.set_position(Gtk.PositionType.BOTTOM)
+        self.episodes_popover.connect(
+            'closed', lambda popover: self.allow_tooltips(True))
 
         # Initialize progress icons
         cake_size = cake_size_from_widget(self.treeAvailable)
@@ -1584,8 +1588,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
         setattr(treeview, TreeViewHelper.LAST_TOOLTIP, None)
         return False
 
-    def treeview_allow_tooltips(self, treeview, allow):
-        setattr(treeview, TreeViewHelper.CAN_TOOLTIP, allow)
+    def allow_tooltips(self, allow):
+        setattr(self.treeChannels, TreeViewHelper.CAN_TOOLTIP, allow)
+        setattr(self.treeAvailable, TreeViewHelper.CAN_TOOLTIP, allow)
 
     def treeview_handle_context_menu_click(self, treeview, event):
         if event is None:
@@ -1911,6 +1916,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     gpodder.user_extensions.on_channel_context_menu(self.active_channel)
                     or [])])
 
+            self.allow_tooltips(False)
+
             area = TreeViewHelper.get_popup_rectangle(treeview, event)
             self.channels_popover.set_pointing_to(area)
             self.channels_popover.show()
@@ -2088,6 +2095,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             # New and Archive state
             self.episode_new_action.change_state(GLib.Variant.new_boolean(any_new))
             self.episode_lock_action.change_state(GLib.Variant.new_boolean(any_locked))
+
+            self.allow_tooltips(False)
 
             area = TreeViewHelper.get_popup_rectangle(treeview, event)
             self.episodes_popover.set_pointing_to(area)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -763,17 +763,29 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         return self.treeview_channels_show_context_menu(event)
 
+    def on_treeview_podcasts_long_press(self, gesture, x, y, treeview):
+        ev = Dummy(x=x, y=y, button=3)
+        return self.treeview_channels_show_context_menu(ev)
+
     def on_treeview_episodes_button_released(self, treeview, event):
         if event.window != treeview.get_bin_window():
             return False
 
         return self.treeview_available_show_context_menu(event)
 
+    def on_treeview_episodes_long_press(self, gesture, x, y, treeview):
+        ev = Dummy(x=x, y=y, button=3)
+        return self.treeview_available_show_context_menu(ev)
+
     def on_treeview_downloads_button_released(self, treeview, event):
         if event.window != treeview.get_bin_window():
             return False
 
         return self.treeview_downloads_show_context_menu(event)
+
+    def on_treeview_downloads_long_press(self, gesture, x, y, treeview):
+        ev = Dummy(x=x, y=y, button=3)
+        return self.treeview_downloads_show_context_menu(ev)
 
     def on_find_podcast_activate(self, *args):
         if self._search_podcasts:
@@ -825,6 +837,13 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.channels_popover.set_position(Gtk.PositionType.BOTTOM)
         self.channels_popover.connect(
             'closed', lambda popover: self.allow_tooltips(True))
+
+        # Long press gesture
+        lp = Gtk.GestureLongPress.new(self.treeChannels)
+        lp.set_touch_only(True)
+        lp.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        lp.connect("pressed", self.on_treeview_podcasts_long_press, self.treeChannels)
+        setattr(self.treeChannels, "long-press-gesture", lp)
 
         # Set up type-ahead find for the podcast list
         def on_key_press(treeview, event):
@@ -1109,6 +1128,13 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Update the visibility of the columns and the check menu items
         self.update_episode_list_columns_visibility()
 
+        # Long press gesture
+        lp = Gtk.GestureLongPress.new(self.treeAvailable)
+        lp.set_touch_only(True)
+        lp.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        lp.connect("pressed", self.on_treeview_episodes_long_press, self.treeAvailable)
+        setattr(self.treeAvailable, "long-press-gesture", lp)
+
         # Set up type-ahead find for the episode list
         def on_key_press(treeview, event):
             if event.keyval == Gdk.KEY_Left:
@@ -1223,6 +1249,13 @@ class gPodder(BuilderWidget, dbus.service.Object):
         menu = self.application.builder.get_object('downloads-context')
         self.downloads_popover = Gtk.Popover.new_from_model(self.treeDownloads, menu)
         self.downloads_popover.set_position(Gtk.PositionType.BOTTOM)
+
+        # Long press gesture
+        lp = Gtk.GestureLongPress.new(self.treeDownloads)
+        lp.set_touch_only(True)
+        lp.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        lp.connect("pressed", self.on_treeview_downloads_long_press, self.treeDownloads)
+        setattr(self.treeDownloads, "long-press-gesture", lp)
 
         def on_key_press(treeview, event):
             if event.keyval == Gdk.KEY_Menu:


### PR DESCRIPTION
Replaces the context menus in channel, episode and download treeviews ~~(actually just channel for now)~~ with action-based GtkPopover menus. Ported and improved from the adaptive branch. 

I think popovers are a better fit for context menus in gPodder. They look better (IMO) and allow styling with CSS for a larger touch surface, if needed.

~~There is an incomplete and slightly outdated implementation of popover context menus for channel, episode and download treeviews in the adaptive branch. For now, I've ported the channel context menu to the same functionality as the master branch, but if this idea is well received, I will complete the rest of them as well.~~