### PR TITLE
Drop old python versions

### DIFF
--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Getting started <!-- omit in toc -->
 
 Before you begin:
-- Ensure you are using Python 3.5+
+- Ensure you are using Python 3.7+
 - Check out the [existing issues](https://github.com/gpodder/gpodder/issues)
 
 Contributions are made to this repo via Issues and Pull Requests (PRs). Make sure to search for existing Issues and PRs before creating your own.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 ## Dependencies
 
-- [Python 3.5](http://python.org/) or newer
+- [Python 3.7](http://python.org/) or newer
 - [Podcastparser](http://gpodder.org/podcastparser/) 0.6.0 or newer
 - [mygpoclient](http://gpodder.org/mygpoclient/) 1.7 or newer
 - [requests](https://requests.readthedocs.io) 2.24.0 or newer
@@ -135,7 +135,7 @@ into an alternative root (default /) and prefix (default /usr):
 [*Debian*](https://wiki.debian.org/Python#Deviations_from_upstream) and *Ubuntu* use `dist-packages`
 instead of `site-packages` for third party installs, so you'll want something like:
 
-    sudo python3 setup.py install --root / --prefix /usr/local --optimize=1 --install-lib=/usr/local/lib/python3.5/dist-packages
+    sudo python3 setup.py install --root / --prefix /usr/local --optimize=1 --install-lib=/usr/local/lib/python3.10/dist-packages
 
 In fact, first try running `python -c "import sys; print(sys.path)"` to check what is the exact path.
 It depends on your version of python.


### PR DESCRIPTION
Podcastparser has dropped support for EOL Python 3.5 and 3.6 versions. Does anyone object to doing the same in gPodder?

I will update website after this is merged.