### PR TITLE
Support Apple Podcasts urls.

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -321,15 +321,16 @@ class gPodderCli(object):
         the podcast has not been subscribed to.
         """
         url = util.normalize_feed_url(original_url)
-        if url is None:
-            self._error(_('Invalid url: %s') % original_url)
-            return None
 
         # Check if it's an Apple Podcasts link, resolves to podcast feed url if that's the case
         url = util.parse_apple_podcasts_url(url)
 
         # Check if it's a YouTube channel, user, or playlist and resolves it to its feed if that's the case
         url = youtube.parse_youtube_url(url)
+
+        if url is None:
+            self._error(_('Invalid url: %s') % original_url)
+            return None
 
         # Subscribe to new podcast
         if create:

--- a/bin/gpo
+++ b/bin/gpo
@@ -322,7 +322,7 @@ class gPodderCli(object):
         """
         url = util.normalize_feed_url(original_url)
 
-        # Check if it's an Apple Podcasts url, resolves to the podcast rss feed if that's the case
+        # Check if it's an Apple Podcasts link, resolves to podcast feed url if that's the case
         url = util.parse_apple_podcasts_url(url)
 
         # Check if it's a YouTube channel, user, or playlist and resolves it to its feed if that's the case

--- a/bin/gpo
+++ b/bin/gpo
@@ -321,12 +321,16 @@ class gPodderCli(object):
         the podcast has not been subscribed to.
         """
         url = util.normalize_feed_url(original_url)
-        if url is None:
-            self._error(_('Invalid url: %s') % original_url)
-            return None
+
+        # Check if it's an Apple Podcasts url, resolves to the podcast rss feed if that's the case
+        url = util.parse_apple_podcasts_url(url)
 
         # Check if it's a YouTube channel, user, or playlist and resolves it to its feed if that's the case
         url = youtube.parse_youtube_url(url)
+
+        if url is None:
+            self._error(_('Invalid url: %s') % original_url)
+            return None
 
         # Subscribe to new podcast
         if create:

--- a/bin/gpo
+++ b/bin/gpo
@@ -321,16 +321,15 @@ class gPodderCli(object):
         the podcast has not been subscribed to.
         """
         url = util.normalize_feed_url(original_url)
+        if url is None:
+            self._error(_('Invalid url: %s') % original_url)
+            return None
 
         # Check if it's an Apple Podcasts link, resolves to podcast feed url if that's the case
         url = util.parse_apple_podcasts_url(url)
 
         # Check if it's a YouTube channel, user, or playlist and resolves it to its feed if that's the case
         url = youtube.parse_youtube_url(url)
-
-        if url is None:
-            self._error(_('Invalid url: %s') % original_url)
-            return None
 
         # Subscribe to new podcast
         if create:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2634,7 +2634,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         for input_title, input_url in podcasts:
             url = util.normalize_feed_url(input_url)
 
-            # Check if it's an Apple Podcasts url, resolves to the podcast rss feed if that's the case
+            # Check if it's an Apple Podcasts link, resolves to podcast feed url if that's the case
             url = util.parse_apple_podcasts_url(url)
 
             # Check if it's a YouTube channel, user, or playlist and resolves it to its feed if that's the case

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2634,6 +2634,9 @@ class gPodder(BuilderWidget, dbus.service.Object):
         for input_title, input_url in podcasts:
             url = util.normalize_feed_url(input_url)
 
+            # Check if it's an Apple Podcasts url, resolves to the podcast rss feed if that's the case
+            url = util.parse_apple_podcasts_url(url)
+
             # Check if it's a YouTube channel, user, or playlist and resolves it to its feed if that's the case
             url = youtube.parse_youtube_url(url)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -308,7 +308,7 @@ def parse_apple_podcasts_url(url):
     if url is None:
         return url
 
-    re_apple_podcasts = re.compile(r'http[s]?://podcasts\.apple\.com(?:/[a-z]{2})?/podcast(?:/[^/]+)?/id[=]?([\d]+)')
+    re_apple_podcasts = re.compile(r'http[s]?://podcasts\.apple\.com(?:/[a-z]{2})?/podcast(?:/[^/]+)?/id[=]?([\d]+)', re.I)
 
     m = re_apple_podcasts.match(url)
     if m is not None:

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -312,9 +312,13 @@ def parse_apple_podcasts_url(url):
 
     m = re_apple_podcasts.match(url)
     if m is not None:
+        apple_url = url
         try:
             lookup = urlopen('https://itunes.apple.com/lookup?id=%s' % m.group(1)).json()
             url = normalize_feed_url(lookup['results'][0]['feedUrl'])
+            if url is None:
+                url = apple_url
+                raise ValueError('Invalid feed url')
         except:
             logger.warning('Could not look up feed url for %s.' % url, exc_info=True)
 


### PR DESCRIPTION
Inspired by #1541.

This PR adds support for Apple Podcasts web links in the format of
`https://podcasts.apple.com/COUNTRY/podcast/PODCAST_TITLE/idPODCAST_ID`.

utils.parse_apple_podcasts_url() opens `https://itunes.apple.com/lookup?id=PODCAST_ID` and returns the `feedUrl` field from the json response, or the original url on error, for further processing.

I also cleaned up and updated 'accelerators' in utils.normalize_feed_url(), fixed the test for feedburner, and added one for apple podcasts.