### PR TITLE
Don't try to download media files with youtube-dl extension

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -426,6 +426,8 @@ class gPodderYoutubeDL(download.CustomDownloader):
         """
         if not self.force and not self.my_config.manage_downloads:
             return None
+        if episode.mime_type.startswith(('audio/', 'video/')):
+            return None
         if self.is_supported_url(episode.url):
             return YoutubeCustomDownload(self, episode.url, episode)
 


### PR DESCRIPTION
gPodder calls `registry.custom_downloader.resolve` for every episode/URL when a download is attempted. Some episode URLs which youtube-dl / yt-dlp claims to support are direct media links, and at least yt-dlp is buggy so that it does not in fact download anything when given such an URL. At least spreaker.com (bug #1263) and audioboom.com fail this way.

Change the youtube-dl extension so that it does not support episodes where the MIME type is `audio/*` or `video/*`. These episodes are then downloaded with the default downloader.

Fixes #1263.