### PR TITLE
Remove border around extensions list in preferences.

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1138,9 +1138,9 @@
                           <object class="GtkBox" id="vbox_extensions">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="border-width">12</property>
+                            <property name="border-width">0</property>
                             <property name="orientation">vertical</property>
-                            <property name="spacing">12</property>
+                            <property name="spacing">0</property>
                             <child>
                               <object class="GtkTreeView" id="treeviewExtensions">
                                 <property name="visible">True</property>


### PR DESCRIPTION
This looks better and provides more space for descriptions on narrow windows.