### PR TITLE
Add color scheme (dark and light mode) support

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <!--*- mode: xml -*-->
 <interface>
   <requires lib="gtk+" version="3.16"/>
@@ -271,6 +271,50 @@
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel" id="label_color_scheme">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-end">8</property>
+                                    <property name="label" translatable="yes">Color scheme:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBoxText" id="combo_color_scheme">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="active">0</property>
+                                    <property name="active-id">1</property>
+                                    <items>
+                                      <item id="system" translatable="yes">System</item>
+                                      <item id="light" translatable="yes">Light</item>
+                                      <item id="dark" translatable="yes">Dark</item>
+                                    </items>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="pack-type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                           </object>
@@ -1157,7 +1201,6 @@
                             <property name="can-focus">False</property>
                             <property name="border-width">0</property>
                             <property name="orientation">vertical</property>
-                            <property name="spacing">0</property>
                             <child>
                               <object class="GtkTreeView" id="treeviewExtensions">
                                 <property name="visible">True</property>

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -182,6 +182,7 @@ defaults = {
             },
 
             'html_shownotes': True,  # enable webkit renderer
+            'color_scheme': None,  # system, light or dark. Initialized in app.py
         },
     },
 

--- a/src/gpodder/gtkui/config.py
+++ b/src/gpodder/gtkui/config.py
@@ -154,6 +154,13 @@ class UIConfig(config.Config):
             setattr(self, name, togglebutton.get_active())
         togglebutton.connect('toggled', _togglebutton_toggled)
 
+    def connect_gtk_combo_box_text(self, name, combo_text):
+        combo_text.set_active_id(getattr(self, name))
+
+        def _combo_box_text_changed(combo):
+            setattr(self, name, combo.get_active_id())
+        combo_text.connect('changed', _combo_box_text_changed)
+
     def connect_gtk_window(self, window, config_prefix, show_window=False):
         cfg = getattr(self.ui.gtk.state, config_prefix)
 

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -205,6 +205,21 @@ class gPodderPreferences(BuilderWidget):
         index = self.video_player_model.get_index(self._config.player.video)
         self.combo_video_player_app.set_active(index)
 
+        self.combo_color_scheme.remove_all()
+        self.combo_color_scheme.prepend('dark', 'Dark')
+        self.combo_color_scheme.prepend('light', 'Light')
+        cs = self._config.ui.gtk.color_scheme
+        if self.have_settings_portal:
+            self.combo_color_scheme.prepend('system', 'System')
+            self.combo_color_scheme.set_active_id(cs)
+        else:
+            if cs == 'system':
+                self.combo_color_scheme.set_active_id('light')
+                self._config.ui.gtk.color_scheme = 'light'
+            else:
+                self.combo_color_scheme.set_active_id(cs)
+        self._config.connect_gtk_combo_box_text('ui.gtk.color_scheme', self.combo_color_scheme)
+
         self.preferred_youtube_format_model = YouTubeVideoFormatListModel(self._config)
         self.combobox_preferred_youtube_format.set_model(self.preferred_youtube_format_model)
         cellrenderer = Gtk.CellRendererText()

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1486,6 +1486,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.update_podcast_list_model()
         elif name == 'ui.gtk.episode_list.columns':
             self.update_episode_list_columns_visibility()
+        elif name == 'ui.gtk.color_scheme':
+            if new_value == 'system':
+                self.application.read_portal_color_scheme()
+            else:
+                self.application.set_dark_mode(new_value == 'dark')
         elif name == 'limit.downloads.concurrent_max':
             # Do not allow value to be set below 1
             if new_value < 1:


### PR DESCRIPTION
Add 'ui.gtk.color_scheme' config variable with 'system', 'light' and 'dark' string values. Config observer in main.py changes the color to match the config.

System color scheme is read from freedesktop.org Settings portal via Dbus.

The setting can be changed with a combo box in the preferences window via new function connect_gtk_combo_box_text().

This fixes issue #1194, but only on Linux and with the Settings portal running.