### PR TITLE
Accept coverart as SVG

### DIFF
--- a/src/gpodder/coverart.py
+++ b/src/gpodder/coverart.py
@@ -44,6 +44,7 @@ class CoverDownloader(object):
         '.jpg': lambda d: d.startswith(b'\xff\xd8'),
         '.gif': lambda d: d.startswith(b'GIF89a') or d.startswith(b'GIF87a'),
         '.ico': lambda d: d.startswith(b'\0\0\1\0'),
+        '.svg': lambda d: d.startswith(b'<svg '),
     }
 
     EXTENSIONS = list(SUPPORTED_EXTENSIONS.keys())


### PR DESCRIPTION
Some feeds have an SVG-file as their cover (the `atom:icon` element). Currently gPodder only accepts raster file formats (.png .jpeg, etc.) as cover files. This adds SVG to the allowed formats.

This causes an implicit dependency on librsvg via `GdkPixbuf.Pifbuf.new_from_file()`. This is probably not a problem on Linux, but could be on other platforms.