### PR TITLE
Revert "Don't try to download media files with youtube-dl extension"

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -428,8 +428,6 @@ class gPodderYoutubeDL(download.CustomDownloader):
         """
         if not self.force and not self.my_config.manage_downloads:
             return None
-        if episode.mime_type.startswith(('audio/', 'video/')):
-            return None
         if self.is_supported_url(episode.url):
             return YoutubeCustomDownload(self, episode.url, episode)
 


### PR DESCRIPTION
Reverts gpodder/gpodder#1347

Unfixes #1263.
Fixes #1364.
May fix unsupported DRM issue in #1311.