### PR TITLE
Track_id and Season support, episode-specific covers, author tagging and genre / keyword tagging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ share/applications/gpodder.desktop
 share/dbus-1/services/org.gpodder.service
 share/locale/
 venv/*
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 ## Dependencies
 
 - [Python 3.5](http://python.org/) or newer
-- [Podcastparser](http://gpodder.org/podcastparser/) 0.6.0 or newer
+- [Podcastparser](http://gpodder.org/podcastparser/) 0.6.9 or newer
 - [mygpoclient](http://gpodder.org/mygpoclient/) 1.7 or newer
 - [requests](https://requests.readthedocs.io) 2.24.0 or newer
 - Python D-Bus bindings

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -124,6 +124,33 @@ class PodcastParserFeed(Feed):
 
     def get_payment_url(self):
         return self.feed.get('payment_url')
+    
+    def get_author(self):
+        return self.feed.get('itunes_author')
+
+    def get_keywords(self):
+        #convert all commas into " / "
+        keywords = self.feed.get('itunes_keywords')
+        if keywords is not None:
+            keywords = keywords.replace(", ", " / ")
+        return keywords
+
+    def get_categorys(self):
+        #its coming in as a list like this 
+        #'itunes_categories': [['Fiction', 'Comedy Fiction'], ['Leisure', 'Games']],
+        #however this doesnt work with the database as it expects a string
+        #convert it to a string, deliminated by " / "
+        categorys = self.feed.get('itunes_categories')
+
+        #flatten the list
+        new_list = []
+        for item in categorys:
+            new_list.extend(item)
+        categorys = new_list
+        
+        if categorys is not None:
+            categorys = " / ".join(categorys)
+        return categorys
 
     def get_http_etag(self):
         return self.feed.get('headers', {}).get('etag')
@@ -293,7 +320,7 @@ class PodcastEpisode(PodcastModelObject):
         episode.link = entry['link']
         episode.episode_art_url = entry.get('episode_art_url')
         if entry.get('description_html'):
-            episode.description = ''
+            episode.description = util.remove_html_tags(entry['description_html'])
             episode.description_html = entry['description_html']
         else:
             episode.description = util.remove_html_tags(entry['description'] or '')
@@ -305,6 +332,19 @@ class PodcastEpisode(PodcastModelObject):
         episode.chapters = None
         if entry.get("chapters"):
             episode.chapters = json.dumps(entry["chapters"])
+        
+        if entry.get('number'):
+            episode.episode_num = entry['number']
+        else:
+            episode.episode_num = 0
+
+        if entry.get('season'):
+            episode.season = entry['season']
+        else:
+            episode.season = 0
+        
+        if entry.get('itunes_author'):
+            episode.author = entry['itunes_author']
 
         audio_available = any(enclosure['mime_type'].startswith('audio/') for enclosure in entry['enclosures'])
         video_available = any(enclosure['mime_type'].startswith('video/') for enclosure in entry['enclosures'])
@@ -385,10 +425,13 @@ class PodcastEpisode(PodcastModelObject):
         self.description = ''
         self.description_html = ''
         self.chapters = None
+        self.episode_num = 0
+        self.season = 0
         self.link = ''
         self.published = 0
         self.download_filename = None
         self.payment_url = None
+        self.author = ''
 
         self.state = gpodder.STATE_NORMAL
         self.is_new = True
@@ -895,12 +938,24 @@ class PodcastEpisode(PodcastModelObject):
 
     def update_from(self, episode):
         for k in ('title', 'url', 'episode_art_url', 'description', 'description_html', 'chapters', 'link',
-                  'published', 'guid', 'payment_url'):
+                  'published', 'guid', 'payment_url', 'episode_num', 'season', 'author'):
             setattr(self, k, getattr(episode, k))
         # Don't overwrite file size on downloaded episodes
         # See #648 refreshing a youtube podcast clears downloaded file size
         if self.state != gpodder.STATE_DOWNLOADED:
             setattr(self, 'file_size', getattr(episode, 'file_size'))
+    
+    @property
+    def cover_file(self):
+        #check if there is an episode cover in the first place
+        if self.episode_art_url is None:
+            return None
+        #create a cover file name from the episode_art_url
+        cover_name = self.episode_art_url.split('/')[-1]
+        cover_name = cover_name.split('?')[0]
+        #remove .jpg or .png
+        cover_name = cover_name.split('.')[0]
+        return os.path.join(self.channel.save_dir, cover_name)
 
 
 class PodcastChannel(PodcastModelObject):
@@ -935,6 +990,9 @@ class PodcastChannel(PodcastModelObject):
         self.description = ''
         self.cover_url = None
         self.payment_url = None
+        self.author = None
+        self.keywords = None
+        self.categorys = None
 
         self.auth_username = ''
         self.auth_password = ''
@@ -1022,12 +1080,21 @@ class PodcastChannel(PodcastModelObject):
                 glob.glob(os.path.join(self.save_dir, '*'))
                 if not filename.endswith('.partial'))
 
-        ignore_files = ['folder' + ext for ext in
+        ignore_files = ['' + ext for ext in
                 coverart.CoverDownloader.EXTENSIONS]
 
         external_files = existing_files.difference(list(known_files)
                 + [os.path.join(self.save_dir, ignore_file)
                  for ignore_file in ignore_files])
+
+        #remove any existing files with .jpg or .png
+        to_keep = []
+        for filename in external_files:
+            if not filename.endswith('.jpg') and not filename.endswith('.png'):
+                to_keep.append(filename)
+        
+        external_files = to_keep
+        
         if not external_files:
             return
 
@@ -1156,12 +1223,15 @@ class PodcastChannel(PodcastModelObject):
             # End YouTube- and Vimeo-specific title FIX
 
     def _consume_metadata(self, title, link, description, cover_url,
-            payment_url):
+            payment_url, author, keywords, categorys):
         self._consume_updated_title(title)
         self.link = link
         self.description = description
         self.cover_url = cover_url
         self.payment_url = payment_url
+        self.author = author
+        self.keywords = keywords
+        self.categorys = categorys
         self.save()
 
     def _consume_updated_feed(self, feed, max_episodes=0):
@@ -1169,7 +1239,10 @@ class PodcastChannel(PodcastModelObject):
                                feed.get_link() or self.link,
                                feed.get_description() or '',
                                feed.get_cover_url() or None,
-                               feed.get_payment_url() or None)
+                               feed.get_payment_url() or None,
+                               feed.get_author() or None,
+                               feed.get_keywords() or None,
+                               feed.get_categorys() or None)
 
         # Update values for HTTP conditional requests
         self.http_etag = feed.get_http_etag() or self.http_etag

--- a/tools/mac-osx/release_on_mac.sh
+++ b/tools/mac-osx/release_on_mac.sh
@@ -67,7 +67,7 @@ cp -a "$checkout"/tools/mac-osx/make_cert_pem.py "$resources"/bin
 
 # install gPodder hard dependencies
 $run_pip install setuptools==64.0.3 wheel || exit 1
-$run_pip install mygpoclient==1.9 podcastparser==0.6.8 requests[socks]==2.28.1 || exit 1
+$run_pip install mygpoclient==1.9 podcastparser==0.6.9 requests[socks]==2.28.1 || exit 1
 # install brotli and pycryptodomex (build from source)
 $run_pip debug -v
 $run_pip install -v brotli || exit 1

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,7 +5,7 @@ dbus-python
 html5lib==1.1
 mutagen==1.45.1
 mygpoclient==1.9
-podcastparser==0.6.8
+podcastparser==0.6.9
 requests[socks]==2.28.1
 urllib3==1.26.10
 yt-dlp

--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -92,7 +92,7 @@ html5lib==1.1
 idna==3.3
 mutagen==1.45.1
 mygpoclient==1.9
-podcastparser==0.6.8
+podcastparser==0.6.9
 PySocks==1.7.1
 requests==2.28.1
 urllib3==1.26.10


### PR DESCRIPTION
This PR implements both the track number, and disc number metadata for the tagging extension to use

This allows the episode number to be the track number, and the season to be the disc number, allowing for external players to better sort podcasts in the right order. closes #1267, closes #1430. Subsequent [PR](https://github.com/gpodder/podcastparser/pull/38) in podcastparser must be accepted aswell for this to function properly

Involves a schema update