### PR TITLE
Keep 'find partial downloads' dialog open longer.

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -420,9 +420,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 logger.debug("find_partial_downloads done, calling extensions")
                 gpodder.user_extensions.on_find_partial_downloads_done()
 
-            if self.partial_downloads_indicator:
-                util.idle_add(self.partial_downloads_indicator.on_finished)
-                self.partial_downloads_indicator = None
+                if self.partial_downloads_indicator:
+                    util.idle_add(self.partial_downloads_indicator.on_finished)
+                    self.partial_downloads_indicator = None
             util.idle_add(offer_resuming)
 
         common.find_partial_downloads(self.channels,


### PR DESCRIPTION
It can take a while to populate the list when there are a lot of downloads to resume. This leaves the list empty and UI, including the `Resume All` button, unresponsive. Keeping the dialog open while Gtk populates the list prevents this from happening.