### PR TITLE
Add socks to settings

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -216,6 +216,11 @@ class gPodderCli(object):
             self._extensions_podcast_update_cb,
             self._extensions_episode_download_cb)
 
+        observer = gpodder.config.get_network_proxy_observer(self._config)
+        self._config.add_observer(observer)
+        # Trigger the global gpodder.config._proxies observer contraption to initialize it.
+        observer("network.", None, None)
+
     @contextlib.contextmanager
     def _action(self, msg):
         self._start_action(msg)

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -352,6 +352,12 @@ class gPodderYoutubeDL(download.CustomDownloader):
             'subtitleslangs': ['all'] if subs else [],
             'postprocessors': [{'key': 'FFmpegEmbedSubtitle'}] if subs else [],
         }
+
+        # Need the proxy_url from src/gpodder/config.py:get_proxies_from_config()
+        if gpodder.config._proxies:
+            opts['proxy'] = gpodder.config._proxies['http']
+            logger.debug(f"Setting proxy from network setting proxy: {opts['proxy']}")
+
         opts.update(self._ydl_opts)
         self.add_format(self.gpodder_config, opts)
         with youtube_dl.YoutubeDL(opts) as ydl:
@@ -371,6 +377,12 @@ class gPodderYoutubeDL(download.CustomDownloader):
         self.add_format(self.gpodder_config, opts, fallback='18')
         opts.update(self._ydl_opts)
         new_entries = []
+
+        # Need the proxy_url from src/gpodder/config.py:get_proxies_from_config()
+        if gpodder.config._proxies:
+            opts['proxy'] = gpodder.config._proxies['http']
+            logger.debug(f"Setting proxy from network setting proxy: {opts['proxy']}")
+
         # refresh videos one by one to catch single videos blocked by youtube
         for e in ie_result.get('entries', []):
             tmp = {k: v for k, v in ie_result.items() if k != 'entries'}
@@ -408,6 +420,12 @@ class gPodderYoutubeDL(download.CustomDownloader):
             'youtube_include_dash_manifest': False,  # only interested in video title and id
         }
         opts.update(self._ydl_opts)
+
+        # Need the proxy_url from src/gpodder/config.py:get_proxies_from_config()
+        if gpodder.config._proxies:
+            opts['proxy'] = gpodder.config._proxies['http']
+            logger.debug(f"Setting proxy from network setting proxy: {opts['proxy']}")
+
         with youtube_dl.YoutubeDL(opts) as ydl:
             ie_result = ydl.extract_info(url, download=False, process=False)
             result_type, has_playlist = extract_type(ie_result)

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1219,7 +1219,7 @@
                             </child>
                             <child>
                               <!-- n-columns=2 n-rows=3 -->
-                              <object class="GtkGrid">
+                              <object class="GtkGrid" id="grid_network_proxy_details">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="hexpand">True</property>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1208,6 +1208,7 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Overrides the proxies given in environment variables</property>
                                 <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="on_checkbutton_use_proxy_toggled" swapped="no"/>
                               </object>
@@ -1308,7 +1309,41 @@
                               </packing>
                             </child>
                             <child>
-                              <placeholder/>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Proxies given in environment variables:</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label_env_proxy">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">None</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
                             </child>
                           </object>
                           <packing>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1308,6 +1308,96 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkBox" id="vbox_network_proxy_username_password">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">12</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="checkbutton_proxy_use_username_password">
+                                    <property name="label" translatable="yes">Use username and password</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="draw-indicator">True</property>
+                                    <signal name="toggled" handler="on_checkbutton_proxy_use_username_password_toggled" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <!-- n-columns=2 n-rows=2 -->
+                                  <object class="GtkGrid" id="grid_network_proxy_username_password">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="row-spacing">6</property>
+                                    <property name="column-spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label_proxy_username">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Username:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="entry_proxy_username">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="hexpand">True</property>
+                                        <signal name="changed" handler="on_proxy_username_changed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label_proxy_password">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Password:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="entry_proxy_password">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="hexpand">True</property>
+                                        <signal name="changed" handler="on_proxy_password_changed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkSeparator">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1315,7 +1405,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -1329,7 +1419,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
@@ -1342,7 +1432,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                           </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1324,7 +1324,8 @@
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Proxies given in environment variables:</property>
+                                <property name="label" translatable="yes">Proxies given in environment variables (will be used only if proxy above is disabled):</property>
+                                <property name="wrap">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1204,11 +1204,10 @@
                             <property name="spacing">12</property>
                             <child>
                               <object class="GtkCheckButton" id="checkbutton_use_proxy">
-                                <property name="label" translatable="yes">Use proxy</property>
+                                <property name="label" translatable="yes">Use proxy (Overrides environment variables)</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
-                                <property name="tooltip-text" translatable="yes">Overrides the proxies given in environment variables</property>
                                 <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="on_checkbutton_use_proxy_toggled" swapped="no"/>
                               </object>
@@ -1279,7 +1278,7 @@
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="hexpand">True</property>
-                                    <property name="placeholder-text" translatable="yes">127.0.0.1</property>
+                                    <property name="placeholder-text">127.0.0.1</property>
                                     <signal name="changed" handler="on_proxy_hostname_changed" swapped="no"/>
                                   </object>
                                   <packing>
@@ -1292,7 +1291,7 @@
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="hexpand">True</property>
-                                    <property name="placeholder-text" translatable="yes">8123</property>
+                                    <property name="placeholder-text">8123</property>
                                     <property name="input-purpose">number</property>
                                     <signal name="changed" handler="on_proxy_port_changed" swapped="no"/>
                                   </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1196,6 +1196,128 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkBox" id="vbox_network">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">12</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_use_proxy">
+                                <property name="label" translatable="yes">Use proxy</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                                <signal name="toggled" handler="on_checkbutton_use_proxy_toggled" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <!-- n-columns=2 n-rows=3 -->
+                              <object class="GtkGrid">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="row-spacing">6</property>
+                                <property name="column-spacing">12</property>
+                                <child>
+                                  <object class="GtkLabel" id="label_proxy_type">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Proxy type:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="label_proxy_hostname">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Hostname:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="label_proxy_port">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Port:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBox" id="combobox_proxy_type">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <signal name="changed" handler="on_combobox_proxy_type_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="entry_proxy_hostname">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="placeholder-text" translatable="yes">127.0.0.1</property>
+                                    <signal name="changed" handler="on_proxy_hostname_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="entry_proxy_port">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="placeholder-text" translatable="yes">8123</property>
+                                    <property name="input-purpose">number</property>
+                                    <signal name="changed" handler="on_proxy_port_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">2</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">network</property>
+                            <property name="title" translatable="yes">Network</property>
+                            <property name="position">6</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkBox" id="vbox_extensions">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -1223,7 +1345,7 @@
                           <packing>
                             <property name="name">extensions</property>
                             <property name="title" translatable="yes">Extensions</property>
-                            <property name="position">6</property>
+                            <property name="position">7</property>
                           </packing>
                         </child>
                       </object>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -234,6 +234,9 @@ defaults = {
         'proxy_type': 'socks5h',  # Possible values: socks5h (routes dns through the proxy), socks5, http
         'proxy_hostname': '127.0.0.1',
         'proxy_port': '8123',
+        'proxy_use_username_password': False,
+        'proxy_username': '',
+        'proxy_password': '',
     },
 
     'extensions': {
@@ -250,12 +253,16 @@ _proxies = None
 def get_network_proxy_observer(config):
     """Return an observer function inside a closure containing given config instance."""
 
-    def get_proxies_from_config(config):  # TODO: add username and password support for proxy
+    def get_proxies_from_config(config):
         proxies = None
         if config.network.use_proxy:
             protocol = config.network.proxy_type
-            proxy_url = f"{protocol}://{config.network.proxy_hostname}:{config.network.proxy_port}"
+            user_pass = ""
+            if config.network.proxy_use_username_password:
+                user_pass = f"{config.network.proxy_username}:{config.network.proxy_password}@"
+            proxy_url = f"{protocol}://{user_pass}{config.network.proxy_hostname}:{config.network.proxy_port}"
             proxies = {"http": proxy_url, "https": proxy_url}
+        logger.debug(f"config observer returning proxies: {proxies}")
         return proxies
 
     def network_proxy_observer(name, old_value, new_value):

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -243,6 +243,28 @@ defaults = {
 
 logger = logging.getLogger(__name__)
 
+# Global variable for network proxies. Updated when the network proxy in the config changes
+_proxies = None
+
+
+def get_network_proxy_observer(config):
+    """Return an observer function inside a closure containing given config instance."""
+
+    def get_proxies_from_config(config):  # TODO: add username and password support for proxy
+        proxies = None
+        if config.network.use_proxy:
+            protocol = config.network.proxy_type
+            proxy_url = f"{protocol}://{config.network.proxy_hostname}:{config.network.proxy_port}"
+            proxies = {"http": proxy_url, "https": proxy_url}
+        return proxies
+
+    def network_proxy_observer(name, old_value, new_value):
+        global _proxies
+        if name.startswith("network."):
+            _proxies = get_proxies_from_config(config)
+
+    return network_proxy_observer
+
 
 def config_value_to_string(config_value):
     config_type = type(config_value)

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -231,7 +231,7 @@ defaults = {
 
     'network': {
         'use_proxy': False,
-        'proxy_type': 'socks5',  # Possible values: socks5, http
+        'proxy_type': 'socks5h',  # Possible values: socks5h (routes dns through the proxy), socks5, http
         'proxy_hostname': '127.0.0.1',
         'proxy_port': '8123',
     },

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -231,7 +231,7 @@ defaults = {
 
     'network': {
         'use_proxy': False,
-        'proxy_type': 'socks5', # Possible values: socks5, http
+        'proxy_type': 'socks5',  # Possible values: socks5, http
         'proxy_hostname': '127.0.0.1',
         'proxy_port': '8123',
     },

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -229,6 +229,13 @@ defaults = {
         'fileformat': '720p',  # preferred file format (see vimeo.py)
     },
 
+    'network': {
+        'use_proxy': False,
+        'proxy_type': 'socks5', # Possible values: socks5, http
+        'proxy_hostname': '127.0.0.1',
+        'proxy_port': '8123',
+    },
+
     'extensions': {
         'enabled': [],
     },

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -43,7 +43,7 @@ from requests.packages.urllib3.exceptions import MaxRetryError
 from requests.packages.urllib3.util.retry import Retry
 
 import gpodder
-from gpodder import registry, util, config
+from gpodder import config, registry, util
 
 logger = logging.getLogger(__name__)
 

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -51,12 +51,13 @@ _ = gpodder.gettext
 
 REDIRECT_RETRIES = 3
 
-def get_proxies_from_config(config): #TODO: add username and password support for proxy
+
+def get_proxies_from_config(config):  # TODO: add username and password support for proxy
     proxies = None
     if config.network.use_proxy:
         protocol = config.network.proxy_type
-        if protocol == "socks5": # See https://requests.readthedocs.io/en/latest/user/advanced/#socks
-            protocol = "socks5h" # I can't imagine why you wouldn't want to use remote dns
+        if protocol == "socks5":  # See https://requests.readthedocs.io/en/latest/user/advanced/#socks
+            protocol = "socks5h"  # I can't imagine why you wouldn't want to use remote dns
         proxy_url = f"{protocol}://{config.network.proxy_hostname}:{config.network.proxy_port}"
         proxies = {"http": proxy_url, "https": proxy_url}
     return proxies

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -56,8 +56,6 @@ def get_proxies_from_config(config):  # TODO: add username and password support 
     proxies = None
     if config.network.use_proxy:
         protocol = config.network.proxy_type
-        if protocol == "socks5":  # See https://requests.readthedocs.io/en/latest/user/advanced/#socks
-            protocol = "socks5h"  # I can't imagine why you wouldn't want to use remote dns
         proxy_url = f"{protocol}://{config.network.proxy_hostname}:{config.network.proxy_port}"
         proxies = {"http": proxy_url, "https": proxy_url}
     return proxies

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -338,10 +338,6 @@ class gPodderPreferences(BuilderWidget):
                                               self.checkbutton_delete_deleted_episodes)
         self._config.connect_gtk_togglebutton('device_sync.compare_episode_filesize',
                                               self.checkbutton_compare_episode_filesize)
-        self._config.connect_gtk_togglebutton('network.use_proxy',
-                                              self.checkbutton_use_proxy)
-        self._config.connect_gtk_togglebutton('network.proxy_use_username_password',
-                                              self.checkbutton_proxy_use_username_password)
 
         # Have to do this before calling set_active on checkbutton_enable
         self._enable_mygpo = self._config.mygpo.enabled
@@ -353,16 +349,20 @@ class gPodderPreferences(BuilderWidget):
         self.entry_password.set_text(self._config.mygpo.password)
         self.entry_caption.set_text(self._config.mygpo.device.caption)
 
+        # Disable mygpo sync while the dialog is open
+        self._config.mygpo.enabled = False
+
+        # Network proxy settings UI
+        self._config.connect_gtk_togglebutton('network.use_proxy',
+                                              self.checkbutton_use_proxy)
+        self._config.connect_gtk_togglebutton('network.proxy_use_username_password',
+                                              self.checkbutton_proxy_use_username_password)
         self.entry_proxy_hostname.set_text(self._config.network.proxy_hostname)
         self.entry_proxy_port.set_text(self._config.network.proxy_port)
         # This will disable the proxy input details on creation if checkbutton
         # is unticked (value from _config) on each preferences menu creation
         self.on_checkbutton_use_proxy_toggled(self.checkbutton_use_proxy)
         self.on_checkbutton_proxy_use_username_password_toggled(self.checkbutton_proxy_use_username_password)
-
-        # Disable mygpo sync while the dialog is open
-        self._config.mygpo.enabled = False
-
         self.proxy_type_model = ProxyTypeActionList(self._config)
         self.combobox_proxy_type.set_model(self.proxy_type_model)
         self.combobox_proxy_type.pack_start(cellrenderer, True)
@@ -810,18 +810,11 @@ class gPodderPreferences(BuilderWidget):
     def on_checkbutton_use_proxy_toggled(self, widget):
         widgets = (self.grid_network_proxy_details,
                    self.vbox_network_proxy_username_password)
-        if widget.get_active():  # Enable the proxy input details
-            for w in widgets:
-                w.set_sensitive(True)
-        else:  # Disable
-            for w in widgets:
-                w.set_sensitive(False)
+        for w in widgets:
+            w.set_sensitive(widget.get_active())
 
     def on_checkbutton_proxy_use_username_password_toggled(self, widget):
-        if widget.get_active():
-            self.grid_network_proxy_username_password.set_sensitive(True)
-        else:
-            self.grid_network_proxy_username_password.set_sensitive(False)
+        self.grid_network_proxy_username_password.set_sensitive(widget.get_active())
 
     def on_combobox_proxy_type_changed(self, widget):
         index = self.combobox_proxy_type.get_active()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -186,6 +186,7 @@ class ProxyTypeActionList(Gtk.ListStore):
     def __init__(self, config):
         Gtk.ListStore.__init__(self, str, str)
         self._config = config
+        self.append((_('SOCKS5 (Remote DNS)'), 'socks5h'))
         self.append((_('SOCKS5'), 'socks5'))
         self.append((_('HTTP'), 'http'))
 

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -340,6 +340,8 @@ class gPodderPreferences(BuilderWidget):
                                               self.checkbutton_compare_episode_filesize)
         self._config.connect_gtk_togglebutton('network.use_proxy',
                                               self.checkbutton_use_proxy)
+        self._config.connect_gtk_togglebutton('network.proxy_use_username_password',
+                                              self.checkbutton_proxy_use_username_password)
 
         # Have to do this before calling set_active on checkbutton_enable
         self._enable_mygpo = self._config.mygpo.enabled
@@ -356,6 +358,7 @@ class gPodderPreferences(BuilderWidget):
         # This will disable the proxy input details on creation if checkbutton
         # is unticked (value from _config) on each preferences menu creation
         self.on_checkbutton_use_proxy_toggled(self.checkbutton_use_proxy)
+        self.on_checkbutton_proxy_use_username_password_toggled(self.checkbutton_proxy_use_username_password)
 
         # Disable mygpo sync while the dialog is open
         self._config.mygpo.enabled = False
@@ -805,10 +808,20 @@ class gPodderPreferences(BuilderWidget):
         fs.destroy()
 
     def on_checkbutton_use_proxy_toggled(self, widget):
+        widgets = (self.grid_network_proxy_details,
+                   self.vbox_network_proxy_username_password)
         if widget.get_active():  # Enable the proxy input details
-            self.grid_network_proxy_details.set_sensitive(True)
+            for w in widgets:
+                w.set_sensitive(True)
         else:  # Disable
-            self.grid_network_proxy_details.set_sensitive(False)
+            for w in widgets:
+                w.set_sensitive(False)
+
+    def on_checkbutton_proxy_use_username_password_toggled(self, widget):
+        if widget.get_active():
+            self.grid_network_proxy_username_password.set_sensitive(True)
+        else:
+            self.grid_network_proxy_username_password.set_sensitive(False)
 
     def on_combobox_proxy_type_changed(self, widget):
         index = self.combobox_proxy_type.get_active()
@@ -819,3 +832,9 @@ class gPodderPreferences(BuilderWidget):
 
     def on_proxy_port_changed(self, widget):
         self._config.network.proxy_port = widget.get_text()
+
+    def on_proxy_username_changed(self, widget):
+        self._config.network.proxy_username = widget.get_text()
+
+    def on_proxy_password_changed(self, widget):
+        self._config.network.proxy_password = widget.get_text()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -796,9 +796,9 @@ class gPodderPreferences(BuilderWidget):
         fs.destroy()
 
     def on_checkbutton_use_proxy_toggled(self, widget):
-        if widget.get_active(): # Enable the proxy input details
+        if widget.get_active():  # Enable the proxy input details
             self.grid_network_proxy_details.set_sensitive(True)
-        else: # Disable
+        else:  # Disable
             self.grid_network_proxy_details.set_sensitive(False)
 
     def on_combobox_proxy_type_changed(self, widget):

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -186,7 +186,7 @@ class ProxyTypeActionList(Gtk.ListStore):
     def __init__(self, config):
         Gtk.ListStore.__init__(self, str, str)
         self._config = config
-        self.append((_('SOCKS5 (Remote DNS)'), 'socks5h'))
+        self.append((_('SOCKS5h (Remote DNS)'), 'socks5h'))
         self.append((_('SOCKS5'), 'socks5'))
         self.append((_('HTTP'), 'http'))
 

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -19,6 +19,7 @@
 
 import html
 import logging
+from urllib.request import getproxies
 
 from gi.repository import Gdk, Gtk, Pango
 
@@ -365,6 +366,13 @@ class gPodderPreferences(BuilderWidget):
         self.combobox_proxy_type.add_attribute(cellrenderer, 'text',
                                                ProxyTypeActionList.C_CAPTION)
         self.combobox_proxy_type.set_active(self.proxy_type_model.get_index())
+        env_proxies = getproxies()
+        env_proxies_str = 'None'
+        if env_proxies:
+            env_proxies_str = ''
+            for var, url in env_proxies.items():
+                env_proxies_str += f"{var}_proxy={url}\n"
+        self.label_env_proxy.set_text(env_proxies_str)
 
         # Configure the extensions manager GUI
         self.set_extension_preferences()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -193,7 +193,7 @@ class ProxyTypeActionList(Gtk.ListStore):
         for index, row in enumerate(self):
             if self._config.network.proxy_type == row[self.C_PROXY_TYPE]:
                 return index
-            return 0
+        return 0
 
     def set_index(self, index):
         self._config.network.proxy_type = self[index][self.C_PROXY_TYPE]
@@ -363,7 +363,7 @@ class gPodderPreferences(BuilderWidget):
         self.combobox_proxy_type.pack_start(cellrenderer, True)
         self.combobox_proxy_type.add_attribute(cellrenderer, 'text',
                                                ProxyTypeActionList.C_CAPTION)
-        self.combobox_proxy_type.set_active(self.device_type_model.get_index())
+        self.combobox_proxy_type.set_active(self.proxy_type_model.get_index())
 
         # Configure the extensions manager GUI
         self.set_extension_preferences()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -351,6 +351,9 @@ class gPodderPreferences(BuilderWidget):
 
         self.entry_proxy_hostname.set_text(self._config.network.proxy_hostname)
         self.entry_proxy_port.set_text(self._config.network.proxy_port)
+        # This will disable the proxy input details on creation if checkbutton
+        # is unticked (value from _config) on each preferences menu creation
+        self.on_checkbutton_use_proxy_toggled(self.checkbutton_use_proxy)
 
         # Disable mygpo sync while the dialog is open
         self._config.mygpo.enabled = False
@@ -793,7 +796,10 @@ class gPodderPreferences(BuilderWidget):
         fs.destroy()
 
     def on_checkbutton_use_proxy_toggled(self, widget):
-        pass #TODO disable other fields when use proxy is false.
+        if widget.get_active(): # Enable the proxy input details
+            self.grid_network_proxy_details.set_sensitive(True)
+        else: # Disable
+            self.grid_network_proxy_details.set_sensitive(False)
 
     def on_combobox_proxy_type_changed(self, widget):
         index = self.combobox_proxy_type.get_active()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -93,6 +93,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.refresh_episode_dates()
 
         self.on_episode_list_selection_changed_id = None
+
         observer = gpodder.config.get_network_proxy_observer(self.config)
         self.config.add_observer(observer)
         # Trigger the global gpodder.config._proxies observer contraption to initialize it.

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -93,6 +93,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.refresh_episode_dates()
 
         self.on_episode_list_selection_changed_id = None
+        observer = gpodder.config.get_network_proxy_observer(self.config)
+        self.config.add_observer(observer)
+        # Trigger the global gpodder.config._proxies observer contraption to initialize it.
+        observer("network.", None, None)
 
     def new(self):
         if self.application.want_headerbar:

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1261,7 +1261,7 @@ def urlopen(url, headers=None, data=None, timeout=None, **kwargs):
     s.mount('https://', a)
     headers.update({'User-agent': gpodder.user_agent})
     proxies = config._proxies
-    logger.debug(f"urlopen: url: {url}, proxies:{proxies}")
+    logger.debug(f"urlopen: url: {url}, proxies: {proxies}")
     return s.get(url, headers=headers, data=data, proxies=proxies, timeout=timeout, **kwargs)
 
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -62,6 +62,7 @@ import requests.exceptions
 from requests.packages.urllib3.util.retry import Retry
 
 import gpodder
+from gpodder import config
 
 logger = logging.getLogger(__name__)
 
@@ -1259,7 +1260,9 @@ def urlopen(url, headers=None, data=None, timeout=None, **kwargs):
     s.mount('http://', a)
     s.mount('https://', a)
     headers.update({'User-agent': gpodder.user_agent})
-    return s.get(url, headers=headers, data=data, timeout=timeout, **kwargs)
+    proxies = config._proxies
+    logger.debug(f"urlopen: url: {url}, proxies:{proxies}")
+    return s.get(url, headers=headers, data=data, proxies=proxies, timeout=timeout, **kwargs)
 
 
 def get_real_url(url):

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -62,7 +62,6 @@ import requests.exceptions
 from requests.packages.urllib3.util.retry import Retry
 
 import gpodder
-from gpodder import config
 
 logger = logging.getLogger(__name__)
 
@@ -1244,6 +1243,7 @@ def urlopen(url, headers=None, data=None, timeout=None, **kwargs):
     """
     An URL opener with the User-agent set to gPodder (with version)
     """
+    from gpodder import config
     if headers is None:
         headers = {}
     else:


### PR DESCRIPTION
- [x] Add proxy input to settings
- [x] Podcast download uses the proxy settings
- [x] Feed update and Add podcast should use the proxy settings
- [x] Add username and password support for proxy
- [x] Show the proxy environment variables in the proxy settings tab if they are set. (They would take effect only when "Use proxy" is disabled)
- [x] youtube-dl should use the proxy settings

Current UI:
![proxy5](https://github.com/gpodder/gpodder/assets/828670/89446503-ef0b-4645-b2f0-36810a0c0600)


Please let me know if anything needs to change.