### PR TITLE
Don't try to download media files with youtube-dl extension

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -428,6 +428,14 @@ class gPodderYoutubeDL(download.CustomDownloader):
         """
         if not self.force and not self.my_config.manage_downloads:
             return None
+
+        try:  # Reject URLs linking to known media files
+            (_, ext) = util.filename_from_url(episode.url)
+            if util.file_type_by_extension(ext) is not None:
+                return None
+        except Exception:
+            pass
+
         if self.is_supported_url(episode.url):
             return YoutubeCustomDownload(self, episode.url, episode)
 


### PR DESCRIPTION
Another try at detecting direct media file links fed to the youtube-dl extension. Uses functions from `util.py` to check if the link has something that looks like a file extension and whether it is from a known media file.

Fixes audioboom feeds with youtube-dl download enabled (#1263) and seems not to break anything else, although thorough testing before merging should be in order this time.