### PR TITLE
Fix hang when resuming thousands of episodes.

### DIFF
--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -193,7 +193,10 @@ class DownloadStatusModel(Gtk.ListStore):
     # as only the main thread is allowed to manipulate the list store.
     def get_next(self):
         dqr = DequeueRequest()
-        util.idle_add(self.__get_next, dqr)
+        # this can not be idle_add because update_downloads_list() is called from a higher
+        # priority timeout_add and would spin forever, never calling this.
+        from gi.repository import GLib
+        GLib.timeout_add(0, self.__get_next, dqr)
         return dqr.dequeue()
 
     def _work_gen(self):


### PR DESCRIPTION
When the number of episodes causes update_downloads_list() to exceed 1.5 seconds, the idle_add callback will never be called and cause gpodder to hang.

Fixes #1311.