### PR TITLE
Show time in episode released column

### DIFF
--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -246,6 +246,10 @@
           <attribute name="label" translatable="yes">Show episode released time</attribute>
         </item>
         <item>
+          <attribute name="action">win.viewRightAlignEpisodeReleasedColumn</attribute>
+          <attribute name="label" translatable="yes">Right align episode released column</attribute>
+        </item>
+        <item>
           <attribute name="action">win.viewCtrlClickToSortEpisodes</attribute>
           <attribute name="label" translatable="yes">Require control click to sort episodes</attribute>
         </item>

--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -242,6 +242,10 @@
           <attribute name="accel">&lt;Primary&gt;d</attribute>
         </item>
         <item>
+          <attribute name="action">win.viewShowEpisodeReleasedTime</attribute>
+          <attribute name="label" translatable="yes">Show episode released time</attribute>
+        </item>
+        <item>
           <attribute name="action">win.viewCtrlClickToSortEpisodes</attribute>
           <attribute name="label" translatable="yes">Require control click to sort episodes</attribute>
         </item>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -172,6 +172,7 @@ defaults = {
                 'trim_title_prefix': True,
                 'descriptions': True,
                 'show_released_time': False,
+                'right_align_released_column': False,
                 'ctrl_click_to_sort': False,
                 'columns': int('110', 2),  # bitfield of visible columns
             },

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -171,6 +171,7 @@ defaults = {
                 'always_show_new': True,
                 'trim_title_prefix': True,
                 'descriptions': True,
+                'show_released_time': False,
                 'ctrl_click_to_sort': False,
                 'columns': int('110', 2),  # bitfield of visible columns
             },

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -320,6 +320,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
         g.add_action(action)
 
         action = Gio.SimpleAction.new_stateful(
+            'viewShowEpisodeReleasedTime', None, GLib.Variant.new_boolean(self.config.ui.gtk.episode_list.show_released_time))
+        action.connect('activate', self.on_item_view_show_episode_released_time_toggled)
+        g.add_action(action)
+
+        action = Gio.SimpleAction.new_stateful(
             'viewCtrlClickToSortEpisodes', None, GLib.Variant.new_boolean(self.config.ui.gtk.episode_list.ctrl_click_to_sort))
         action.connect('activate', self.on_item_view_ctrl_click_to_sort_episodes_toggled)
         g.add_action(action)
@@ -926,7 +931,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
         timecolumn.set_sort_column_id(EpisodeListModel.C_TOTAL_TIME)
 
         releasecell = Gtk.CellRendererText()
-        releasecolumn = Gtk.TreeViewColumn(_('Released'), releasecell, text=EpisodeListModel.C_PUBLISHED_TEXT)
+        releasecolumn = Gtk.TreeViewColumn(_('Released'))
+        releasecolumn.pack_start(releasecell, True)
+        releasecolumn.add_attribute(releasecell, 'markup', EpisodeListModel.C_PUBLISHED_TEXT)
         releasecolumn.set_sort_column_id(EpisodeListModel.C_PUBLISHED)
 
         sizetimecell = Gtk.CellRendererText()
@@ -1365,7 +1372,8 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def _on_config_changed(self, name, old_value, new_value):
         if name == 'ui.gtk.toolbar':
             self.toolbar.set_property('visible', new_value)
-        elif name in ('ui.gtk.episode_list.descriptions',
+        elif name in ('ui.gtk.episode_list.show_released_time',
+                'ui.gtk.episode_list.descriptions',
                 'ui.gtk.episode_list.trim_title_prefix',
                 'ui.gtk.episode_list.always_show_new'):
             self.update_episode_list_model()
@@ -3505,6 +3513,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
     def on_item_view_show_episode_description_toggled(self, action, param):
         state = action.get_state()
         self.config.ui.gtk.episode_list.descriptions = not state
+        action.set_state(GLib.Variant.new_boolean(not state))
+
+    def on_item_view_show_episode_released_time_toggled(self, action, param):
+        state = action.get_state()
+        self.config.ui.gtk.episode_list.show_released_time = not state
         action.set_state(GLib.Variant.new_boolean(not state))
 
     def on_item_view_ctrl_click_to_sort_episodes_toggled(self, action, param):

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -128,7 +128,7 @@ class BackgroundUpdate(object):
                 model.C_URL, episode.url,
                 model.C_TITLE, episode.title,
                 model.C_EPISODE, episode,
-                model.C_PUBLISHED_TEXT, episode.cute_pubdate(),
+                model.C_PUBLISHED_TEXT, episode.cute_pubdate(show_time=self.model._config_ui_gtk_episode_list_show_released_time),
                 model.C_PUBLISHED, episode.published,
             )
             update_fields = model.get_update_fields(episode)
@@ -215,11 +215,13 @@ class EpisodeListModel(Gtk.ListStore):
         self._config_ui_gtk_episode_list_always_show_new = False
         self._config_ui_gtk_episode_list_trim_title_prefix = False
         self._config_ui_gtk_episode_list_descriptions = False
+        self._config_ui_gtk_episode_list_show_released_time = False
 
     def cache_config(self, config):
         self._config_ui_gtk_episode_list_always_show_new = config.ui.gtk.episode_list.always_show_new
         self._config_ui_gtk_episode_list_trim_title_prefix = config.ui.gtk.episode_list.trim_title_prefix
         self._config_ui_gtk_episode_list_descriptions = config.ui.gtk.episode_list.descriptions
+        self._config_ui_gtk_episode_list_show_released_time = config.ui.gtk.episode_list.show_released_time
 
     def _format_filesize(self, episode):
         if episode.file_size > 0:

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import datetime
 import html
 import logging
 from urllib.parse import urlparse
@@ -201,7 +202,8 @@ class gPodderShownotesText(gPodderShownotes):
         heading = episode.title
         subheading = _('from %s') % (episode.channel.title)
         details = self.details_fmt % {
-            'date': util.format_date(episode.published),
+            'date': '{} {}'.format(datetime.datetime.fromtimestamp(episode.published).strftime('%H:%M'),
+                util.format_date(episode.published)),
             'size': util.format_filesize(episode.file_size, digits=1)
             if episode.file_size > 0 else "-",
             'duration': episode.get_play_info_string()}
@@ -342,7 +344,8 @@ class gPodderShownotesHTML(gPodderShownotes):
         heading = '<h3>%s</h3>' % html.escape(episode.title)
         subheading = _('from %s') % html.escape(episode.channel.title)
         details = '<small>%s</small>' % html.escape(self.details_fmt % {
-            'date': util.format_date(episode.published),
+            'date': '{} {}'.format(datetime.datetime.fromtimestamp(episode.published).strftime('%H:%M'),
+                util.format_date(episode.published)),
             'size': util.format_filesize(episode.file_size, digits=1)
             if episode.file_size > 0 else "-",
             'duration': episode.get_play_info_string()})

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -842,11 +842,18 @@ class PodcastEpisode(PodcastModelObject):
                 self.title,
                 self.cute_pubdate())
 
-    def cute_pubdate(self):
+    def cute_pubdate(self, show_time=False):
         result = util.format_date(self.published)
         if result is None:
             return '(%s)' % _('unknown')
-        else:
+
+        try:
+            if show_time:
+                timestamp = datetime.datetime.fromtimestamp(self.published)
+                return '<small>{}</small>\n{}'.format(timestamp.strftime('%H:%M'), result)
+            else:
+                return result
+        except:
             return result
 
     pubdate_prop = property(fget=cute_pubdate)


### PR DESCRIPTION
Add two View menu options to show time in episode released column and right align the column. It also always shows the released time in shownotes.

Closes #1503.