### PR TITLE
Fix the format_time() function to display times greater than 24 hours.

### DIFF
--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1386,7 +1386,7 @@ def bluetooth_send_file(filename):
         return False
 
 
-def format_time(value):
+def format_time(seconds):
     """Format a seconds value to a string
 
     >>> format_time(0)
@@ -1397,12 +1397,22 @@ def format_time(value):
     '01:00:00'
     >>> format_time(10921)
     '03:02:01'
+    >>> format_time(86401)
+    '24:00:01'
     """
-    dt = datetime.datetime.utcfromtimestamp(value)
-    if dt.hour == 0:
-        return dt.strftime('%M:%S')
+    hours = 0
+    minutes = 0
+    if seconds >= 3600:
+        hours = seconds // 3600
+        seconds -= hours * 3600
+    if seconds >= 60:
+        minutes = seconds // 60
+        seconds -= minutes * 60
+
+    if hours == 0:
+        return '%02d:%02d' % (minutes, seconds)
     else:
-        return dt.strftime('%H:%M:%S')
+        return '%02d:%02d:%02d' % (hours, minutes, seconds)
 
 
 def parse_time(value):


### PR DESCRIPTION
Using datetime converts the seconds value into date and time components. A value of 86400 generates a 00:00 time on the 2nd of January 1970.

The new code properly increments the hour field to 24 and beyond instead of wrapping around to zero. The left-most zero for hour or minute field is now dropped to make episode times easier to read.