### PR TITLE
Add setting to disable find-as-you-type.

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -287,6 +287,20 @@
                                 <property name="position">3</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_find_as_you_type">
+                                <property name="label" translatable="yes">Find as you type</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="name">general</property>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -156,6 +156,7 @@ defaults = {
             'new_episodes': 'show',  # ignore, show, queue, download
             'live_search_delay': 200,
             'search_always_visible': False,
+            'find_as_you_type': True,
 
             'podcast_list': {
                 'all_episodes': True,

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -234,6 +234,8 @@ class gPodderPreferences(BuilderWidget):
                                               self.checkbutton_show_all_episodes)
         self._config.connect_gtk_togglebutton('podcast_list_sections',
                                               self.checkbutton_podcast_sections)
+        self._config.connect_gtk_togglebutton('ui.gtk.find_as_you_type',
+                                              self.checkbutton_find_as_you_type)
 
         self.update_interval_presets = [0, 10, 30, 60, 2 * 60, 6 * 60, 12 * 60]
         adjustment_update_interval = self.hscale_update_interval.get_adjustment()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -777,8 +777,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 # < 32 to intercept Delete and Tab events
                 if unicode_char_id < 32:
                     return False
-                input_char = chr(unicode_char_id)
-                self._search_podcasts.show_search(input_char)
+                if self.config.ui.gtk.find_as_you_type:
+                    input_char = chr(unicode_char_id)
+                    self._search_podcasts.show_search(input_char)
             return True
         self.treeChannels.connect('key-press-event', on_key_press)
 
@@ -1000,8 +1001,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 # < 32 to intercept Delete and Tab events
                 if unicode_char_id < 32:
                     return False
-                input_char = chr(unicode_char_id)
-                self._search_episodes.show_search(input_char)
+                if self.config.ui.gtk.find_as_you_type:
+                    input_char = chr(unicode_char_id)
+                    self._search_episodes.show_search(input_char)
             return True
         self.treeAvailable.connect('key-press-event', on_key_press)
 


### PR DESCRIPTION
The new setting defaults to enabled to preserve the current behavior of opening search fields in channel and episode lists when the user begins typing. Disabling the feature ignores the keypresses and requires ctrl-f or ctrl-shift-f to open or focus the search field.