### PR TITLE
YouTube feeds no longer contain the required 'UC' prefix on channel ID.

### DIFF
--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -454,6 +454,10 @@ def get_channel_id_url(url, feed_data=None):
                         channel_id = m.group(1)
                     if channel_id is None:
                         raise Exception('Could not retrieve YouTube channel ID for URL %s.' % url)
+
+                # feeds no longer contain the required "UC" prefix on channel ID
+                if len(channel_id) == 22:
+                    channel_id = "UC" + channel_id
             channel_url = 'https://www.youtube.com/channel/{}'.format(channel_id)
             return channel_url
 


### PR DESCRIPTION
Which produces a broken channel URL, and missing description. New channels will also be missing a thumbnail.

This checks for 22 character IDs and prepends 'UC' to form a valid ID. Updating all channels with this patch will fix all of the above issues.