### PR TITLE
Treat only really new episodes as new after an update

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -522,7 +522,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkLabel" id="label_episode_limit">
                                         <property name="visible">True</property>
@@ -537,7 +537,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkSpinButton" id="spinbutton_episode_limit">
                                         <property name="visible">True</property>
@@ -593,7 +593,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkLabel" id="label_auto_download">
                                         <property name="visible">True</property>
@@ -608,7 +608,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkComboBox" id="combo_auto_download">
                                         <property name="visible">True</property>
@@ -622,7 +622,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -764,7 +764,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkLabel" id="label_device_type">
                                         <property name="visible">True</property>
@@ -778,7 +778,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkComboBox" id="combobox_device_type">
                                         <property name="visible">True</property>
@@ -806,7 +806,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkLabel" id="label_device_mount">
                                         <property name="visible">True</property>
@@ -820,7 +820,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkButton" id="btn_filesystemMountpoint">
                                         <property name="visible">True</property>
@@ -876,7 +876,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkLabel" id="label_device_playlists">
                                         <property name="visible">True</property>
@@ -890,7 +890,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkButton" id="btn_playlistfolder">
                                         <property name="visible">True</property>
@@ -945,7 +945,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkLabel" id="label_on_sync">
                                         <property name="visible">True</property>
@@ -959,7 +959,7 @@
                                 <child>
                                   <object class="GtkFlowBoxChild">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
+                                    <property name="can-focus">False</property>
                                     <child>
                                       <object class="GtkComboBox" id="combobox_on_sync">
                                         <property name="visible">True</property>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -569,6 +569,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="checkbutton_only_added_are_new">
+                                <property name="label" translatable="yes">Consider only episodes added in the update as new</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFlowBox">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -154,6 +154,7 @@ defaults = {
 
             'toolbar': False,
             'new_episodes': 'show',  # ignore, show, queue, download
+            'only_added_are_new': False,  # Only just added episodes are considered new after an update
             'live_search_delay': 200,
             'search_always_visible': False,
             'find_as_you_type': True,

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -249,6 +249,9 @@ class gPodderPreferences(BuilderWidget):
 
         self._config.connect_gtk_spinbutton('limit.episodes', self.spinbutton_episode_limit)
 
+        self._config.connect_gtk_togglebutton('ui.gtk.only_added_are_new',
+                                              self.checkbutton_only_added_are_new)
+
         self.auto_download_model = NewEpisodeActionList(self._config)
         self.combo_auto_download.set_model(self.auto_download_model)
         cellrenderer = Gtk.CellRendererText()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2842,6 +2842,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         def update_feed_cache_proc():
             updated_channels = []
             nr_update_errors = 0
+            new_episodes = []
             for updated, channel in enumerate(channels):
                 if self.feed_cache_update_cancelled:
                     break
@@ -2855,7 +2856,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 try:
                     channel._update_error = None
                     util.idle_add(indicate_updating_podcast, channel)
-                    channel.update(max_episodes=self.config.limit.episodes)
+                    new_episodes.extend(channel.update(max_episodes=self.config.limit.episodes))
                     self._update_cover(channel)
                 except Exception as e:
                     message = str(e)
@@ -2899,7 +2900,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                        nr_update_errors) % {'count': nr_update_errors},
                     _('Error while updating feeds'), widget=self.treeChannels)
 
-            def update_feed_cache_finish_callback():
+            def update_feed_cache_finish_callback(new_episodes):
                 # Process received episode actions for all updated URLs
                 self.process_received_episode_actions()
 
@@ -2912,9 +2913,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     # The user decided to abort the feed update
                     self.show_update_feeds_buttons()
 
-                # Only search for new episodes in podcasts that have been
-                # updated, not in other podcasts (for single-feed updates)
-                episodes = self.get_new_episodes([c for c in updated_channels])
+                # The filter extension can mark newly added episodes as old,
+                # so take only episodes marked as new.
+                episodes = ((e for e in new_episodes if e.check_is_new())
+                            if self.config.ui.gtk.only_added_are_new
+                            else self.get_new_episodes([c for c in updated_channels]))
 
                 if self.config.downloads.chronological_order:
                     # download older episodes first
@@ -2965,7 +2968,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
                     self.show_update_feeds_buttons()
 
-            util.idle_add(update_feed_cache_finish_callback)
+            util.idle_add(update_feed_cache_finish_callback, new_episodes)
 
     def on_gPodder_delete_event(self, *args):
         """Called when the GUI wants to close the window


### PR DESCRIPTION
Currently, when a channel or all channels are updated, all episodes marked as new are treated as being new, which usually means being shown in the episode selector. If one treats the 'new' marking as a kind of a to-do list for interesting episodes, sorting through the old, but marked as new episodes after each update gets tiring. This PR makes gPodder treat as new only episodes which are added in an update.

This change could be added behind a new configuration variable, but I decided not to, because episodes marked as new are easily accessible either from View->Unplayed episodes, or from Podcasts->Download new episodes. 