### PR TITLE
Create context menus from GMenuModel

### DIFF
--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -229,5 +229,46 @@
       </submenu>
     </submenu>
   </menu>
+  <menu id="channels-context">
+    <section>
+      <item>
+        <attribute name="action">win.updateChannel</attribute>
+        <attribute name="label" translatable="yes">Update channel</attribute>
+        <attribute name="icon">view-refresh</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.openChannelDownloadFolder</attribute>
+        <attribute name="label" translatable="yes">Open download folder</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.markEpisodesAsOld</attribute>
+        <attribute name="label" translatable="yes">Mark episodes as old</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.channelAutoArchive</attribute>
+        <attribute name="label" translatable="yes">Archive all episodes</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.refreshImage</attribute>
+        <attribute name="label" translatable="yes">Refresh image</attribute>
+      </item>
+      <item>
+        <attribute name="action">win.removeChannel</attribute>
+        <attribute name="label" translatable="yes">Delete channel</attribute>
+        <attribute name="icon">edit-delete</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">win.editChannel</attribute>
+        <attribute name="label" translatable="yes">Channel settings</attribute>
+        <attribute name="icon">document-properties</attribute>
+      </item>
+    </section>
+  </menu>
 </interface>
 <!-- :noTabs=true:tabSize=2:indentSize=2: -->

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -118,6 +118,7 @@ class gPodderApplication(Gtk.Application):
 
         builder = Gtk.Builder()
         builder.set_translation_domain(gpodder.textdomain)
+        self.builder = builder
 
         menu_filename = None
         for ui_folder in gpodder.ui_folders:

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -358,6 +358,26 @@ class TreeViewHelper(object):
             return (x, y, True)
         return position_func
 
+    @staticmethod
+    def get_selected_rectangle(treeview):
+        """
+        :return: Gdk.Rectangle to pass to Gtk.Popover.set_pointing_to()
+        It's used for instance when the popup trigger is the Menu key:
+        it will position the popover on top of the selected row even if the mouse is elsewhere
+        """
+
+        # If there's a selection, place the popup menu on top of
+        # the first-selected row (otherwise in the top left corner)
+        selection = treeview.get_selection()
+        model, paths = selection.get_selected_rows()
+        if paths:
+            path = paths[0]
+            area = treeview.get_cell_area(path, treeview.get_column(0))
+        else:
+            area = Gdk.Rectangle()  # x, y, width, height are all 0
+
+        return area
+
 
 class ExtensionMenuHelper(object):
     """A helper class to handle extension submenus"""

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -20,7 +20,7 @@
 import os
 import shutil
 
-from gi.repository import Gdk, Gtk
+from gi.repository import Gdk, Gio, Gtk
 
 import gpodder
 from gpodder import util
@@ -357,3 +357,42 @@ class TreeViewHelper(object):
 
             return (x, y, True)
         return position_func
+
+
+class ExtensionMenuHelper(object):
+    """A helper class to handle extension submenus"""
+
+    def __init__(self, gpodder, menu, action_prefix, gen_callback_func=None):
+        self.gPodder = gpodder
+        self.menu = menu
+        self.action_prefix = action_prefix
+        self.gen_callback_func = gen_callback_func
+        self.actions = []
+
+    def replace_entries(self, new_entries):
+        # remove previous menu entries
+        for a in self.actions:
+            self.gPodder.remove_action(a.get_property('name'))
+        self.actions = []
+        self.menu.remove_all()
+        # create new ones
+        new_entries = list(new_entries or [])
+        for i, (label, callback) in enumerate(new_entries):
+            action_id = self.action_prefix + str(i)
+            action = Gio.SimpleAction.new(action_id)
+            action.set_enabled(callback is not None)
+            if callback is not None:
+                if self.gen_callback_func is None:
+                    action.connect('activate', callback)
+                else:
+                    action.connect('activate', self.gen_callback_func(callback))
+            self.actions.append(action)
+            self.gPodder.add_action(action)
+            itm = Gio.MenuItem.new(label, 'win.' + action_id)
+            self.menu.append_item(itm)
+
+
+class Dummy:
+    """A class for objects with arbitrary attributes (for imitating Gtk Events etc.)"""
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -679,6 +679,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         return self.treeview_channels_show_context_menu(treeview, event)
 
+    def on_treeview_podcasts_long_press(self, gesture, x, y, treeview):
+        ev = Dummy(x=x, y=y, button=3)
+        return self.treeview_channels_show_context_menu(treeview, ev)
+
     def on_treeview_episodes_button_released(self, treeview, event):
         if event.window != treeview.get_bin_window():
             return False
@@ -729,6 +733,12 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         # When no podcast is selected, clear the episode list model
         selection = self.treeChannels.get_selection()
+
+        # Long press gesture
+        lp = Gtk.GestureLongPress.new(self.treeChannels)
+        lp.set_touch_only(True)
+        lp.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        lp.connect("pressed", self.on_treeview_podcasts_long_press, self.treeChannels)
 
         # Set up type-ahead find for the podcast list
         def on_key_press(treeview, event):


### PR DESCRIPTION
A remix of / alternative to #1293. Add action definitions for context menu items and create context menus (just for channels, for now) from `menus.ui`.