### PR TITLE
sync.py: Don't print traceback on missing libgpod_ctypes and eyed3.mp3

### DIFF
--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -50,7 +50,7 @@ gpod_available = True
 try:
     from gpodder import libgpod_ctypes
 except:
-    logger.info('iPod sync not available', exc_info=True)
+    logger.info('iPod sync not available')
     gpod_available = False
 
 mplayer_available = True if util.find_command('mplayer') is not None else False
@@ -59,7 +59,7 @@ eyed3mp3_available = True
 try:
     import eyed3.mp3
 except:
-    logger.info('eyeD3 MP3 not available', exc_info=True)
+    logger.info('eyeD3 MP3 not available')
     eyed3mp3_available = False
 
 


### PR DESCRIPTION
Current master prints rather excessive log output with the `-v` option from `sync.py` if libgpod_ctypes and eyed3 are not installed:

```
1657639825.704173 [gpodder.sync] INFO: iPod sync not available
Traceback (most recent call last):
  File "/home/tpikonen/src/gpodder/master-worktree/src/gpodder/sync.py", line 51, in <module>
    from gpodder import libgpod_ctypes
  File "/home/tpikonen/src/gpodder/master-worktree/src/gpodder/libgpod_ctypes.py", line 37, in <module>
    libgpod = ctypes.CDLL('libgpod.so.4')
  File "/usr/lib/python3.10/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: libgpod.so.4: cannot open shared object file: No such file or directory
1657639825.705882 [gpodder.sync] INFO: eyeD3 MP3 not available
Traceback (most recent call last):
  File "/home/tpikonen/src/gpodder/master-worktree/src/gpodder/sync.py", line 60, in <module>
    import eyed3.mp3
ModuleNotFoundError: No module named 'eyed3'
``` 

Remove the printing of exception info from these log messages, so the output reduces to:

```
1657640118.353999 [gpodder.sync] INFO: iPod sync not available
1657640118.354441 [gpodder.sync] INFO: eyeD3 MP3 not available
```
