### PR TITLE
libgpod_ctypes: Use ctypes.c_time_t on Python 3.12

### DIFF
--- a/src/gpodder/libgpod_ctypes.py
+++ b/src/gpodder/libgpod_ctypes.py
@@ -57,16 +57,21 @@ libglib.g_strdup.restype = ctypes.c_void_p
 libglib.g_free.argtypes = (ctypes.c_void_p,)
 libglib.g_free.restype = None
 
-# See also: https://github.com/python/cpython/issues/92869
-if ctypes.sizeof(ctypes.c_void_p) == ctypes.sizeof(ctypes.c_int64):
-    time_t = ctypes.c_int64
+# ctypes.c_time_t will be available in Python 3.12 onwards
+# See also: https://github.com/python/cpython/pull/92870
+if hasattr(ctypes, 'c_time_t'):
+    time_t = ctypes.c_time_t
 else:
-    # On 32-bit systems, time_t is historically 32-bit, but due to Y2K38
-    # there have been efforts to establish 64-bit time_t on 32-bit Linux:
-    # https://linux.slashdot.org/story/20/02/15/0247201/linux-is-ready-for-the-end-of-time
-    # https://www.gnu.org/software/libc/manual/html_node/64_002dbit-time-symbol-handling.html
-    logger.info('libgpod may cause issues if time_t is 64-bit on your 32-bit system.')
-    time_t = ctypes.c_int32
+    # See also: https://github.com/python/cpython/issues/92869
+    if ctypes.sizeof(ctypes.c_void_p) == ctypes.sizeof(ctypes.c_int64):
+        time_t = ctypes.c_int64
+    else:
+        # On 32-bit systems, time_t is historically 32-bit, but due to Y2K38
+        # there have been efforts to establish 64-bit time_t on 32-bit Linux:
+        # https://linux.slashdot.org/story/20/02/15/0247201/linux-is-ready-for-the-end-of-time
+        # https://www.gnu.org/software/libc/manual/html_node/64_002dbit-time-symbol-handling.html
+        logger.info('libgpod may cause issues if time_t is 64-bit on your 32-bit system.')
+        time_t = ctypes.c_int32
 
 
 # glib/glist.h: struct _GList


### PR DESCRIPTION
On top of #1289, the PR that adds `c_time_t` has been merged to CPython and should become available in 3.12.