### PR TITLE
preferences: Show extension context menu on row-activation

### DIFF
--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -388,6 +388,15 @@ class gPodderPreferences(BuilderWidget):
         extension_column.set_expand(True)
         self.treeviewExtensions.append_column(extension_column)
 
+        def activate_to_context_menu(treeview, path, column):
+            if column == extension_column:
+                self.on_treeview_extension_show_context_menu(treeview)
+            else:
+                return
+
+        self.treeviewExtensions.connect('row-activated',
+            activate_to_context_menu)
+
         self.extensions_model = Gtk.ListStore(bool, str, object, bool)
 
         def key_func(pair):

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -397,6 +397,13 @@ class gPodderPreferences(BuilderWidget):
         self.treeviewExtensions.connect('row-activated',
             activate_to_context_menu)
 
+        lp = Gtk.GestureLongPress.new(self.treeviewExtensions)
+        lp.set_touch_only(True)
+        lp.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+        lp.connect("pressed", self.on_treeview_extension_long_press,
+            self.treeviewExtensions)
+        setattr(self.treeviewExtensions, "long-press-gesture", lp)
+
         self.extensions_model = Gtk.ListStore(bool, str, object, bool)
 
         def key_func(pair):
@@ -431,6 +438,9 @@ class gPodderPreferences(BuilderWidget):
             return self.on_treeview_extension_show_context_menu(treeview, event)
 
         return False
+
+    def on_treeview_extension_long_press(self, gesture, x, y, treeview):
+        return self.on_treeview_extension_show_context_menu(treeview)
 
     def on_treeview_extension_show_context_menu(self, treeview, event=None):
         selection = treeview.get_selection()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -361,7 +361,7 @@ class gPodderPreferences(BuilderWidget):
         toggle_column.pack_start(toggle_cell, True)
         toggle_column.add_attribute(toggle_cell, 'active', self.C_TOGGLE)
         toggle_column.add_attribute(toggle_cell, 'visible', self.C_SHOW_TOGGLE)
-        toggle_column.set_property('min-width', 32)
+        toggle_column.set_property('min-width', 48)
         self.treeviewExtensions.append_column(toggle_column)
 
         name_cell = Gtk.CellRendererText()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -21,7 +21,7 @@ import html
 import logging
 import urllib.parse
 
-from gi.repository import Gdk, Gtk, Pango
+from gi.repository import Gdk, Gio, Gtk, Pango
 
 import gpodder
 from gpodder import util, vimeo, youtube
@@ -352,6 +352,22 @@ class gPodderPreferences(BuilderWidget):
             return True
         self.treeviewExtensions.set_search_equal_func(search_equal_func)
 
+        ag = Gio.SimpleActionGroup()
+        ag.add_action(Gio.SimpleAction.new('doc'))
+        ag.add_action(Gio.SimpleAction.new('info'))
+        ag.add_action(Gio.SimpleAction.new('payment'))
+        self.treeviewExtensions.insert_action_group('exts', ag)
+        self.extensions_context_actions = ag
+
+        self.extensions_context_cbids = {k: None for k in ('doc', 'info', 'payment')}
+
+        mm = Gio.Menu()
+        mm.append_item(Gio.MenuItem.new(_('Documentation'), 'exts.doc'))
+        mm.append_item(Gio.MenuItem.new(_('Extension info'), 'exts.info'))
+        mm.append_item(Gio.MenuItem.new(_('Support the author'), 'exts.payment'))
+        self.extensions_context_menu = Gtk.Popover.new_from_model(
+            self.treeviewExtensions, mm)
+
         selection = self.treeviewExtensions.get_selection()
         selection.set_select_function(self._extensions_select_function)
 
@@ -415,29 +431,41 @@ class gPodderPreferences(BuilderWidget):
         if not container:
             return
 
-        menu = Gtk.Menu()
+        ag = self.extensions_context_actions
+        ids = self.extensions_context_cbids
+
+        # disconnect old callbacks
+        for name in ids:
+            action = ag.lookup_action(name)
+            action.set_enabled(False)
+            if ids[name] is not None:
+                action.disconnect(ids[name])
+                ids[name] = None
+
+        def connect_action_cb(name, callback):
+            action = ag.lookup_action(name)
+            ids[name] = action.connect('activate', callback)
+            action.set_enabled(True)
 
         if container.metadata.doc:
-            menu_item = Gtk.MenuItem(_('Documentation'))
-            menu_item.connect('activate', self.open_weblink,
-                container.metadata.doc)
-            menu.append(menu_item)
+            connect_action_cb("doc",
+                lambda a, p: util.open_website(container.metadata.doc))
 
-        menu_item = Gtk.MenuItem(_('Extension info'))
-        menu_item.connect('activate', self.show_extension_info, model, container)
-        menu.append(menu_item)
+        connect_action_cb("info",
+            lambda a, p: self.show_extension_info(None, model, container))
 
         if container.metadata.payment:
-            menu_item = Gtk.MenuItem(_('Support the author'))
-            menu_item.connect('activate', self.open_weblink, container.metadata.payment)
-            menu.append(menu_item)
+            connect_action_cb("payment",
+                lambda a, p: util.open_website(container.metadata.payment))
 
-        menu.show_all()
+        menu = self.extensions_context_menu
         if event is None:
-            func = TreeViewHelper.make_popup_position_func(treeview)
-            menu.popup(None, None, func, None, 3, Gtk.get_current_event_time())
+            rect = TreeViewHelper.get_popup_rectangle(treeview, column=1)
         else:
-            menu.popup(None, None, None, None, 3, Gtk.get_current_event_time())
+            rect = Gdk.Rectangle()
+            rect.x, rect.y = event.x, event.y
+        menu.set_pointing_to(rect)
+        menu.popup()
 
         return True
 
@@ -482,9 +510,6 @@ class gPodderPreferences(BuilderWidget):
                          if key not in ('title', 'description'))
 
         self.show_message_details(container.metadata.title, container.metadata.description, info)
-
-    def open_weblink(self, w, url):
-        util.open_website(url)
 
     def on_dialog_destroy(self, widget):
         # Re-enable mygpo sync if the user has selected it

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -346,3 +346,23 @@ class TreeViewHelper(object):
 
             return (x, y, True)
         return position_func
+
+    @staticmethod
+    def get_popup_rectangle(treeview, column=0):
+        """
+        :return: Gdk.Rectangle to pass to Gtk.Popover.set_pointing_to()
+        It's used for instance when the popup trigger is the Menu key:
+        it will position the popover on top of the selected row even if the mouse is elsewhere
+        """
+
+        # If there's a selection, place the popup menu on top of
+        # the first-selected row (otherwise in the top left corner)
+        selection = treeview.get_selection()
+        model, paths = selection.get_selected_rows()
+        if paths:
+            path = paths[0]
+            area = treeview.get_cell_area(path, treeview.get_column(column))
+        else:
+            area = Gdk.Rectangle()  # x, y, width, height are all 0
+
+        return area


### PR DESCRIPTION
Change the 'Extensions' page context menu to a GtkPopover and make it pop-up when the `row-activation` signal of the Treeview is emitted (double click, return-key press), on long-press gesture and on right mouse click.

Also widen the toggles on the rows to make them more mobile friendly.

Possibly fixes #1329. A button popping up the context menu would be perhaps better, but there is no CellRenderer for that.