### PR TITLE
Update appdata.xml from the flatpak package

### DIFF
--- a/share/metainfo/org.gpodder.gpodder.appdata.xml
+++ b/share/metainfo/org.gpodder.gpodder.appdata.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- :indentSize=4:noTabs=true:tabSize=4: -->
 <component type="desktop-application">
   <id>org.gpodder.gpodder</id>
   <metadata_license>CC0-1.0</metadata_license>
@@ -10,22 +9,75 @@
     <p>gPodder lets you manage your Podcast subscriptions, discover new content and download episodes to your devices.</p>
     <p>You can also take advantage of the service gpodder.net, which lets you sync subscriptions, playback progress and starred episodes.</p>
   </description>
-  <launchable type="desktop-id">gpodder.desktop</launchable>
+  <launchable type="desktop-id">org.gpodder.gpodder.desktop</launchable>
   <url type="homepage">https://www.gpodder.org</url>
   <provides>
     <binary>gpodder</binary>
     <id>gpodder.desktop</id>
   </provides>
-  <content_rating type="oars-1.0"/>
-  <screenshots>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+   <screenshots>
     <screenshot type="default">
       <caption>The main window</caption>
       <image>https://raw.githubusercontent.com/flathub/org.gpodder.gpodder/master/screenshot.png</image>
     </screenshot>
   </screenshots>
   <releases>
+    <release version="3.11.0" date="2022-07-30">
+      <description>
+        <p>This release contains a year's worth of improvements. Major changes:</p>
+        <ul>
+          <li>Warning: There is a database schema update (See "Moving to an older gPodder release" in the user manual at gpodder.github.io for how to rollback)</li>
+          <li>Numerous bug fixes</li>
+          <li>Performance improvements</li>
+          <li>A new preferences dialog</li>
+          <li>Support again syncing to mtp:// and iPod devices on Linux</li>
+        </ul>
+      </description>
+    </release>
+    <release version="3.10.21" date="2021-07-20"/>
+    <release version="3.10.20" date="2021-06-06"/>
+    <release version="3.10.19" date="2021-04-15"/>
+    <release version="3.10.17" date="2020-11-23"/>
+    <release version="3.10.13" date="2020-01-29"/>
+    <release version="3.10.12" date="2020-01-25"/>
+    <release version="3.10.11" date="2019-09-29"/>
+    <release version="3.10.10" date="2019-09-27"/>
+    <release version="3.10.9" date="2019-06-09"/>
+    <release version="3.10.8" date="2019-04-08"/>
+    <release version="3.10.7" date="2019-02-02"/>
     <release version="3.10.5" date="2018-09-15">
-        <description>This is a bugfix release, shortly after 3.10.4, for the Rename after Download extension.</description>
+      <description>
+        <p>This is a bugfix release, shortly after 3.10.4, for the Rename after Download extension.</p>
+      </description>
     </release>
     <release version="3.10.4" date="2018-09-09"/>
     <release version="3.10.3" date="2018-06-14"/>

--- a/share/metainfo/org.gpodder.gpodder.appdata.xml
+++ b/share/metainfo/org.gpodder.gpodder.appdata.xml
@@ -74,6 +74,7 @@
     <release version="3.10.9" date="2019-06-09"/>
     <release version="3.10.8" date="2019-04-08"/>
     <release version="3.10.7" date="2019-02-02"/>
+    <release version="3.10.6" date="2018-12-29">
     <release version="3.10.5" date="2018-09-15">
       <description>
         <p>This is a bugfix release, shortly after 3.10.4, for the Rename after Download extension.</p>
@@ -81,5 +82,8 @@
     </release>
     <release version="3.10.4" date="2018-09-09"/>
     <release version="3.10.3" date="2018-06-14"/>
+    <release version="3.10.2" date="2018-06-10"/>
+    <release version="3.10.1" date="2018-02-19"/>
+    <release version="3.10.0" date="2017-12-29"/>
   </releases>
 </component>


### PR DESCRIPTION
The appdata.xml in the flathub flatpak package has more recent updates than the version in this repository. Merge the changes from there and also add missing release dates starting from release 3.10.0.

Adding short release notes to this file should be made part of the release process, so that it's up-to-date in the release tarballs.