### PR TITLE
Fix yt-dlp output file name

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -717,6 +717,7 @@ class DownloadTask(object):
         self.speed = 0.0
         self.progress = 0.0
         self.error_message = None
+        self.custom_downloader = None
 
         # Have we already shown this task in a notification?
         self._notification_shown = False
@@ -898,6 +899,7 @@ class DownloadTask(object):
             else:
                 downloader = DefaultDownloader.custom_downloader(self._config, self.episode)
 
+            self.custom_downloader = downloader
             headers, real_url = downloader.retrieve_resume(self.tempname, self.status_updated)
 
             new_mimetype = headers.get('content-type', self.__episode.mime_type)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2003,7 +2003,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
             menu = Gtk.Menu()
 
-            (open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete, can_lock) = self.play_or_download()
+            (open_instead_of_play, can_play, can_preview, can_download, can_pause,
+             can_cancel, can_delete, can_lock) = self.play_or_download()
 
             if open_instead_of_play:
                 item = Gtk.ImageMenuItem(_('Open'))
@@ -2011,7 +2012,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             else:
                 if downloaded:
                     item = Gtk.ImageMenuItem(_('Play'))
-                elif downloading:
+                elif can_preview:
                     item = Gtk.ImageMenuItem(_('Preview'))
                 else:
                     item = Gtk.ImageMenuItem(_('Stream'))
@@ -2302,7 +2303,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         if current_page is None:
             current_page = self.wNotebook.get_current_page()
         if current_page == 0:
-            (open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete, can_lock) = (False,) * 7
+            (open_instead_of_play, can_play, can_preview, can_download,
+             can_pause, can_cancel, can_delete, can_lock) = (False,) * 8
 
             selection = self.treeAvailable.get_selection()
             if selection.count_selected_rows() > 0:
@@ -2322,6 +2324,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                     # Actions filter episodes using these methods.
                     open_instead_of_play = open_instead_of_play or episode.file_type() not in ('audio', 'video')
                     can_play = can_play or episode.can_play(self.config)
+                    can_preview = can_preview or episode.can_preview()
                     can_download = can_download or episode.can_download()
                     can_pause = can_pause or episode.can_pause()
                     can_cancel = can_cancel or episode.can_cancel()
@@ -2331,7 +2334,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.set_episode_actions(open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete, can_lock,
                                     selection.count_selected_rows() > 0)
 
-            return (open_instead_of_play, can_play, can_download, can_pause, can_cancel, can_delete, can_lock)
+            return (open_instead_of_play, can_play, can_preview, can_download,
+                    can_pause, can_cancel, can_delete, can_lock)
         else:
             (can_queue, can_pause, can_cancel, can_remove) = (False,) * 4
 
@@ -2358,7 +2362,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
             self.set_episode_actions(False, False, can_queue, can_pause, can_cancel, can_remove, False, False)
 
-            return (False, False, can_queue, can_pause, can_cancel, can_remove, False)
+            return (False, False, False, can_queue, can_pause, can_cancel,
+                    can_remove, False)
 
     def on_cbMaxDownloads_toggled(self, widget, *args):
         self.spinMaxDownloads.set_sensitive(self.cbMaxDownloads.get_active())

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1636,7 +1636,7 @@ def sanitize_filename_ext(filename, ext, max_length, max_length_with_ext):
     """
     sanitized_fn = sanitize_filename(filename, max_length)
     sanitized_ext = sanitize_filename(ext, max_length_with_ext - len(sanitized_fn))
-    return (sanitized_fn, "." + sanitized_ext)
+    return (sanitized_fn, ('.' + sanitized_ext) if sanitized_ext else '')
 
 
 def find_mount_point(directory):


### PR DESCRIPTION
Get the output file name from the yt-dlp result dict and rename the file to what is expected (`tempname`), if it is different.

Add the extension to the output template. This is needed to unbreak post-processing (like subtitle embedding). See yt-dlp issue 1844.

Set the 'paths' param in ydl to get all downloaded files to the correct location.

In addition, the first commit makes `util.sanitize_filename_ext()` to return a file name without an ending perdiod, if ext is empty.
