### PR TITLE
Adapt youtube-dl plugin to latest yt-dlp

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -296,9 +296,14 @@ class gPodderYoutubeDL(download.CustomDownloader):
         os.makedirs(cachedir, exist_ok=True)
         self._ydl_opts = {
             'cachedir': cachedir,
-            'no_color': True,  # prevent escape codes in desktop notifications on errors
             'noprogress': True,  # prevent progress bar from appearing in console
         }
+        # prevent escape codes in desktop notifications on errors
+        if program_name == 'yt-dlp':
+            self._ydl_opts['color'] = 'no_color'
+        else:
+            self._ydl_opts['no_color'] = True
+
         if gpodder.verbose:
             self._ydl_opts['verbose'] = True
         else:

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Iterable
 
 try:
     import yt_dlp as youtube_dl
@@ -311,7 +312,7 @@ class gPodderYoutubeDL(download.CustomDownloader):
         # Don't create downloaders for URLs supported by these youtube-dl extractors
         self.ie_blacklist = ["Generic"]
         # Cache URL regexes from youtube-dl matches here, seed with youtube regex
-        self.regex_cache = [re.compile(r'https://www.youtube.com/watch\?v=.+')]
+        self.regex_cache = [(re.compile(r'https://www.youtube.com/watch\?v=.+'),)]
         # #686 on windows without a console, sys.stdout is None, causing exceptions
         # when adding podcasts.
         # See https://docs.python.org/3/library/sys.html#sys.__stderr__ Note
@@ -453,12 +454,11 @@ class gPodderYoutubeDL(download.CustomDownloader):
     def is_supported_url(self, url):
         if url is None:
             return False
-        if self.regex_cache[0].match(url) is not None:
-            return True
-        for r in self.regex_cache[1:]:
-            if r.match(url) is not None:
-                self.regex_cache.remove(r)
-                self.regex_cache.insert(0, r)
+        for i, res in enumerate(self.regex_cache):
+            if next(filter(None, (r.match(url) for r in res)), None) is not None:
+                if i > 0:
+                    self.regex_cache.remove(res)
+                    self.regex_cache.insert(0, res)
                 return True
         with youtube_dl.YoutubeDL(self._ydl_opts) as ydl:
             # youtube-dl returns a list, yt-dlp returns a dict
@@ -467,7 +467,9 @@ class gPodderYoutubeDL(download.CustomDownloader):
                 ies = ydl._ies.values()
             for ie in ies:
                 if ie.suitable(url) and ie.ie_key() not in self.ie_blacklist:
-                    self.regex_cache.insert(0, ie._VALID_URL_RE)
+                    self.regex_cache.insert(
+                        0, (ie._VALID_URL_RE if isinstance(ie._VALID_URL_RE, Iterable)
+                            else (ie._VALID_URL_RE,)))
                     return True
         return False
 


### PR DESCRIPTION
This fixes two problems found when using the youtube-dl plugin with the latest yt-dlp (2023.06.22).

Use `'color': 'no_color'` in yt-dlp params instead of `'no_color': True`. This prevents warning log output.

The internal member `_VALID_URL_RE` is now an iterable. Adapt the `is_supported_url` function and the regex cache code.

This likely breaks compatibility with original youtube-dl.