### PR TITLE
Correct invalid XML in appdata

### DIFF
--- a/share/metainfo/org.gpodder.gpodder.appdata.xml
+++ b/share/metainfo/org.gpodder.gpodder.appdata.xml
@@ -74,7 +74,7 @@
     <release version="3.10.9" date="2019-06-09"/>
     <release version="3.10.8" date="2019-04-08"/>
     <release version="3.10.7" date="2019-02-02"/>
-    <release version="3.10.6" date="2018-12-29">
+    <release version="3.10.6" date="2018-12-29"/>
     <release version="3.10.5" date="2018-09-15">
       <description>
         <p>This is a bugfix release, shortly after 3.10.4, for the Rename after Download extension.</p>


### PR DESCRIPTION
Hi.

This PR addresses an XML parsing error in the appdata.xml caught by `appstreamcli` (part of the `appstream` package on Debian systems):


**before this PR**
```
$ appstreamcli validate ./share/metainfo/org.gpodder.gpodder.appdata.xml
E: ~:~: xml-markup-invalid
     Could not parse XML data: Entity: line 88: parser error : Opening and ending tag
     mismatch: release line 77 and releases
       </releases>
                  ^
     Entity: line 89: parser error : Opening and ending tag mismatch: releases line 53 and
     component
     </component>
                ^
     Entity: line 90: parser error : Premature end of data in tag component line 2
     
     ^
     

✘ Validation failed: errors: 1
```

**after this PR**
```
$ appstreamcli validate ./share/metainfo/org.gpodder.gpodder.appdata.xml
✔ Validation was successful.
```

Also, the file doesn't contain information about the 3.11.1 release, but that's a separate issue.