### PR TITLE
Fix UI issues

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -630,6 +630,7 @@ class gPodderCli(object):
         common.find_partial_downloads(self._model.get_podcasts(),
                                       noop,
                                       noop,
+                                      noop,
                                       on_finish)
         return True
 
@@ -687,6 +688,7 @@ class gPodderCli(object):
             self._download_episodes(episodes)
 
         common.find_partial_downloads(self._model.get_podcasts(),
+                                      noop,
                                       noop,
                                       noop,
                                       on_finish)

--- a/share/gpodder/extensions/rename_download.py
+++ b/share/gpodder/extensions/rename_download.py
@@ -62,26 +62,20 @@ class gPodderExtension:
         number_of_episodes = len(episodes)
         progress_indicator = ProgressIndicator(
             _('Renaming all downloaded episodes'),
-            '', True, self.gpodder.get_dialog_parent())
-        progress_indicator.on_message('0 / %d' % number_of_episodes)
+            '', True, self.gpodder.get_dialog_parent(), number_of_episodes)
 
-        renamed_count = 0
         for episode in episodes:
             self.on_episode_downloaded(episode)
 
-            renamed_count += 1
-            progress_indicator.on_message('%d / %d' % (renamed_count, number_of_episodes))
-            progress_indicator.on_progress(renamed_count / number_of_episodes)
-            if time.time() >= progress_indicator.next_update:
-                progress_indicator.update_gui()
-                self.gpodder.force_ui_update()
-                if not progress_indicator.cancellable:
-                    break
+            if not progress_indicator.on_tick():
+                break
+        renamed_count = progress_indicator.tick_counter
 
         progress_indicator.on_finished()
 
-        self.gpodder.show_message(_('Renamed %(count)d downloaded episodes') % {'count': number_of_episodes},
-            _('Renaming finished'), important=True)
+        if renamed_count > 0:
+            self.gpodder.show_message(_('Renamed %(count)d downloaded episodes') % {'count': renamed_count},
+                _('Renaming finished'), important=True)
 
     def make_filename(self, current_filename, title, sortdate, podcast_title):
         dirname = os.path.dirname(current_filename)

--- a/src/gpodder/common.py
+++ b/src/gpodder/common.py
@@ -47,7 +47,7 @@ def clean_up_downloads(delete_partial=False):
         util.delete_file(tempfile)
 
 
-def find_partial_downloads(channels, start_progress_callback, progress_callback, finish_progress_callback):
+def find_partial_downloads(channels, start_progress_callback, progress_callback, final_progress_callback, finish_progress_callback):
     """Find partial downloads and match them with episodes
 
     channels - A list of all model.PodcastChannel objects
@@ -85,6 +85,8 @@ def find_partial_downloads(channels, start_progress_callback, progress_callback,
 
             if not candidates:
                 break
+
+        final_progress_callback()
 
         for f in partial_files:
             logger.warning('Partial file without episode: %s', f)

--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -195,10 +195,7 @@ class DownloadStatusModel(Gtk.ListStore):
     # as only the main thread is allowed to manipulate the list store.
     def get_next(self):
         dqr = DequeueRequest()
-        # this can not be idle_add because update_downloads_list() is called from a higher
-        # priority timeout_add and would spin forever, never calling this.
-        from gi.repository import GLib
-        GLib.timeout_add(0, self.__get_next, dqr)
+        util.idle_add(self.__get_next, dqr)
         return dqr.dequeue()
 
     def _work_gen(self):

--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -72,6 +72,8 @@ class DownloadStatusModel(Gtk.ListStore):
         self._status_ids[download.DownloadTask.PAUSING] = 'media-playback-pause'
         self._status_ids[download.DownloadTask.PAUSED] = 'media-playback-pause'
 
+        self.enabled = True
+
     def _format_message(self, episode, message, podcast):
         episode = html.escape(episode)
         podcast = html.escape(podcast)

--- a/src/gpodder/gtkui/interface/progress.py
+++ b/src/gpodder/gtkui/interface/progress.py
@@ -50,6 +50,7 @@ class ProgressIndicator(object):
         self._initial_message = None
         self._initial_progress = None
         self._progress_set = False
+        # use timeout_add, not util.idle_timeout_add, so it updates before Gtk+ redraws the dialog
         self.source_id = GLib.timeout_add(self.DELAY, self._create_progress)
 
         self.set_max_ticks(max_ticks)
@@ -111,6 +112,7 @@ class ProgressIndicator(object):
         self._update_gui()
 
         # previous self.source_id timeout is removed when this returns False
+        # use timeout_add, not util.idle_timeout_add, so it updates before Gtk+ redraws the dialog
         self.source_id = GLib.timeout_add(self.INTERVAL, self._update_gui)
         return False
 

--- a/src/gpodder/gtkui/interface/searchtree.py
+++ b/src/gpodder/gtkui/interface/searchtree.py
@@ -48,6 +48,7 @@ class SearchTree:
         if self.search_box.get_property('visible'):
             if self._search_timeout is not None:
                 GLib.source_remove(self._search_timeout)
+            # use timeout_add, not util.idle_timeout_add, so it updates the TreeView before background tasks
             self._search_timeout = GLib.timeout_add(
                     self.config.ui.gtk.live_search_delay,
                     self.set_search_term, editable.get_chars(0, -1))

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -3824,7 +3824,6 @@ class gPodder(BuilderWidget, dbus.service.Object):
         if self.wNotebook.get_current_page() == 0:
             episodes = [e for e in self.get_selected_episodes() if e.can_download()]
             self.download_episode_list(episodes)
-            self.update_downloads_list()
         else:
             selection = self.treeDownloads.get_selection()
             (model, paths) = selection.get_selected_rows()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2431,7 +2431,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         if remaining_seconds > 3600:
             # timeout an hour early in the event daylight savings changes the clock forward
             remaining_seconds = remaining_seconds - 3600
-        GLib.timeout_add(remaining_seconds * 1000, self.refresh_episode_dates)
+        util.idle_timeout_add(remaining_seconds * 1000, self.refresh_episode_dates)
 
     def update_podcast_list_model(self, urls=None, selected=False, select_url=None,
             sections_changed=False):
@@ -3821,8 +3821,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             interval = 60 * 1000 * self.config.auto.update.frequency
             logger.debug('Setting up auto update timer with interval %d.',
                     self.config.auto.update.frequency)
-            self._auto_update_timer_source_id = GLib.timeout_add(
-                    interval, self._on_auto_update_timer)
+            self._auto_update_timer_source_id = util.idle_timeout_add(interval, self._on_auto_update_timer)
 
     def _on_auto_update_timer(self):
         if self.config.check_connection and not util.connection_available():

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -3835,10 +3835,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
     def on_pause_selected_episodes(self, action_or_widget, param=None):
         if self.wNotebook.get_current_page() == 0:
-            for episode in self.get_selected_episodes():
-                if episode.can_pause():
-                    episode.download_task.pause()
-            self.update_downloads_list()
+            selection = self.get_selected_episodes()
+            selected_tasks = [(None, e.download_task) for e in selection if e.download_task is not None and e.can_pause()]
+            self._for_each_task_set_status(selected_tasks, download.DownloadTask.PAUSING)
         else:
             selection = self.treeDownloads.get_selection()
             (model, paths) = selection.get_selected_rows()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -93,6 +93,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.last_episode_date_refresh = None
         self.refresh_episode_dates()
 
+        self.on_episode_list_selection_changed_id = None
+
     def new(self):
         if self.application.want_headerbar:
             self.header_bar = Gtk.HeaderBar()
@@ -1059,6 +1061,13 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self._search_episodes.show_search(grab_focus=False)
 
     def on_episode_list_selection_changed(self, selection):
+        # Only update the UI every 250ms to prevent lag when rapidly changing selected episode or shift-selecting episodes
+        if self.on_episode_list_selection_changed_id is None:
+            self.on_episode_list_selection_changed_id = util.idle_timeout_add(250, self._on_episode_list_selection_changed)
+
+    def _on_episode_list_selection_changed(self):
+        self.on_episode_list_selection_changed_id = None
+
         # Update the toolbar buttons
         self.play_or_download()
         # and the shownotes

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1161,7 +1161,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.things_adding_tasks -= 1
         if self.download_list_update_timer is None:
             self.update_downloads_list()
-            self.download_list_update_timer = util.IdleTimeout(1500, self.update_downloads_list)
+            self.download_list_update_timer = util.IdleTimeout(1500, self.update_downloads_list).set_max_milliseconds(5000)
 
     def stop_download_list_update_timer(self):
         if self.download_list_update_timer is None:

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1348,21 +1348,40 @@ class IdleTimeout(object):
         if not gpodder.ui.gtk:
             raise Exception('util.IdleTimeout() is only supported by Gtk+')
         self.milliseconds = milliseconds
+        self.max_milliseconds = 0
         self.func = func
         from gi.repository import GLib
         self.id = GLib.timeout_add(milliseconds, self._callback, *args, priority=GLib.PRIORITY_DEFAULT_IDLE)
 
+    def set_max_milliseconds(self, max):
+        self.max_milliseconds = max
+        return self
+
     def _callback(self, *args):
         self.cancel()
+        start_time = time.time()
         if self.func(*args):
+            if self.max_milliseconds > self.milliseconds:
+                duration = round((time.time() - start_time) * 1000)
+                if duration > self.max_milliseconds:
+                    duration = self.max_milliseconds
+                milliseconds = round(lerp(self.milliseconds, self.max_milliseconds, duration / self.max_milliseconds))
+            else:
+                milliseconds = self.milliseconds
             from gi.repository import GLib
-            self.id = GLib.timeout_add(self.milliseconds, self._callback, *args, priority=GLib.PRIORITY_DEFAULT_IDLE)
+            self.id = GLib.timeout_add(milliseconds, self._callback, *args, priority=GLib.PRIORITY_DEFAULT_IDLE)
 
     def cancel(self):
         if self.id:
             from gi.repository import GLib
             GLib.source_remove(self.id)
             self.id = 0
+
+
+def lerp(a, b, f):
+    """Linear interpolation between 'a' and 'b', where 'f' is between 0.0 and 1.0
+    """
+    return ((1.0 - f) * a) + (f * b)
 
 
 def bluetooth_available():


### PR DESCRIPTION
`update_downloads_list()` can take several seconds when thousands of episodes are downloading. Its timer is now adjusted from 1.5 to 5 seconds based on how long the function took to run. This will increase the time between UI lockups when downloading. The timer is also disabled when performing actions that show a progress indicator, which allows the actions to finish significantly faster.

The download queue manager can also be disabled when performing actions to further decrease the time they take.

A progress indicator is now shown when cancelling tasks, pausing downloads, resuming paused downloads, or when retrying failed downloads. These actions now finish much faster due to the above improvements.

The new progress indicator requires less code at callsites and can show a message on the final tick if the action performs a final long running operation, such as calling update_downloads_list().

Shift-selections now only update at 250ms intervals to improve responsiveness while mass selecting episodes.

A new `idle_timeout_add()` function has been added to allow for timeouts that are handled at the same priority as `idle_add()`. This should eliminate all issues related to #1311.