### PR TITLE
Optimize episode list

### DIFF
--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -146,8 +146,8 @@ class BackgroundUpdate(object):
             model.set(it, *(base_fields + update_fields))
             self.index += 1
 
-            # Check for the time limit of 20 ms after each 50 rows processed
-            if self.index % 50 == 0 and (time.time() - started) > 0.02:
+            # Check for the time limit of 500ms after each 50 rows processed
+            if self.index % 50 == 0 and (time.time() - started) > 0.5:
                 break
 
         return bool(self.episodes)

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -192,6 +192,7 @@ class EpisodeListModel(Gtk.ListStore):
         # Are we currently showing "all episodes"/section or a single channel?
         self._section_view = False
 
+        self.icon_theme = Gtk.IconTheme.get_default()
         self.ICON_WEB_BROWSER = 'web-browser'
         self.ICON_AUDIO_FILE = 'audio-x-generic'
         self.ICON_VIDEO_FILE = 'video-x-generic'
@@ -377,7 +378,6 @@ class EpisodeListModel(Gtk.ListStore):
         view_show_undeleted = True
         view_show_downloaded = False
         view_show_unplayed = False
-        icon_theme = Gtk.IconTheme.get_default()
 
         task = episode.download_task
 
@@ -434,7 +434,7 @@ class EpisodeListModel(Gtk.ListStore):
                         file_info = file.query_info('*', Gio.FileQueryInfoFlags.NONE, None)
                         icon = file_info.get_icon()
                         for icon_name in icon.get_names():
-                            if icon_theme.has_icon(icon_name):
+                            if self.icon_theme.has_icon(icon_name):
                                 status_icon = icon_name
                                 break
 
@@ -605,6 +605,7 @@ class PodcastListModel(Gtk.ListStore):
         self._scale = 1
         self._cover_downloader = cover_downloader
 
+        self.icon_theme = Gtk.IconTheme.get_default()
         self.ICON_DISABLED = 'media-playback-pause'
         self.ICON_ERROR = 'dialog-warning'
 
@@ -712,14 +713,13 @@ class PodcastListModel(Gtk.ListStore):
 
     def _overlay_pixbuf(self, pixbuf, icon):
         try:
-            icon_theme = Gtk.IconTheme.get_default()
-            emblem = icon_theme.load_icon(icon, self._max_image_side / 2, 0)
+            emblem = self.icon_theme.load_icon(icon, self._max_image_side / 2, 0)
             (width, height) = (emblem.get_width(), emblem.get_height())
             xpos = pixbuf.get_width() - width
             ypos = pixbuf.get_height() - height
             if ypos < 0:
                 # need to resize overlay for none standard icon size
-                emblem = icon_theme.load_icon(icon, pixbuf.get_height() - 1, 0)
+                emblem = self.icon_theme.load_icon(icon, pixbuf.get_height() - 1, 0)
                 (width, height) = (emblem.get_width(), emblem.get_height())
                 xpos = pixbuf.get_width() - width
                 ypos = pixbuf.get_height() - height

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -282,24 +282,27 @@ class EpisodeListModel(Gtk.ListStore):
         return self._search_term
 
     def _format_description(self, episode, include_description=False):
-        title = episode.trimmed_title
+        d = []
 
+        title = episode.trimmed_title
         if episode.state != gpodder.STATE_DELETED and episode.is_new:
-            yield '<b>'
-            yield html.escape(title)
-            yield '</b>'
+            d.append('<b>')
+            d.append(html.escape(title))
+            d.append('</b>')
         else:
-            yield html.escape(title)
+            d.append(html.escape(title))
 
         if include_description:
-            yield '\n'
+            d.append('\n')
             if self._section_view:
-                yield _('from %s') % html.escape(episode.channel.title)
+                d.append(_('from %s') % html.escape(episode.channel.title))
             else:
                 description = episode.one_line_description()
                 if description.startswith(title):
                     description = description[len(title):].strip()
-                yield html.escape(description)
+                d.append(html.escape(description))
+
+        return ''.join(d)
 
     def replace_from_channel(self, channel, include_description=False):
         """
@@ -485,7 +488,8 @@ class EpisodeListModel(Gtk.ListStore):
 
         tooltip = ', '.join(tooltip)
 
-        description = ''.join(self._format_description(episode, include_description))
+        description = self._format_description(episode, include_description)
+
         return (
                 (self.C_STATUS_ICON, status_icon),
                 (self.C_VIEW_SHOW_UNDELETED, view_show_undeleted),

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -489,6 +489,8 @@ class EpisodeListModel(Gtk.ListStore):
         tooltip = ', '.join(tooltip)
 
         description = self._format_description(episode, include_description)
+        time = episode.get_play_info_string()
+        filesize = self._format_filesize(episode)
 
         return (
                 (self.C_STATUS_ICON, status_icon),
@@ -497,18 +499,16 @@ class EpisodeListModel(Gtk.ListStore):
                 (self.C_VIEW_SHOW_UNPLAYED, view_show_unplayed),
                 (self.C_DESCRIPTION, description),
                 (self.C_TOOLTIP, tooltip),
-                (self.C_TIME, episode.get_play_info_string()),
+                (self.C_TIME, time),
                 (self.C_TIME_VISIBLE, bool(episode.total_time)),
                 (self.C_TOTAL_TIME, episode.total_time),
                 (self.C_LOCKED, episode.archive),
-                (self.C_FILESIZE_TEXT, self._format_filesize(episode)),
+                (self.C_FILESIZE_TEXT, filesize),
                 (self.C_FILESIZE, episode.file_size),
 
-                (self.C_TIME_AND_SIZE, "%s\n<small>%s</small>"
-                    % (episode.get_play_info_string(), self._format_filesize(episode) if episode.file_size > 0 else "")),
+                (self.C_TIME_AND_SIZE, "%s\n<small>%s</small>" % (time, filesize if episode.file_size > 0 else "")),
                 (self.C_TOTAL_TIME_AND_SIZE, episode.total_time),
-                (self.C_FILESIZE_AND_TIME_TEXT, "%s\n<small>%s</small>"
-                    % (self._format_filesize(episode) if episode.file_size > 0 else "", episode.get_play_info_string())),
+                (self.C_FILESIZE_AND_TIME_TEXT, "%s\n<small>%s</small>" % (filesize if episode.file_size > 0 else "", time)),
                 (self.C_FILESIZE_AND_TIME, episode.file_size),
         )
 


### PR DESCRIPTION
These patches improve episode list refresh time by about 12%. Additional optimizations in `get_update_fields()` could improve it more but half of the time is spent in the `model.set()` call.

The themed Gio icon check increases the time spent in `get_update_fields()` by 24% for downloaded episodes. There was talk in #872 about removing those icons.