### PR TITLE
Wait for worker threads to finish before quitting.

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -471,6 +471,9 @@ class DownloadQueueManager(object):
         self.tasks.queue_task(task)
         self.__spawn_threads()
 
+    def has_workers(self):
+        return len(self.worker_threads) > 0
+
 
 class DownloadTask(object):
     """An object representing the download task of an episode

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2919,7 +2919,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Notify all tasks to to carry out any clean-up actions
         self.download_status_model.tell_all_tasks_to_quit()
 
-        while Gtk.events_pending():
+        while Gtk.events_pending() or self.download_queue_manager.has_workers():
             Gtk.main_iteration()
 
         self.core.shutdown()


### PR DESCRIPTION
Closing gpodder while tasks are downloading or pausing causes a hang and must be killed from task manager or interrupted if launched from command line. This was introduced in ed5d18e1b04f5e32b18d90b3da151a57ae507571 but only applicable when using python 3.10. The idle_add() callback is no longer invoked to wake up the dequeue wait_for() condition, likely due to the main thread terminating early, which didn't happen in older python versions. Simply waiting for all worker threads to terminate fixes the issue.

Fixes #1306.