### PR TITLE
Add PotPlayer Support For Windows

### DIFF
--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -113,6 +113,7 @@ WIN32_APP_REG_KEYS = [
     ('Windows Media Player 11', ('audio', 'video'), r'HKEY_CLASSES_ROOT\WMP11.AssocFile.MP3\shell\open\command'),
     ('QuickTime Player', ('audio', 'video'), r'HKEY_CLASSES_ROOT\QuickTime.mp3\shell\open\command'),
     ('VLC', ('audio', 'video'), r'HKEY_CLASSES_ROOT\VLC.mp3\shell\open\command'),
+    ('PotPlayer', ('audio', 'video'), r'HKEY_CLASSES_ROOT\potrun\shell\open\command'),
 ]
 
 


### PR DESCRIPTION
This pull request aims to add support for the Pot Player media playing app. Specifically for Windows. As an alternate to apps such as VLC, Windows Media Player Legacy, etc,. I recently found this app, as of tonight. So I thought why not include it and make it ready to go for anyone else that uses Pot Player. 