### PR TITLE
[WIP] add mandatory dependencies to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 - [Podcastparser](http://gpodder.org/podcastparser/) 0.6.0 or newer
 - [mygpoclient](http://gpodder.org/mygpoclient/) 1.7 or newer
 - [requests](https://requests.readthedocs.io) 2.24.0 or newer
-- Python D-Bus bindings
+- [dbus-python](http://dbus.freedesktop.org/doc/dbus-python/)
 
 As an alternative to python-dbus on Mac OS X and Windows, you can use
 the dummy (no-op) D-Bus module provided in "tools/fake-dbus-module/".

--- a/makefile
+++ b/makefile
@@ -53,7 +53,7 @@ PREFIX ?= /usr
 PYTHON ?= python3
 HELP2MAN ?= help2man
 
-PYTEST ?= $(shell which pytest || which pytest-3)
+PYTEST ?= $(shell command -v pytest || command -v pytest-3)
 
 ##########################################################################
 

--- a/setup.py
+++ b/setup.py
@@ -211,4 +211,12 @@ setup(
     packages=packages,
     scripts=scripts,
     data_files=data_files,
+
+    install_requires=[
+        "podcastparser>=0.6.0",
+        "mygpoclient>=1.7",
+        "requests>2.24.0",
+        "dbus-python;platform_system=='Linux'",
+        "PyGObject",
+    ]
 )

--- a/tools/mac-osx/release.sh
+++ b/tools/mac-osx/release.sh
@@ -28,7 +28,7 @@ appname=$(basename "$app")
 zip="${appname%.app}-$version.zip"
 contents="${appname%.app}.contents"
 
-if (which md5 >& /dev/null) ; then
+if command -v md5 2>/dev/null; then
 	MD5=md5
 else
 	MD5=md5sum

--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -155,7 +155,7 @@ function install_gpodder {
     fi
 
     # Create launchers
-    echo "python3 is $(which python3) version is $(python3 --version)"
+    echo "python3 is $(command -v python3) version is $(python3 --version)"
     python3 "${MISC}"/create-launcher.py \
         "${GPO_VERSION}" "${MINGW_ROOT}"/bin
 


### PR DESCRIPTION
```
rm -rf venv
python3 -m venv venv
 ./venv/bin/activate
python -m pip install setuptools
python -m pip install --no-use-pep517 --no-binary ':all:' -e . # BUG. does not populate data files
make PREFIX=$(pwd)/venv/ install  # this kindof works
```