### PR TITLE
correct absolute path config settings for playlist

### DIFF
--- a/src/gpodder/deviceplaylist.py
+++ b/src/gpodder/deviceplaylist.py
@@ -101,7 +101,7 @@ class gPodderDevicePlaylist(object):
         foldername = episode_foldername_on_device(self._config, episode)
         if foldername:
             filename = os.path.join(foldername, filename)
-        if self._config.device_sync.playlist.absolute_path:
+        if self._config.device_sync.playlists.use_absolute_path:
             filename = os.path.join(util.relpath(self._config.device_sync.device_folder, self.mountpoint.get_uri()), filename)
         return filename
 

--- a/src/gpodder/syncui.py
+++ b/src/gpodder/syncui.py
@@ -256,7 +256,10 @@ class gPodderSyncUI(object):
                                 # if playlist doesn't exist (yet) episodes_in_playlist will be empty
                                 if episodes_in_playlists:
                                     for episode_filename in episodes_in_playlists:
-                                        if not playlist.mountpoint.resolve_relative_path(episode_filename).query_exists():
+                                        if ((not self._config.device_sync.playlists.use_absolute_path
+                                        and not playlist.playlist_folder.resolve_relative_path(episode_filename).query_exists()) or
+                                        (self._config.device_sync.playlists.use_absolute_path
+                                        and not playlist.mountpoint.resolve_relative_path(episode_filename).query_exists())):
                                             # episode was synced but no longer on device
                                             # i.e. must have been deleted by user, so delete from gpodder
                                             try:


### PR DESCRIPTION
self._config.device_sync.playlists.use_absolute_path when checking if absolute path in playlists was desired
This lead to always have the absolute path (which does lead using non existing config variables not to an error?)