### PR TITLE
Replace SimpleMessageArea with GtkInfoBar when resuming

### DIFF
--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <!--*- mode: xml -*-->
 <interface>
   <requires lib="gtk+" version="3.16"/>
@@ -384,17 +384,85 @@
                   </packing>
                 </child>
                 <child>
-                  <!-- n-columns=1 n-rows=2 -->
-                  <object class="GtkGrid" id="vboxDownloadStatusWidgets">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="border-width">5</property>
                     <property name="orientation">vertical</property>
-                    <property name="row-spacing">5</property>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow1">
+                      <object class="GtkInfoBar" id="resume_all_infobar">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="message-type">question</property>
+                        <property name="show-close-button">True</property>
+                        <property name="revealed">False</property>
+                        <signal name="response" handler="on_resume_all_infobar_response" swapped="no"/>
+                        <child internal-child="action_area">
+                          <object class="GtkButtonBox">
+                            <property name="can-focus">False</property>
+                            <property name="spacing">6</property>
+                            <property name="layout-style">end</property>
+                            <child>
+                              <object class="GtkButton" id="resume_all_button">
+                                <property name="label" translatable="yes">Resume all</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child internal-child="content_area">
+                          <object class="GtkBox">
+                            <property name="can-focus">False</property>
+                            <property name="spacing">16</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Incomplete downloads from a previous session were found.</property>
+                                <property name="wrap">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <action-widgets>
+                          <action-widget response="-5">resume_all_button</action-widget>
+                        </action-widgets>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
+                        <property name="margin-top">5</property>
+                        <property name="margin-bottom">5</property>
                         <property name="vexpand">True</property>
                         <property name="shadow-type">in</property>
                         <child>
@@ -415,23 +483,26 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">0</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
-                      <!-- n-columns=3 n-rows=1 -->
-                      <object class="GtkGrid" id="hboxDownloadSettings">
+                      <object class="GtkBox">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="border-width">5</property>
-                        <property name="column-spacing">10</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
+                        <property name="margin-top">5</property>
+                        <property name="margin-bottom">10</property>
+                        <property name="spacing">5</property>
                         <child>
-                          <!-- n-columns=3 n-rows=1 -->
-                          <object class="GtkGrid" id="hboxDownloadLimit">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="column-spacing">5</property>
+                            <property name="margin-start">5</property>
+                            <property name="spacing">5</property>
                             <child>
                               <object class="GtkCheckButton" id="cbLimitDownloads">
                                 <property name="label" translatable="yes">Limit rate to</property>
@@ -442,22 +513,27 @@
                                 <signal name="toggled" handler="on_cbLimitDownloads_toggled" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="left-attach">0</property>
-                                <property name="top-attach">0</property>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spinLimitDownloads">
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
-                                <property name="invisible-char">●</property>
+                                <property name="caps-lock-warning">False</property>
+                                <property name="input-purpose">number</property>
                                 <property name="adjustment">adjustment1</property>
                                 <property name="climb-rate">1</property>
                                 <property name="digits">1</property>
+                                <property name="numeric">True</property>
+                                <property name="update-policy">if-valid</property>
                               </object>
                               <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">0</property>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
@@ -468,33 +544,23 @@
                                 <property name="xalign">0</property>
                               </object>
                               <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">0</property>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="DownloadSettingsSpacer">
+                          <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="hexpand">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <!-- n-columns=2 n-rows=1 -->
-                          <object class="GtkGrid" id="hboxDownloadRate">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="column-spacing">5</property>
+                            <property name="spacing">5</property>
                             <child>
                               <object class="GtkCheckButton" id="cbMaxDownloads">
                                 <property name="label" translatable="yes">Limit downloads to</property>
@@ -505,33 +571,42 @@
                                 <signal name="toggled" handler="on_cbMaxDownloads_toggled" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="left-attach">0</property>
-                                <property name="top-attach">0</property>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkSpinButton" id="spinMaxDownloads">
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
-                                <property name="invisible-char">●</property>
+                                <property name="caps-lock-warning">False</property>
+                                <property name="input-purpose">number</property>
                                 <property name="adjustment">adjustment2</property>
                                 <property name="climb-rate">1</property>
+                                <property name="snap-to-ticks">True</property>
+                                <property name="numeric">True</property>
+                                <property name="update-policy">if-valid</property>
                               </object>
                               <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">0</property>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">0</property>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack-type">end</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">1</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                   </object>

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -3664,10 +3664,6 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
     def on_wNotebook_switch_page(self, notebook, page, page_num):
         self.play_or_download(current_page=page_num)
-        if page_num == 0:
-            # The infobar in the downloads tab should be hidden
-            # when the user switches away from the downloads tab
-            self.resume_all_infobar.set_revealed(False)
 
     def on_treeChannels_row_activated(self, widget, path, *args):
         # double-click action of the podcast list or enter

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -56,7 +56,6 @@ from .interface.progress import ProgressIndicator
 from .interface.searchtree import SearchTree
 from .model import EpisodeListModel, PodcastChannelProxy, PodcastListModel
 from .services import CoverDownloader
-from .widgets import SimpleMessageArea
 
 import gi  # isort:skip
 gi.require_version('Gtk', '3.0')  # isort:skip
@@ -225,8 +224,6 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.feed_cache_update_cancelled = False
         self.update_podcast_list_model()
 
-        self.message_area = None
-
         self.partial_downloads_indicator = None
         util.run_in_background(self.find_partial_downloads)
 
@@ -380,6 +377,15 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 itm = Gio.MenuItem.new(label, 'win.' + action_id)
                 self.extensions_menu.append_item(itm)
 
+    def on_resume_all_infobar_response(self, infobar, response_id):
+        if response_id == Gtk.ResponseType.OK:
+            selection = self.treeDownloads.get_selection()
+            selection.select_all()
+            selected_tasks = self.downloads_list_get_selection()[0]
+            selection.unselect_all()
+            self._for_each_task_set_status(selected_tasks, download.DownloadTask.QUEUED)
+        self.resume_all_infobar.set_revealed(False)
+
     def find_partial_downloads(self):
         def start_progress_callback(count):
             if count:
@@ -404,23 +410,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             def offer_resuming():
                 if resumable_episodes:
                     self.download_episode_list_paused(resumable_episodes, hide_progress=True)
-
-                    def on_resume_all(button):
-                        selection = self.treeDownloads.get_selection()
-                        selection.select_all()
-                        selected_tasks, _, _, _, _, _ = self.downloads_list_get_selection()
-                        selection.unselect_all()
-                        self._for_each_task_set_status(selected_tasks, download.DownloadTask.QUEUED)
-                        self.message_area.hide()
-
-                    resume_all = Gtk.Button(_('Resume all'))
-                    resume_all.connect('clicked', on_resume_all)
-
-                    self.message_area = SimpleMessageArea(
-                            _('Incomplete downloads from a previous session were found.'),
-                            (resume_all,))
-                    self.vboxDownloadStatusWidgets.attach(self.message_area, 0, -1, 1, 1)
-                    self.message_area.show_all()
+                    self.resume_all_infobar.set_revealed(True)
                 else:
                     util.idle_add(self.wNotebook.set_current_page, 0)
                 logger.debug("find_partial_downloads done, calling extensions")
@@ -429,6 +419,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 if self.partial_downloads_indicator:
                     util.idle_add(self.partial_downloads_indicator.on_finished)
                     self.partial_downloads_indicator = None
+
             util.idle_add(offer_resuming)
 
         common.find_partial_downloads(self.channels,
@@ -3674,11 +3665,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def on_wNotebook_switch_page(self, notebook, page, page_num):
         self.play_or_download(current_page=page_num)
         if page_num == 0:
-            # The message area in the downloads tab should be hidden
+            # The infobar in the downloads tab should be hidden
             # when the user switches away from the downloads tab
-            if self.message_area is not None:
-                self.message_area.hide()
-                self.message_area = None
+            self.resume_all_infobar.set_revealed(False)
 
     def on_treeChannels_row_activated(self, widget, path, *args):
         # double-click action of the podcast list or enter

--- a/src/gpodder/gtkui/widgets.py
+++ b/src/gpodder/gtkui/widgets.py
@@ -28,69 +28,6 @@ import html
 from gi.repository import Gdk, GObject, Gtk, Pango
 
 
-class SimpleMessageArea(Gtk.HBox):
-    """A simple, yellow message area. Inspired by gedit.
-
-    Original C source code:
-    http://svn.gnome.org/viewvc/gedit/trunk/gedit/gedit-message-area.c
-    """
-    def __init__(self, message, buttons=()):
-        Gtk.HBox.__init__(self, spacing=6)
-        self.set_border_width(6)
-        self.__in_style_updated = False
-        self.connect('style-updated', self.__style_updated)
-        self.connect('draw', self.__on_draw)
-
-        self.__label = Gtk.Label()
-        self.__label.set_alignment(0.0, 0.5)
-        self.__label.set_line_wrap(False)
-        self.__label.set_ellipsize(Pango.EllipsizeMode.END)
-        self.__label.set_markup('<b>%s</b>' % html.escape(message))
-        self.pack_start(self.__label, True, True, 0)
-
-        hbox = Gtk.HBox()
-        for button in buttons:
-            hbox.pack_start(button, True, False, 0)
-        self.pack_start(hbox, False, False, 0)
-
-    def set_markup(self, markup, line_wrap=True, min_width=3, max_width=100):
-        # The longest line should determine the size of the label
-        width_chars = max(len(line) for line in markup.splitlines())
-
-        # Enforce upper and lower limits for the width
-        width_chars = max(min_width, min(max_width, width_chars))
-
-        self.__label.set_width_chars(width_chars)
-        self.__label.set_markup(markup)
-        self.__label.set_line_wrap(line_wrap)
-
-    def __style_updated(self, widget):
-        if self.__in_style_updated:
-            return
-
-        w = Gtk.Window(Gtk.WindowType.POPUP)
-        w.set_name('gtk-tooltip')
-        w.ensure_style()
-        style = w.get_style()
-
-        self.__in_style_set = True
-        self.set_style(style)
-        self.__label.set_style(style)
-        self.__in_style_set = False
-
-        w.destroy()
-
-        self.queue_draw()
-
-    def __on_draw(self, widget, cr):
-        style = widget.get_style()
-        x, rect = Gdk.cairo_get_clip_rectangle(cr)
-        Gtk.paint_flat_box(style, cr, Gtk.StateType.NORMAL,
-                Gtk.ShadowType.OUT, widget, "tooltip",
-                rect.x, rect.y, rect.width, rect.height)
-        return False
-
-
 class SpinningProgressIndicator(Gtk.Image):
     # Progress indicator loading inspired by glchess from gnome-games-clutter
     def __init__(self, size=32):


### PR DESCRIPTION
Removes the custom SimpleMessageArea widget in the Progress tab and replaces it with a standard GtkInfoBar. The functionality is identical, but I added a close button to the bar, so it can be dismissed immediately. The bar also disappears when changing to the first notebook tab, as before.

Also does some cleanups (change GtkGrid to GtkBox layouts) in the Download limits area.
