### PR TITLE
Add flake8 config and fix some code style issues

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -1176,8 +1176,8 @@ class gPodderCli(object):
         defaults = defaults or ()
         minarg, maxarg = len(args) - len(defaults), len(args)
 
-        if (len(command_line) < minarg or
-                (len(command_line) > maxarg and varargs is None)):
+        if (len(command_line) < minarg
+                or (len(command_line) > maxarg and varargs is None)):
             self._error('Wrong argument count for %s.' % func.__name__)
             return False
 

--- a/bin/gpodder
+++ b/bin/gpodder
@@ -139,9 +139,9 @@ def main():
     from gpodder import log
     log.setup(options.verbose, options.quiet)
 
-    if (not (gpodder.ui.win32 or gpodder.ui.osx) and
-            os.environ.get('DISPLAY', '') == '' and
-            os.environ.get('WAYLAND_DISPLAY', '') == ''):
+    if (not (gpodder.ui.win32 or gpodder.ui.osx)
+            and os.environ.get('DISPLAY', '') == ''
+            and os.environ.get('WAYLAND_DISPLAY', '') == ''):
         logger.error('Cannot start gPodder: $DISPLAY or $WAYLAND_DISPLAY is not set.')
         sys.exit(1)
 

--- a/bin/gpodder
+++ b/bin/gpodder
@@ -39,7 +39,6 @@ logger = logging.getLogger(__name__)
 
 try:
     import dbus
-    from dbus.mainloop.glib import DBusGMainLoop
     have_dbus = True
 except ImportError:
     print("""

--- a/bin/gpodder-migrate2tres
+++ b/bin/gpodder-migrate2tres
@@ -26,7 +26,6 @@
 
 import configparser
 import os
-import re
 import shutil
 import sys
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,7 @@ max-line-length = 142
 [isort]
 known_third_party=dbus,gi,mutagen,cairo,requests,github3,jinja2,magic,youtube_dl,podcastparser,mygpoclient
 known_first_party=gpodder,soco
+
+[flake8]
+max-line-length = 142
+ignore = E126, E128, W503

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import glob
 import os
 import re
 import sys

--- a/share/gpodder/extensions/command_on_download.py
+++ b/share/gpodder/extensions/command_on_download.py
@@ -6,7 +6,6 @@
 import datetime
 import logging
 import os
-import subprocess
 
 import gpodder
 from gpodder import util

--- a/share/gpodder/extensions/concatenate_videos.py
+++ b/share/gpodder/extensions/concatenate_videos.py
@@ -5,7 +5,6 @@
 
 import logging
 import os
-import subprocess
 
 from gi.repository import Gtk
 

--- a/share/gpodder/extensions/enqueue_in_mediaplayer.py
+++ b/share/gpodder/extensions/enqueue_in_mediaplayer.py
@@ -5,7 +5,6 @@
 # Released under the same license terms as gPodder itself.
 import functools
 import logging
-import subprocess
 
 import gpodder
 from gpodder import util

--- a/share/gpodder/extensions/mpris-listener.py
+++ b/share/gpodder/extensions/mpris-listener.py
@@ -121,18 +121,18 @@ class CurrentTrackTracker(object):
             # If the position is being updated, and the current status was Playing
             # If the status *is* playing, and *was* playing, but the position
             # has changed discontinuously, notify a stop for the old position
-            if (cur['status'] == 'Playing' and
-                    ('status' not in kwargs or kwargs['status'] == 'Playing') and not
+            if (cur['status'] == 'Playing'
+                    and ('status' not in kwargs or kwargs['status'] == 'Playing') and not
                     subsecond_difference(cur['pos'], kwargs['pos'])):
-                logger.debug('notify Stopped: playback discontinuity:' +
-                             'calc: %r observed: %r', cur['pos'], kwargs['pos'])
+                logger.debug('notify Stopped: playback discontinuity:'
+                             + 'calc: %r observed: %r', cur['pos'], kwargs['pos'])
                 self.notify_stop()
 
-            if ((kwargs['pos']) <= 0 and
-                    self.pos is not None and
-                    self.length is not None and
-                    (self.length - USECS_IN_SEC) < self.pos and
-                    self.pos < (self.length + 2 * USECS_IN_SEC)):
+            if ((kwargs['pos']) <= 0
+                    and self.pos is not None
+                    and self.length is not None
+                    and (self.length - USECS_IN_SEC) < self.pos
+                    and self.pos < (self.length + 2 * USECS_IN_SEC)):
                 logger.debug('pos=0 end of stream (calculated pos: %f/%f [%f])',
                              self.pos / USECS_IN_SEC, self.length / USECS_IN_SEC,
                              (self.pos / USECS_IN_SEC) - (self.length / USECS_IN_SEC))
@@ -174,11 +174,11 @@ class CurrentTrackTracker(object):
         self.notify('Playing')
 
     def notify(self, status):
-        if (self.uri is None or
-                self.pos is None or
-                self.status is None or
-                self.length is None or
-                self.length <= 0):
+        if (self.uri is None
+                or self.pos is None
+                or self.status is None
+                or self.length is None
+                or self.length <= 0):
             return
         pos = self.pos // USECS_IN_SEC
         parsed_url = urllib.parse.urlparse(self.uri)

--- a/share/gpodder/extensions/notification-win32.py
+++ b/share/gpodder/extensions/notification-win32.py
@@ -44,11 +44,6 @@ import tempfile
 
 import gpodder
 
-import gi  # isort:skip
-gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import Gtk  # isort:skip
-
-
 logger = logging.getLogger(__name__)
 _ = gpodder.gettext
 

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -26,7 +26,6 @@ import base64
 import datetime
 import logging
 import mimetypes
-import os
 
 from mutagen import File
 from mutagen.easyid3 import EasyID3

--- a/share/gpodder/extensions/taskbar_progress.py
+++ b/share/gpodder/extensions/taskbar_progress.py
@@ -32,6 +32,7 @@ from comtypes import COMMETHOD, GUID, IUnknown, client, wireHWND
 import gpodder
 
 import gi  # isort:skip
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk  # isort:skip
 
 

--- a/share/gpodder/extensions/ted_subtitles.py
+++ b/share/gpodder/extensions/ted_subtitles.py
@@ -48,8 +48,8 @@ class gPodderExtension(object):
         srtContent = ''
         for captionIndex, caption in enumerate(jsonobject['captions'], 1):
             startTime = self.milli_to_srt(introduration + caption['startTime'])
-            endTime = self.milli_to_srt(introduration + caption['startTime'] +
-                                        caption['duration'])
+            endTime = self.milli_to_srt(introduration + caption['startTime']
+                                        + caption['duration'])
             srtContent += ''.join([str(captionIndex), os.linesep, startTime,
                                    ' --> ', endTime, os.linesep,
                                    caption['content'], os.linesep * 2])

--- a/share/gpodder/extensions/ubuntu_unity.py
+++ b/share/gpodder/extensions/ubuntu_unity.py
@@ -4,12 +4,8 @@
 # Thomas Perl <thp@gpodder.org>; 2012-02-06
 
 import logging
-import os
-import subprocess
-import sys
 
 import gpodder
-from gpodder import util
 
 import gi  # isort:skip
 gi.require_version('Unity', '7.0')  # isort:skip

--- a/share/gpodder/extensions/video_converter.py
+++ b/share/gpodder/extensions/video_converter.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 
 import gpodder
-from gpodder import util, youtube
+from gpodder import util
 
 logger = logging.getLogger(__name__)
 

--- a/src/gpodder/common.py
+++ b/src/gpodder/common.py
@@ -104,8 +104,8 @@ def get_expired_episodes(channels, config):
                 continue
 
             # Download strategy "Only keep latest"
-            if (channel.download_strategy == channel.STRATEGY_LATEST and
-                    index > 0):
+            if (channel.download_strategy == channel.STRATEGY_LATEST
+                    and index > 0):
                 logger.info('Removing episode (only keep latest strategy): %s',
                         episode.title)
                 yield episode

--- a/src/gpodder/dbsqlite.py
+++ b/src/gpodder/dbsqlite.py
@@ -25,8 +25,6 @@
 #
 
 import logging
-import re
-import sys
 import threading
 from sqlite3 import dbapi2 as sqlite
 

--- a/src/gpodder/directory.py
+++ b/src/gpodder/directory.py
@@ -23,8 +23,6 @@
 # Thomas Perl <thp@gpodder.org>; 2014-10-22
 #
 
-import json
-import os
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -25,15 +25,12 @@
 #  Based on libwget.py (2005-10-29)
 #
 
-import collections
-import email
 import glob
 import logging
 import mimetypes
 import os
 import os.path
 import shutil
-import socket
 import threading
 import time
 import urllib.error

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -333,11 +333,11 @@ class ExtensionManager(object):
             logger.debug('Found extension "%s" in %s', name, filename)
             config = getattr(core.config.extensions, name)
             container = ExtensionContainer(self, name, config, filename)
-            if (name in enabled_extensions or
-                    container.metadata.mandatory_in_current_ui):
+            if (name in enabled_extensions
+                    or container.metadata.mandatory_in_current_ui):
                 container.set_enabled(True)
-            if (name in enabled_extensions and
-                    container.metadata.disable_in_current_ui):
+            if (name in enabled_extensions
+                    and container.metadata.disable_in_current_ui):
                 container.set_enabled(False)
             self.containers.append(container)
 
@@ -390,9 +390,9 @@ class ExtensionManager(object):
     def get_extensions(self):
         """Get a list of all loaded extensions and their enabled flag"""
         return [c for c in self.containers
-            if c.metadata.available_for_current_ui and
-            not c.metadata.mandatory_in_current_ui and
-            not c.metadata.disable_in_current_ui]
+            if c.metadata.available_for_current_ui
+            and not c.metadata.mandatory_in_current_ui
+            and not c.metadata.disable_in_current_ui]
 
     # Define all known handler functions here, decorate them with the
     # "call_extension" decorator to forward all calls to extension scripts that have

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -32,15 +32,9 @@ For an example extension see share/gpodder/examples/extensions.py
 import functools
 import glob
 import imp
-import inspect
-import json
 import logging
 import os
 import re
-import shlex
-import subprocess
-import sys
-from datetime import datetime
 
 import gpodder
 from gpodder import util
@@ -414,7 +408,6 @@ class ExtensionManager(object):
         @param update_podcast_callback: Function to update a podcast feed
         @param download_episode_callback: Function to download an episode
         """
-        pass
 
     @call_extensions
     def on_podcast_subscribe(self, podcast):
@@ -422,7 +415,6 @@ class ExtensionManager(object):
 
         @param podcast: A gpodder.model.PodcastChannel instance
         """
-        pass
 
     @call_extensions
     def on_podcast_updated(self, podcast):
@@ -432,7 +424,6 @@ class ExtensionManager(object):
 
         @param podcast: A gpodder.model.PodcastChannel instance
         """
-        pass
 
     @call_extensions
     def on_podcast_update_failed(self, podcast, exception):
@@ -442,7 +433,6 @@ class ExtensionManager(object):
 
         @param exception: The reason.
         """
-        pass
 
     @call_extensions
     def on_podcast_save(self, podcast):
@@ -453,7 +443,6 @@ class ExtensionManager(object):
 
         @param podcast: A gpodder.model.PodcastChannel instance
         """
-        pass
 
     @call_extensions
     def on_podcast_delete(self, podcast):
@@ -461,7 +450,6 @@ class ExtensionManager(object):
 
         @param podcast: A gpodder.model.PodcastChannel instance
         """
-        pass
 
     @call_extensions
     def on_episode_playback(self, episode):
@@ -472,7 +460,6 @@ class ExtensionManager(object):
 
         @param episode: A gpodder.model.PodcastEpisode instance
         """
-        pass
 
     @call_extensions
     def on_episode_save(self, episode):
@@ -483,7 +470,6 @@ class ExtensionManager(object):
 
         @param episode: A gpodder.model.PodcastEpisode instance
         """
-        pass
 
     @call_extensions
     def on_episode_downloaded(self, episode):
@@ -493,13 +479,11 @@ class ExtensionManager(object):
 
         @param episode: A gpodder.model.PodcastEpisode instance
         """
-        pass
 
     @call_extensions
     def on_all_episodes_downloaded(self):
         """Called when all episodes has been downloaded
         """
-        pass
 
     @call_extensions
     def on_episode_synced(self, device, episode):
@@ -515,7 +499,6 @@ class ExtensionManager(object):
         @param device: A gpodder.sync.Device instance
         @param episode: A gpodder.model.PodcastEpisode instance
         """
-        pass
 
     @call_extensions
     def on_create_menu(self):
@@ -529,7 +512,6 @@ class ExtensionManager(object):
 
         [('Sync to Smartphone', lambda : ...)]
         """
-        pass
 
     @call_extensions
     def on_episodes_context_menu(self, episodes):
@@ -546,7 +528,6 @@ class ExtensionManager(object):
 
         @param episodes: A list of gpodder.model.PodcastEpisode instances
         """
-        pass
 
     @call_extensions
     def on_channel_context_menu(self, channel):
@@ -561,13 +542,11 @@ class ExtensionManager(object):
         [('Update channel', lambda channel: ...)]
         @param channel: A gpodder.model.PodcastChannel instance
         """
-        pass
 
     @call_extensions
     def on_episode_delete(self, episode, filename):
         """Called just before the episode's disk file is about to be
         deleted."""
-        pass
 
     @call_extensions
     def on_episode_removed_from_podcast(self, episode):
@@ -577,7 +556,6 @@ class ExtensionManager(object):
 
         @param podcast: A gpodder.model.PodcastChannel instance
         """
-        pass
 
     @call_extensions
     def on_notification_show(self, title, message):
@@ -586,7 +564,6 @@ class ExtensionManager(object):
         @param title: title of the notification
         @param message: message of the notification
         """
-        pass
 
     @call_extensions
     def on_download_progress(self, progress):
@@ -594,7 +571,6 @@ class ExtensionManager(object):
 
         @param progress: The current progress value (0..1)
         """
-        pass
 
     @call_extensions
     def on_ui_object_available(self, name, ui_object):
@@ -606,7 +582,6 @@ class ExtensionManager(object):
         @param name: The name/ID of the object
         @param ui_object: The object itself
         """
-        pass
 
     @call_extensions
     def on_application_started(self):
@@ -619,7 +594,6 @@ class ExtensionManager(object):
 
         It is called after on_ui_object_available and on_ui_initialized.
         """
-        pass
 
     @call_extensions
     def on_find_partial_downloads_done(self):
@@ -630,7 +604,6 @@ class ExtensionManager(object):
 
         It is called after on_application_started.
         """
-        pass
 
     @call_extensions
     def on_preferences(self):
@@ -644,7 +617,6 @@ class ExtensionManager(object):
 
         [('Tab name', lambda: ...)]
         """
-        pass
 
     @call_extensions
     def on_channel_settings(self, channel):
@@ -661,4 +633,3 @@ class ExtensionManager(object):
 
         @param channel: A gpodder.model.PodcastChannel instance
         """
-        pass

--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -27,8 +27,6 @@ import urllib.parse
 from html.parser import HTMLParser
 from io import BytesIO
 
-from requests.exceptions import RequestException
-
 from gpodder import util, youtube
 
 logger = logging.getLogger(__name__)

--- a/src/gpodder/gtkui/base.py
+++ b/src/gpodder/gtkui/base.py
@@ -22,7 +22,6 @@ Based on SimpleGladeApp.py Copyright (C) 2004 Sandino Flores Moreno
 
 import os
 import re
-import sys
 import tokenize
 
 from gi.repository import Gtk
@@ -103,7 +102,6 @@ class GtkBuilderWidget(object):
         Method called when the user interface is loaded and ready to be used.
         At this moment, the widgets are loaded and can be refered as self.widget_name
         """
-        pass
 
     def main(self):
         """
@@ -149,4 +147,3 @@ class GtkBuilderWidget(object):
         This method is called by the default implementation of run()
         after a program is finished by pressing Control-C.
         """
-        pass

--- a/src/gpodder/gtkui/desktop/exportlocal.py
+++ b/src/gpodder/gtkui/desktop/exportlocal.py
@@ -18,10 +18,7 @@
 #
 import os
 
-from gi.repository import Gtk, Pango
-
 import gpodder
-from gpodder import util
 from gpodder.gtkui.interface.common import BuilderWidget
 
 _ = gpodder.gettext

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -92,11 +92,11 @@ class OnSyncActionList(Gtk.ListStore):
 
     def get_index(self):
         for index, row in enumerate(self):
-            if (self._config.device_sync.after_sync.delete_episodes and
-                    row[self.C_ON_SYNC_DELETE]):
+            if (self._config.device_sync.after_sync.delete_episodes
+                    and row[self.C_ON_SYNC_DELETE]):
                 return index
-            if (self._config.device_sync.after_sync.mark_episodes_played and
-                    row[self.C_ON_SYNC_MARK_PLAYED] and not
+            if (self._config.device_sync.after_sync.mark_episodes_played
+                    and row[self.C_ON_SYNC_MARK_PLAYED] and not
                     self._config.device_sync.after_sync.delete_episodes):
                 return index
         return 0  # Some sane default

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -19,7 +19,6 @@
 
 import html
 import logging
-import urllib.parse
 
 from gi.repository import Gdk, Gtk, Pango
 

--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -169,7 +169,6 @@ class UserAppsReader(object):
 
         self.__has_read = True
         if gpodder.ui.win32:
-            import winreg
             for caption, types, hkey in WIN32_APP_REG_KEYS:
                 try:
                     cmdline = win32_read_registry_key(hkey)

--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -28,8 +28,6 @@ import math
 
 import cairo
 
-import gpodder
-
 import gi  # isort:skip
 gi.require_version('Gdk', '3.0')  # isort:skip
 gi.require_version('Gtk', '3.0')  # isort:skip

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -18,7 +18,6 @@
 #
 
 import os
-import shutil
 
 from gi.repository import Gdk, Gtk
 

--- a/src/gpodder/gtkui/interface/configeditor.py
+++ b/src/gpodder/gtkui/interface/configeditor.py
@@ -74,8 +74,8 @@ class gPodderConfigEditor(BuilderWidget):
             return True
         else:
             # either the variable name or its value
-            return (text in model.get_value(iter, 0).lower() or
-                    text in model.get_value(iter, 2).lower())
+            return (text in model.get_value(iter, 0).lower()
+                    or text in model.get_value(iter, 2).lower())
 
     def value_edited(self, renderer, path, new_text):
         model = self.configeditor.get_model()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -496,8 +496,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 # Assume the episode's total time for the action
                 total = episode.total_time
 
-            assert (episode.current_position_updated is None or
-                    now >= episode.current_position_updated)
+            assert (episode.current_position_updated is None
+                    or now >= episode.current_position_updated)
 
             episode.current_position = end
             episode.current_position_updated = now
@@ -649,8 +649,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 path, column, x, y = result
                 # The user clicked the icon if she clicked in the first column
                 # and the x position is in the area where the icon resides
-                if (x < self.EPISODE_LIST_ICON_WIDTH and
-                        column == treeview.get_columns()[0]):
+                if (x < self.EPISODE_LIST_ICON_WIDTH
+                        and column == treeview.get_columns()[0]):
                     model = treeview.get_model()
                     cursor_episode = model.get_value(model.get_iter(path),
                             EpisodeListModel.C_EPISODE)
@@ -841,8 +841,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         # Initialize progress icons
         cake_size = cake_size_from_widget(self.treeAvailable)
         for i in range(EpisodeListModel.PROGRESS_STEPS + 1):
-            pixbuf = draw_cake_pixbuf(i /
-                   EpisodeListModel.PROGRESS_STEPS, size=cake_size)
+            pixbuf = draw_cake_pixbuf(
+                i / EpisodeListModel.PROGRESS_STEPS, size=cake_size)
             icon_name = 'gpodder-progress-%d' % i
             Gtk.IconTheme.add_builtin_icon(icon_name, cake_size, pixbuf)
 
@@ -1443,14 +1443,14 @@ class gPodder(BuilderWidget, dbus.service.Object):
         selection = treeview.get_selection()
         model, paths = selection.get_selected_rows()
 
-        if path is None or (path not in paths and
-                event.button == 3):
+        if path is None or (path not in paths
+                and event.button == 3):
             # We have right-clicked, but not into the selection,
             # assume we don't want to operate on the selection
             paths = []
 
-        if (path is not None and not paths and
-                event.button == 3):
+        if (path is not None and not paths
+                and event.button == 3):
             # No selection or clicked outside selection;
             # select the single item where we clicked
             treeview.grab_focus()
@@ -2440,8 +2440,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         else:
             list_model_length = len(self.podcast_list_model)
 
-        force_update = (sections_active != self.config.podcast_list_sections or
-                sections_changed)
+        force_update = (sections_active != self.config.podcast_list_sections
+                or sections_changed)
 
         # Filter items in the list model that are not podcasts, so we get the
         # correct podcast list count (ignore section headers and separators)
@@ -2914,8 +2914,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
                             count) % {'count': count}
                         self.show_message(title, _('New episodes available'))
                     else:
-                        if (show_new_episodes_dialog and
-                                self.config.auto_download == 'show'):
+                        if (show_new_episodes_dialog
+                                and self.config.auto_download == 'show'):
                             self.new_episodes_show(episodes, notification=True)
                         else:  # !show_new_episodes_dialog or auto_download == 'ignore'
                             message = N_('%(count)d new episode available',
@@ -3771,8 +3771,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
             GLib.source_remove(self._auto_update_timer_source_id)
             self._auto_update_timer_source_id = None
 
-        if (self.config.auto_update_feeds and
-                self.config.auto_update_frequency):
+        if (self.config.auto_update_feeds
+                and self.config.auto_update_frequency):
             interval = 60 * 1000 * self.config.auto_update_frequency
             logger.debug('Setting up auto update timer with interval %d.',
                     self.config.auto_update_frequency)
@@ -3922,8 +3922,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         try:
             file.mount_enclosing_volume_finish(res)
         except GLib.Error as err:
-            if (not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.NOT_SUPPORTED) and
-                    not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.ALREADY_MOUNTED)):
+            if (not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.NOT_SUPPORTED)
+                    and not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.ALREADY_MOUNTED)):
                 logger.error('mounting volume %s failed: %s' % (file.get_uri(), err.message))
                 result = False
         finally:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -34,8 +34,7 @@ import requests.exceptions
 import urllib3.exceptions
 
 import gpodder
-from gpodder import (common, download, extensions, feedcore, my, opml, player,
-                     util, youtube)
+from gpodder import common, download, feedcore, my, opml, player, util, youtube
 from gpodder.dbusproxy import DBusPodcastsProxy
 from gpodder.model import Model, PodcastEpisode
 from gpodder.syncui import gPodderSyncUI
@@ -59,7 +58,7 @@ from .services import CoverDownloader
 
 import gi  # isort:skip
 gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import Gdk, GdkPixbuf, Gio, GLib, Gtk, Pango  # isort:skip
+from gi.repository import Gdk, Gio, GLib, Gtk, Pango  # isort:skip
 
 
 logger = logging.getLogger(__name__)

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -64,8 +64,8 @@ class GEpisode(model.PodcastEpisode):
             length_str = '%s; ' % util.format_filesize(self.file_size)
         else:
             length_str = ''
-        return ('<b>%s</b>\n<small>%s' + _('released %s') +
-                '; ' + _('from %s') + '</small>') % (
+        return ('<b>%s</b>\n<small>%s' + _('released %s')
+                + '; ' + _('from %s') + '</small>') % (
                 html.escape(re.sub(r'\s+', ' ', self.title)),
                 html.escape(length_str),
                 html.escape(self.pubdate_prop),
@@ -82,8 +82,8 @@ class GEpisode(model.PodcastEpisode):
         downloaded_string = self.get_age_string()
         if not downloaded_string:
             downloaded_string = _('today')
-        return ('<b>%s</b>\n<small>%s; %s; ' + _('downloaded %s') +
-                '; ' + _('from %s') + '</small>') % (
+        return ('<b>%s</b>\n<small>%s; %s; ' + _('downloaded %s')
+                + '; ' + _('from %s') + '</small>') % (
                 html.escape(self.title),
                 html.escape(util.format_filesize(self.file_size)),
                 html.escape(played_string),
@@ -459,8 +459,8 @@ class EpisodeListModel(Gtk.ListStore):
                         tooltip.append(_('deletion prevented'))
 
                 if episode.total_time > 0 and episode.current_position:
-                    tooltip.append('%d%%' % (100. * float(episode.current_position) /
-                                             float(episode.total_time),))
+                    tooltip.append('%d%%' % (
+                        100. * float(episode.current_position) / float(episode.total_time)))
             elif episode._download_error is not None:
                 tooltip.append(_('ERROR: %s') % episode._download_error)
                 status_icon = self.ICON_ERROR

--- a/src/gpodder/gtkui/services.py
+++ b/src/gpodder/gtkui/services.py
@@ -25,7 +25,7 @@
 
 import logging
 
-from gi.repository import GdkPixbuf, Gtk
+from gi.repository import GdkPixbuf
 
 import gpodder
 from gpodder import coverart, util

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -18,7 +18,6 @@
 #
 import html
 import logging
-import re
 from urllib.parse import urlparse
 
 import gpodder

--- a/src/gpodder/gtkui/widgets.py
+++ b/src/gpodder/gtkui/widgets.py
@@ -23,9 +23,8 @@
 #  Thomas Perl <thp@gpodder.org> 2009-03-31
 #
 
-import html
 
-from gi.repository import Gdk, GObject, Gtk, Pango
+from gi.repository import Gtk
 
 
 class SpinningProgressIndicator(Gtk.Image):

--- a/src/gpodder/libgpod_ctypes.py
+++ b/src/gpodder/libgpod_ctypes.py
@@ -28,7 +28,6 @@
 import ctypes
 import logging
 import os
-import struct
 
 logger = logging.getLogger(__name__)
 

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -282,8 +282,8 @@ class PodcastEpisode(PodcastModelObject):
     is_locked = property(fget=_deprecated, fset=_deprecated)
 
     def has_website_link(self):
-        return bool(self.link) and (self.link != self.url or
-                youtube.is_video_link(self.link))
+        return bool(self.link) and (self.link != self.url
+                or youtube.is_video_link(self.link))
 
     @classmethod
     def from_podcastparser_entry(cls, entry, channel):
@@ -417,8 +417,8 @@ class PodcastEpisode(PodcastModelObject):
         # "Podcast Name - Title" and "Podcast Name: Title" -> "Title"
         for postfix in (' - ', ': '):
             prefix = self.parent.title + postfix
-            if (self.title.startswith(prefix) and
-                    len(self.title) - len(prefix) > LEFTOVER_MIN):
+            if (self.title.startswith(prefix)
+                    and len(self.title) - len(prefix) > LEFTOVER_MIN):
                 return self.title[len(prefix):]
 
         regex_patterns = [
@@ -437,14 +437,14 @@ class PodcastEpisode(PodcastModelObject):
 
         # "#001: Title" -> "001: Title"
         if (
-                not self.parent._common_prefix and
-                re.match(r'^#\d+: ', self.title) and
-                len(self.title) - 1 > LEFTOVER_MIN):
+                not self.parent._common_prefix
+                and re.match(r'^#\d+: ', self.title)
+                and len(self.title) - 1 > LEFTOVER_MIN):
             return self.title[1:]
 
-        if (self.parent._common_prefix is not None and
-                self.title.startswith(self.parent._common_prefix) and
-                len(self.title) - len(self.parent._common_prefix) > LEFTOVER_MIN):
+        if (self.parent._common_prefix is not None
+                and self.title.startswith(self.parent._common_prefix)
+                and len(self.title) - len(self.parent._common_prefix) > LEFTOVER_MIN):
             return self.title[len(self.parent._common_prefix):]
 
         return self.title
@@ -535,8 +535,8 @@ class PodcastEpisode(PodcastModelObject):
         return self.state != gpodder.STATE_DELETED or self.archive
 
     def check_is_new(self):
-        return (self.state == gpodder.STATE_NORMAL and self.is_new and
-                not self.downloading)
+        return (self.state == gpodder.STATE_NORMAL and self.is_new
+                and not self.downloading)
 
     def save(self):
         gpodder.user_extensions.on_episode_save(self)
@@ -642,8 +642,8 @@ class PodcastEpisode(PodcastModelObject):
         filename = filename.strip('.' + string.whitespace) + extension
 
         for name in util.generate_names(filename):
-            if (not self.db.episode_filename_exists(self.podcast_id, name) or
-                    self.download_filename == name):
+            if (not self.db.episode_filename_exists(self.podcast_id, name)
+                    or self.download_filename == name):
                 return name
 
     def local_filename(self, create, force_update=False, check_only=False,
@@ -706,9 +706,9 @@ class PodcastEpisode(PodcastModelObject):
                 episode_filename, _ = util.filename_from_url(url)
 
             # Use title for YouTube, Vimeo and Soundcloud downloads
-            if (youtube.is_video_link(self.url) or
-                    vimeo.is_video_link(self.url) or
-                    episode_filename == 'stream'):
+            if (youtube.is_video_link(self.url)
+                    or vimeo.is_video_link(self.url)
+                    or episode_filename == 'stream'):
                 episode_filename = self.title
 
             # If the basename is empty, use the md5 hexdigest of the URL
@@ -865,9 +865,10 @@ class PodcastEpisode(PodcastModelObject):
         current position is greater than 99 percent of the
         total time or inside the last 10 seconds of a track.
         """
-        return (self.current_position > 0 and self.total_time > 0 and
-                (self.current_position + 10 >= self.total_time or
-                 self.current_position >= self.total_time * .99))
+        return (self.current_position > 0
+                and self.total_time > 0
+                and (self.current_position + 10 >= self.total_time
+                or self.current_position >= self.total_time * .99))
 
     def get_play_info_string(self, duration_only=False):
         duration = util.format_time(self.total_time)
@@ -1016,8 +1017,8 @@ class PodcastChannel(PodcastModelObject):
         ignore_files = ['folder' + ext for ext in
                 coverart.CoverDownloader.EXTENSIONS]
 
-        external_files = existing_files.difference(list(known_files) +
-                [os.path.join(self.save_dir, ignore_file)
+        external_files = existing_files.difference(list(known_files)
+                + [os.path.join(self.save_dir, ignore_file)
                  for ignore_file in ignore_files])
         if not external_files:
             return
@@ -1228,8 +1229,8 @@ class PodcastChannel(PodcastModelObject):
                 real_new_episode_count += 1
 
             # Only allow a certain number of new episodes per update
-            if (self.download_strategy == PodcastChannel.STRATEGY_LATEST and
-                    real_new_episode_count > 1):
+            if (self.download_strategy == PodcastChannel.STRATEGY_LATEST
+                    and real_new_episode_count > 1):
                 episode.is_new = False
                 episode.save()
 
@@ -1243,8 +1244,8 @@ class PodcastChannel(PodcastModelObject):
         # Keep episodes that are currently being downloaded, though (bug 1534)
         if self.id is not None:
             episodes_to_purge = [e for e in existing if
-                    e.state != gpodder.STATE_DOWNLOADED and
-                    e.guid not in seen_guids and not e.downloading]
+                    e.state != gpodder.STATE_DOWNLOADED
+                    and e.guid not in seen_guids and not e.downloading]
 
             for episode in episodes_to_purge:
                 logger.debug('Episode removed from feed: %s (%s)',
@@ -1415,8 +1416,8 @@ class PodcastChannel(PodcastModelObject):
         download_folder = download_folder.strip('.' + string.whitespace)
 
         for folder_name in util.generate_names(download_folder):
-            if (not self.db.podcast_download_folder_exists(folder_name) or
-                    self.download_folder == folder_name):
+            if (not self.db.podcast_download_folder_exists(folder_name)
+                    or self.download_folder == folder_name):
                 return folder_name
 
     def get_save_dir(self, force_new=False):

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -24,7 +24,6 @@
 #  Based on libpodcasts.py (thp, 2005-10-29)
 #
 
-import collections
 import datetime
 import glob
 import hashlib

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -254,8 +254,8 @@ class MygPoClient(object):
                 logger.debug('Play action for %s', episode.url)
                 episode.mark(is_played=True)
 
-                if (action.timestamp > episode.current_position_updated and
-                        action.position is not None):
+                if (action.timestamp > episode.current_position_updated
+                        and action.position is not None):
                     logger.debug('Updating position for %s', episode.url)
                     episode.current_position = action.position
                     episode.current_position_updated = action.timestamp

--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -38,7 +38,6 @@ import io
 import logging
 import os
 import os.path
-import shutil
 import xml.dom.minidom
 from email.utils import formatdate
 

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -20,7 +20,6 @@
 # Soundcloud.com API client module for gPodder
 # Thomas Perl <thp@gpodder.org>; 2009-11-03
 
-import email
 import json
 import logging
 import os

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -221,8 +221,8 @@ class Device(services.ObservableService):
         for track in list(tracklist):
             # Filter tracks that are not meant to be synchronized
             does_not_exist = not track.was_downloaded(and_exists=True)
-            exclude_played = (not track.is_new and
-                    self._config.device_sync.skip_played_episodes)
+            exclude_played = (not track.is_new
+                    and self._config.device_sync.skip_played_episodes)
             wrong_type = track.file_type() not in self.allowed_types
 
             if does_not_exist:
@@ -347,8 +347,8 @@ class iPodDevice(Device):
 
     def episode_on_device(self, episode):
         return next((track for track in self.tracks_list
-                     if track.ipod_track.podcast_rss == episode.channel.url and
-                     track.ipod_track.podcast_url == episode.url), None)
+                     if track.ipod_track.podcast_rss == episode.channel.url
+                     and track.ipod_track.podcast_url == episode.url), None)
 
     def remove_track(self, track):
         self.notify('status', _('Removing %s') % track.title)
@@ -444,8 +444,8 @@ class MP3PlayerDevice(Device):
 
         try:
             info = self.destination.query_info(
-                Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE + "," +
-                Gio.FILE_ATTRIBUTE_STANDARD_TYPE,
+                Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE + ","
+                + Gio.FILE_ATTRIBUTE_STANDARD_TYPE,
                 Gio.FileQueryInfoFlags.NONE,
                 None)
         except GLib.Error as err:
@@ -460,8 +460,8 @@ class MP3PlayerDevice(Device):
         # open is ok if the target is a directory, and it can be written to
         # for smb, query_info doesn't return FILE_ATTRIBUTE_ACCESS_CAN_WRITE,
         # -- if that's the case, just assume that it's writable
-        if (not info.has_attribute(Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE) or
-                info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE)):
+        if (not info.has_attribute(Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE)
+                or info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE)):
             self.notify('status', _('MP3 player opened'))
             self.tracks_list = self.get_all_tracks()
             return True
@@ -558,10 +558,10 @@ class MP3PlayerDevice(Device):
         tracks = []
 
         attributes = (
-            Gio.FILE_ATTRIBUTE_STANDARD_NAME + "," +
-            Gio.FILE_ATTRIBUTE_STANDARD_TYPE + "," +
-            Gio.FILE_ATTRIBUTE_STANDARD_SIZE + "," +
-            Gio.FILE_ATTRIBUTE_TIME_MODIFIED)
+            Gio.FILE_ATTRIBUTE_STANDARD_NAME + ","
+            + Gio.FILE_ATTRIBUTE_STANDARD_TYPE + ","
+            + Gio.FILE_ATTRIBUTE_STANDARD_SIZE + ","
+            + Gio.FILE_ATTRIBUTE_TIME_MODIFIED)
 
         root_path = self.destination
         for path_info in root_path.enumerate_children(attributes, Gio.FileQueryInfoFlags.NONE, None):

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -23,15 +23,10 @@
 # based on libipodsync.py (2006-04-05 Thomas Perl)
 # Ported to gPodder 3 by Joseph Wickremasinghe in June 2012
 
-import calendar
-import glob
 import logging
 import os.path
 import threading
 import time
-from enum import Enum
-from re import S
-from urllib.parse import urlparse
 
 import gpodder
 from gpodder import download, services, util

--- a/src/gpodder/syncui.py
+++ b/src/gpodder/syncui.py
@@ -79,8 +79,8 @@ class gPodderSyncUI(object):
                 continue
 
             for episode in channel.get_all_episodes():
-                if (episode.was_downloaded(and_exists=True) or
-                        not only_downloaded):
+                if (episode.was_downloaded(and_exists=True)
+                        or not only_downloaded):
                     episodes.append(episode)
         return episodes
 
@@ -133,8 +133,8 @@ class gPodderSyncUI(object):
                     return False
 
                 # Might not be synced if it's played already
-                if (not force_played and
-                        self._config.device_sync.skip_played_episodes):
+                if (not force_played
+                        and self._config.device_sync.skip_played_episodes):
                     return False
 
                 # In all other cases, we expect the episode to be
@@ -316,9 +316,9 @@ class gPodderSyncUI(object):
         def cleanup_episodes():
             # 'skip_played_episodes' must be used or else all the
             # played tracks will be copied then immediately deleted
-            if (self._config.device_sync.delete_deleted_episodes or
-                (self._config.device_sync.delete_played_episodes and
-                 self._config.device_sync.skip_played_episodes)):
+            if (self._config.device_sync.delete_deleted_episodes
+                or (self._config.device_sync.delete_played_episodes
+                    and self._config.device_sync.skip_played_episodes)):
                 all_episodes = self._filter_sync_episodes(
                     channels, only_downloaded=False)
                 for local_episode in all_episodes:

--- a/src/gpodder/syncui.py
+++ b/src/gpodder/syncui.py
@@ -22,7 +22,6 @@
 # Ported to gPodder 3 by Joseph Wickremasinghe in June 2012
 
 import logging
-import os
 
 import gpodder
 from gpodder import sync, util

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -2350,8 +2350,8 @@ def mount_volume_for_file(file, op=None):
             file.mount_enclosing_volume_finish(res)
             result = True
         except GLib.Error as err:
-            if (not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.NOT_SUPPORTED) and
-                    not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.ALREADY_MOUNTED)):
+            if (not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.NOT_SUPPORTED)
+                    and not err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.ALREADY_MOUNTED)):
                 message = err.message
                 result = False
         finally:

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -33,11 +33,8 @@ import collections
 import datetime
 import email
 import glob
-import gzip
 import http.client
-import io
 import itertools
-import json
 import locale
 import logging
 import mimetypes
@@ -57,7 +54,6 @@ import time
 import urllib.error
 import urllib.parse
 import webbrowser
-import xml.dom.minidom
 from html.entities import entitydefs, name2codepoint
 from html.parser import HTMLParser
 
@@ -2373,7 +2369,6 @@ def mount_volume_for_file(file, op=None):
 
 
 def scale_pixbuf(pixbuf, max):
-    import gi
     from gi.repository import GdkPixbuf
 
     w_cur = pixbuf.get_width()

--- a/src/gpodder/utilwin32ctypes.py
+++ b/src/gpodder/utilwin32ctypes.py
@@ -20,7 +20,7 @@
 
 import ctypes
 from ctypes import HRESULT, Structure, byref, c_ulonglong
-from ctypes.wintypes import (BOOL, BYTE, DWORD, HANDLE, LPCWSTR, MAX_PATH,
+from ctypes.wintypes import (BOOL, BYTE, DWORD, HANDLE, LPCWSTR,
                              PULARGE_INTEGER, WORD)
 from uuid import UUID
 

--- a/src/gpodder/vimeo.py
+++ b/src/gpodder/vimeo.py
@@ -23,7 +23,6 @@
 #
 
 
-import json
 import logging
 import re
 

--- a/tests/model.py
+++ b/tests/model.py
@@ -23,7 +23,6 @@
 
 import unittest
 
-import gpodder
 from gpodder import model
 
 

--- a/tests/test_feedcore.py
+++ b/tests/test_feedcore.py
@@ -21,7 +21,7 @@ import io
 import pytest
 import requests.exceptions
 
-from gpodder.feedcore import Fetcher, Result, NEW_LOCATION, NOT_MODIFIED, UPDATED_FEED
+from gpodder.feedcore import Fetcher, NEW_LOCATION, Result, UPDATED_FEED
 
 
 class MyFetcher(Fetcher):

--- a/tools/create-desktop-icon.py
+++ b/tools/create-desktop-icon.py
@@ -5,7 +5,6 @@
 import os
 import sys
 
-import gi
 from gi.repository import GLib
 
 BASE = os.path.normpath(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tools/fake-dbus-module/dbus/__init__.py
+++ b/tools/fake-dbus-module/dbus/__init__.py
@@ -1,10 +1,9 @@
-import dbus.exceptions
+import dbus.exceptions  # noqa: F401
 
 
 class SessionBus(object):
     def __init__(self, *args, **kwargs):
         self.fake = True
-        pass
 
     def add_signal_receiver(self, *args, **kwargs):
         pass

--- a/tools/i18n/summary.py
+++ b/tools/i18n/summary.py
@@ -10,7 +10,6 @@ import math
 import os
 import re
 import subprocess
-import sys
 
 width = 40
 

--- a/tools/mac-osx/launcher.py
+++ b/tools/mac-osx/launcher.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import time
 import traceback
-from os.path import dirname, expanduser, join
+from os.path import join
 from subprocess import PIPE, CalledProcessError, Popen
 
 

--- a/tools/mac-osx/launcher.py
+++ b/tools/mac-osx/launcher.py
@@ -32,9 +32,9 @@ class MakeCertPem:
         """
         cmd = ["security", "find-certificate", "-a", "-p",
                "/System/Library/Keychains/SystemRootCertificates.keychain"]
-        cert_re = re.compile(b"^-----BEGIN CERTIFICATE-----$" +
-                             b".+?" +
-                             b"^-----END CERTIFICATE-----$", re.M | re.S)
+        cert_re = re.compile(b"^-----BEGIN CERTIFICATE-----$"
+                             + b".+?"
+                             + b"^-----END CERTIFICATE-----$", re.M | re.S)
         try:
             certs_str = subprocess.check_output(cmd)
             all_certs = cert_re.findall(certs_str)

--- a/tools/mac-osx/make_cert_pem.py
+++ b/tools/mac-osx/make_cert_pem.py
@@ -32,9 +32,9 @@ def get_certs(openssl):
 
     cmd = ["security", "find-certificate", "-a", "-p",
            "/System/Library/Keychains/SystemRootCertificates.keychain"]
-    cert_re = re.compile(b"^-----BEGIN CERTIFICATE-----$" +
-                         b".+?" +
-                         b"^-----END CERTIFICATE-----$", re.M | re.S)
+    cert_re = re.compile(b"^-----BEGIN CERTIFICATE-----$"
+                         + b".+?"
+                         + b"^-----END CERTIFICATE-----$", re.M | re.S)
     try:
         certs_str = subprocess.check_output(cmd)
         all_certs = cert_re.findall(certs_str)


### PR DESCRIPTION
I think it would be nice to have a stricter machine validated code style for gPodder (i.e. I started using autolinting on my editor and everything is red). This PR adds a flake8 config section to setup.cfg with ignores for some errors and warnings, and fixes (mostly automatically made) for some others.

There are still 157 flake8 errors in gPodder after the fixes and ignores, but it's a start. This is also probably really boring to review, but here goes.