### PR TITLE
appdata: Update to version 3.11.1, fixes

### DIFF
--- a/share/metainfo/org.gpodder.gpodder.appdata.xml
+++ b/share/metainfo/org.gpodder.gpodder.appdata.xml
@@ -51,6 +51,17 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="3.11.1" date="2023-02-18">
+      <description>
+        <p>Major changes:</p>
+        <ul>
+          <li>new yt-dlp to fix the recent YouTube change</li>
+          <li>fix multiple bugs that caused gPodder to freeze or appear frozen</li>
+          <li>embed subtitles in videos with youtube-dl extension</li>
+          <li>performance improvements</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.11.0" date="2022-07-30">
       <description>
         <p>This release contains a year's worth of improvements. Major changes:</p>

--- a/share/metainfo/org.gpodder.gpodder.appdata.xml
+++ b/share/metainfo/org.gpodder.gpodder.appdata.xml
@@ -44,7 +44,7 @@
     <content_attribute id="money-purchasing">none</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
-   <screenshots>
+  <screenshots>
     <screenshot type="default">
       <caption>The main window</caption>
       <image>https://raw.githubusercontent.com/flathub/org.gpodder.gpodder/master/screenshot.png</image>
@@ -74,7 +74,7 @@
     <release version="3.10.9" date="2019-06-09"/>
     <release version="3.10.8" date="2019-04-08"/>
     <release version="3.10.7" date="2019-02-02"/>
-    <release version="3.10.6" date="2018-12-29">
+    <release version="3.10.6" date="2018-12-29"/>
     <release version="3.10.5" date="2018-09-15">
       <description>
         <p>This is a bugfix release, shortly after 3.10.4, for the Rename after Download extension.</p>
@@ -85,5 +85,12 @@
     <release version="3.10.2" date="2018-06-10"/>
     <release version="3.10.1" date="2018-02-19"/>
     <release version="3.10.0" date="2017-12-29"/>
+    <release version="3.9.6" date="2017-12-29"/>
+    <release version="3.9.5" date="2017-12-16"/>
+    <release version="3.9.4" date="2017-12-16"/>
+    <release version="3.9.3" date="2016-12-22"/>
+    <release version="3.9.2" date="2016-11-30"/>
+    <release version="3.9.1" date="2016-08-31"/>
+    <release version="3.9.0" date="2016-02-03"/>
   </releases>
 </component>


### PR DESCRIPTION
Add the latest release to the appdata.xml, fix the XML syntax and add the release dates of 3.9.x versions.

The flathub guidelines now recommend that the appdata file is maintained with the upstream sources. It would be nice to have the release notes included in the appdata before the release, so it does not need to be patched for the flatpak.