### PR TITLE
util.open_website: Return True to block 'activate-link' default handler

### DIFF
--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1521,6 +1521,7 @@ def open_website(url):
     make sure your system is set up correctly.
     """
     run_in_background(lambda: webbrowser.open(url))
+    return True
 
 
 def copy_text_to_clipboard(text):


### PR DESCRIPTION
Clicking a web link on a GtkLabel (there is one at least in Preferences->youtube-dl) opens the web page twice, from util.open_website and from GtKLabels 'activate-link' default handler.

Return True from util.open_website, so that the default handler will not be run.