### PR TITLE
Modernize userappsdirs

### DIFF
--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -44,7 +44,6 @@ logger = logging.getLogger(__name__)
 userappsdirs = [os.path.expanduser(p) for p in (
     '/usr/share/applications/',
     '/usr/local/share/applications/',
-    '/usr/share/applications/kde/',
     '~/.local/share/applications',
     '/var/lib/flatpak/exports/share/applications/',
     '~/.local/share/flatpak/exports/share/applications/',

--- a/src/gpodder/gtkui/desktopfile.py
+++ b/src/gpodder/gtkui/desktopfile.py
@@ -41,9 +41,14 @@ _ = gpodder.gettext
 logger = logging.getLogger(__name__)
 
 # where are the .desktop files located?
-userappsdirs = ['/usr/share/applications/',
-                '/usr/local/share/applications/',
-                '/usr/share/applications/kde/']
+userappsdirs = [os.path.expanduser(p) for p in (
+    '/usr/share/applications/',
+    '/usr/local/share/applications/',
+    '/usr/share/applications/kde/',
+    '~/.local/share/applications',
+    '/var/lib/flatpak/exports/share/applications/',
+    '~/.local/share/flatpak/exports/share/applications/',
+)]
 
 # the name of the section in the .desktop files
 sect = 'Desktop Entry'


### PR DESCRIPTION
Adds tilde expansion to userappsdirs (= the list of directories where .desktop files for players are searched).

Adds the local application dir and local and system flatpak app dirs to userappsdirs.

Removes '/usr/share/applications/kde/' which does not seem to be used in modern (post 4.0) KDE (this directory does not exist in Debian, not sure about other distros).