### PR TITLE
Use symbolic toolbar icons.

### DIFF
--- a/share/gpodder/ui/gtk/gpodder.ui
+++ b/share/gpodder/ui/gtk/gpodder.ui
@@ -36,7 +36,7 @@
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Play</property>
-                <property name="icon-name">media-playback-start</property>
+                <property name="icon-name">media-playback-start-symbolic</property>
                 <signal name="clicked" handler="on_playback_selected_episodes" swapped="no"/>
               </object>
               <packing>
@@ -51,7 +51,7 @@
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Download</property>
-                <property name="icon-name">go-down</property>
+                <property name="icon-name">document-save-symbolic</property>
                 <signal name="clicked" handler="on_download_selected_episodes" swapped="no"/>
               </object>
               <packing>
@@ -66,7 +66,7 @@
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Pause</property>
-                <property name="icon-name">media-playback-pause</property>
+                <property name="icon-name">media-playback-pause-symbolic</property>
                 <signal name="clicked" handler="on_pause_selected_episodes" swapped="no"/>
               </object>
               <packing>
@@ -81,7 +81,7 @@
                 <property name="can-focus">False</property>
                 <property name="is-important">True</property>
                 <property name="label" translatable="yes">Cancel</property>
-                <property name="icon-name">process-stop</property>
+                <property name="icon-name">process-stop-symbolic</property>
                 <signal name="clicked" handler="on_item_cancel_download_activate" swapped="no"/>
               </object>
               <packing>
@@ -105,7 +105,7 @@
                 <property name="can-focus">False</property>
                 <property name="action-name">app.preferences</property>
                 <property name="label" translatable="yes">Preferences</property>
-                <property name="icon-name">preferences-desktop</property>
+                <property name="icon-name">preferences-other-symbolic</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -127,7 +127,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Quit</property>
-                <property name="icon-name">application-exit</property>
+                <property name="icon-name">application-exit-symbolic</property>
                 <signal name="clicked" handler="on_gPodder_delete_event" swapped="no"/>
               </object>
               <packing>

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2128,10 +2128,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         # play icon and label
         if open_instead_of_play or not is_episode_selected:
-            self.toolPlay.set_icon_name('document-open')
+            self.toolPlay.set_icon_name('document-open-symbolic')
             self.toolPlay.set_label(_('Open'))
         else:
-            self.toolPlay.set_icon_name('media-playback-start')
+            self.toolPlay.set_icon_name('media-playback-start-symbolic')
 
             downloaded = all(e.was_downloaded(and_exists=True) for e in episodes)
             downloading = any(e.downloading for e in episodes)


### PR DESCRIPTION
The preferences-desktop icon is not available for 64x64 and larger icon sizes, and gtk displays a missing icon instead of falling back to smaller icons. Switching to preferences-other-symbolic would fix the issue, but the other toolbar icons should probably be changed to symbolic to match.