### PR TITLE
Add download retry without authentication if auth is set

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -231,7 +231,7 @@ class DownloadURLOpener:
 # The following is based on Python's urllib.py "URLopener.retrieve"
 # Also based on http://mail.python.org/pipermail/python-list/2001-October/110069.html
 
-    def retrieve_resume(self, url, filename, reporthook=None, data=None):
+    def retrieve_resume(self, url, filename, reporthook=None, data=None, disable_auth=False):
         """Download files from an URL; return (headers, real_url)
 
         Resumes a download if the local filename exists and
@@ -244,7 +244,7 @@ class DownloadURLOpener:
             'User-agent': gpodder.user_agent
         }
 
-        if self.channel.auth_username or self.channel.auth_password:
+        if (self.channel.auth_username or self.channel.auth_password) and not disable_auth:
             logger.debug('Authenticating as "%s"', self.channel.auth_username)
             auth = (self.channel.auth_username, self.channel.auth_password)
         else:
@@ -278,10 +278,8 @@ class DownloadURLOpener:
                 resp.raise_for_status()
             except HTTPError as e:
                 if auth is not None:
-                    # Try again without authentification (bug 1296)
-                    self.channel.auth_username = None
-                    self.channel.auth_password = None
-                    return self.retrieve_resume(url, filename, reporthook, data)
+                    # Try again without authentication (bug 1296)
+                    return self.retrieve_resume(url, filename, reporthook, data, True)
                 else:
                     raise gPodderDownloadHTTPError(url, resp.status_code, str(e))
 

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -277,7 +277,13 @@ class DownloadURLOpener:
             try:
                 resp.raise_for_status()
             except HTTPError as e:
-                raise gPodderDownloadHTTPError(url, resp.status_code, str(e))
+                if auth is not None:
+                    # Try again without authentification (bug 1296)
+                    self.channel.auth_username = None
+                    self.channel.auth_password = None
+                    return self.retrieve_resume(url, filename, reporthook, data)
+                else:
+                    raise gPodderDownloadHTTPError(url, resp.status_code, str(e))
 
             headers = resp.headers
 


### PR DESCRIPTION
This is a naive workaround that adds another try without authentication if the download fails. This is to work around servers where the .rss file is protected but the .mp3 files are strictly not protected (where sending the authentication causes the download to fail).
Works around bug #1296.