### PR TITLE
Show remaining duration for each download in progress tab.

### DIFF
--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -95,10 +95,12 @@ class DownloadStatusModel(Gtk.ListStore):
                     task.STATUS_MESSAGE[task.status],
                     task.error_message)
         elif task.status == task.DOWNLOADING:
-            status_message = '%s (%.0f%%, %s/s)' % (
-                    task.STATUS_MESSAGE[task.status],
-                    task.progress * 100,
-                    util.format_filesize(task.speed))
+            status_message = _('%(status)s (%(progress).0f%%, %(rate)s/s, %(remaining)s)') % {
+                    'status': task.STATUS_MESSAGE[task.status],
+                    'progress': task.progress * 100,
+                    'rate': util.format_filesize(task.speed),
+                    'remaining': util.format_time(round((task.total_size * (1 - task.progress)) / task.speed)) if task.speed > 0 else '--:--'
+            }
         else:
             status_message = task.STATUS_MESSAGE[task.status]
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -582,15 +582,15 @@ def format_filesize(bytesize, use_si_units=False, digits=2):
     has a negative value.
     """
     si_units = (
-            ('kB', 10**3),
-            ('MB', 10**6),
-            ('GB', 10**9),
+            (_('kB'), 10**3),
+            (_('MB'), 10**6),
+            (_('GB'), 10**9),
     )
 
     binary_units = (
-            ('KiB', 2**10),
-            ('MiB', 2**20),
-            ('GiB', 2**30),
+            (_('KiB'), 2**10),
+            (_('MiB'), 2**20),
+            (_('GiB'), 2**30),
     )
 
     try:
@@ -606,7 +606,7 @@ def format_filesize(bytesize, use_si_units=False, digits=2):
     else:
         units = binary_units
 
-    (used_unit, used_value) = ('B', bytesize)
+    (used_unit, used_value) = (_('B'), bytesize)
 
     for (unit, value) in units:
         if bytesize >= value:


### PR DESCRIPTION
There is a brief moment at the start of download were task speed is zero, and it displays "00:00". Should it instead show "?" or "??:??", the later looking more like a an unknown duration? If so, it would need to be translatable since some languages don't use "?" as question mark, such as ";" in Greek.