### PR TITLE
Add setting to toggle sync filesize comparisons.

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1019,6 +1019,22 @@
                                 <property name="position">10</property>
                               </packing>
                             </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_compare_episode_filesize">
+                                <property name="label" translatable="yes">Sync existing episodes on device when file size differs from gPodder (disable if device modifies files)</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">4</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">11</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="name">devices</property>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -197,6 +197,8 @@ defaults = {
 
         'max_filename_length': 120,
 
+        'compare_episode_filesize': True,
+
         'custom_sync_name': '{episode.sortdate}_{episode.title}',
         'custom_sync_name_enabled': False,
 

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -300,6 +300,8 @@ class gPodderPreferences(BuilderWidget):
                                               self.checkbutton_delete_using_playlists)
         self._config.connect_gtk_togglebutton('device_sync.delete_deleted_episodes',
                                               self.checkbutton_delete_deleted_episodes)
+        self._config.connect_gtk_togglebutton('device_sync.compare_episode_filesize',
+                                              self.checkbutton_compare_episode_filesize)
 
         # Have to do this before calling set_active on checkbutton_enable
         self._enable_mygpo = self._config.mygpo.enabled
@@ -688,6 +690,7 @@ class gPodderPreferences(BuilderWidget):
             self.combobox_on_sync.set_sensitive(False)
             self.checkbutton_skip_played_episodes.set_sensitive(True)
             self.checkbutton_delete_deleted_episodes.set_sensitive(True)
+        self.checkbutton_compare_episode_filesize.set_sensitive(True)
 
         children = self.btn_filesystemMountpoint.get_children()
         if children:

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -532,16 +532,14 @@ class MP3PlayerDevice(Device):
         # Comparing file size would detect such files and finish uploading.
         # However, some devices add metadata to files, increasing their size, and forcing an upload on every sync.
         # File size and checksum can not be used.
-        # TODO: see https://github.com/gpodder/gpodder/issues/1416
-#        if to_file_exists:
-#            try:
-#                info = to_file.query_info(Gio.FILE_ATTRIBUTE_STANDARD_SIZE, Gio.FileQueryInfoFlags.NONE)
-#                to_size = info.get_attribute_uint64(Gio.FILE_ATTRIBUTE_STANDARD_SIZE)
-#            except GLib.Error:
-#                # Assume same size and don't sync again
-#                pass
-#        if not to_file_exists or from_size != to_size:
-        if not to_file_exists:
+        if to_file_exists and self._config.device_sync.compare_episode_filesize:
+            try:
+                info = to_file.query_info(Gio.FILE_ATTRIBUTE_STANDARD_SIZE, Gio.FileQueryInfoFlags.NONE)
+                to_size = info.get_attribute_uint64(Gio.FILE_ATTRIBUTE_STANDARD_SIZE)
+            except GLib.Error:
+                # Assume same size and don't sync again
+                pass
+        if not to_file_exists or from_size != to_size:
             logger.info('Copying %s (%d bytes) => %s (%d bytes)',
                     os.path.basename(from_file), from_size,
                     to_file.get_uri(), to_size)


### PR DESCRIPTION
Fixes #1416.

This defaults to comparing episode file sizes. I haven't yet figured out how to alert the user when it re-syncs all files, as the check happens inside the sync task code, and not in a loop that could easily track existing syncs.