### PR TITLE
delete tags before modifying

### DIFF
--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -94,7 +94,7 @@ class AudioFile(object):
             audio.add_tags()
 
         if modify_tags:
-            if remove_before_modify and audio.tags is not None:
+            if remove_before_modify:
                 audio.delete()
 
             if self.album is not None:

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -95,7 +95,7 @@ class AudioFile(object):
         if modify_tags:
             if audio.tags is not None:
                 audio.delete()
-            
+
             if self.album is not None:
                 audio.tags['album'] = self.album
 

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -93,6 +93,9 @@ class AudioFile(object):
             audio.add_tags()
 
         if modify_tags:
+            if audio.tags is not None:
+                audio.delete()
+            
             if self.album is not None:
                 audio.tags['album'] = self.album
 

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -62,7 +62,8 @@ DefaultConfig = {
     'auto_embed_coverart': False,
     'set_artist_to_album': False,
     'set_version': 4,
-    'modify_tags': True
+    'modify_tags': True,
+    'remove_before_modify': False
 }
 
 
@@ -82,7 +83,7 @@ class AudioFile(object):
             audio.delete()
         audio.save()
 
-    def write_basic_tags(self, modify_tags, set_artist_to_album, set_version):
+    def write_basic_tags(self, remove_before_modify, modify_tags, set_artist_to_album, set_version):
         audio = File(self.filename, easy=True)
 
         if audio is None:
@@ -93,7 +94,7 @@ class AudioFile(object):
             audio.add_tags()
 
         if modify_tags:
-            if audio.tags is not None:
+            if remove_before_modify and audio.tags is not None:
                 audio.delete()
 
             if self.album is not None:
@@ -287,7 +288,8 @@ class gPodderExtension:
         if self.container.config.always_remove_tags:
             audio.remove_tags()
         else:
-            audio.write_basic_tags(self.container.config.modify_tags,
+            audio.write_basic_tags(self.container.config.remove_before_modify,
+                                   self.container.config.modify_tags,
                                    self.container.config.set_artist_to_album,
                                    self.container.config.set_version)
 


### PR DESCRIPTION
When "modify_tags" is enabled some episodes are getting carryover unrelated metadata prepended to the comments tag.

<img width="660" alt="Screenshot 2022-11-28 at 12 14 01 AM" src="https://user-images.githubusercontent.com/11912474/204217823-67db307f-b018-4a20-ba25-154c498eff7a.png">

This displays different in different players. In iTunes the bug isn't visible and it displays "People trying to coax each other [...]". However in other clients, such as Emby, it displays "preroll_1;postroll_1" and the show notes are not displayed at all.

This patch clears existing tags from the mp3 before writing the new ones, which fixes this bug.
