### PR TITLE
Fix undownload dialog layout

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2932,7 +2932,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             titles.append('• ' + (html.escape(thing.title if len(thing.title) <= max_length else thing.title[:max_length] + '…')))
         if len(things) > max_things:
             titles.append('+%(count)d more…' % {'count': len(things) - max_things})
-        return '\n'.join(titles) + '\n\n' + message
+        return message + '\n\n' + '\n'.join(titles)
 
     def delete_episode_list(self, episodes, confirm=True, callback=None, undownload=False):
         if self.wNotebook.get_current_page() > 0:


### PR DESCRIPTION
This forces the new undownload checkbox to wrap, preventing wide delete dialogs. It also wraps other confirmation dialogs, like the wide "uploading list to gpodder.net" dialog. It would be better if the message textview could be resized to fit its content, but that doesn't appear to be possible. The chosen height should display all dialogs, including translations, without scrolling the message. It should only scroll when deleting multiple episodes with long titles.

The confirmation dialog is used for:
* deleting episodes (with or without undownload checkbox)
* deleting channels
* upload button on gpodder.net preferences
* new version available, download latest
* overwrite saved episode when sending to local folder
* error saving episode when sending to local folder
* URL redirection warning when adding channels
* sync to device when no device is configured
* not enough space when syncing

Fixes #1292.