### PR TITLE
Extract YouTube channel ID from URL.

### DIFF
--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -432,6 +432,14 @@ def get_real_channel_url(url):
 @lru_cache(1)
 def get_channel_id_url(url, feed_data=None):
     if 'youtube.com' in url:
+        # URL may contain channel ID, avoid a network request
+        m = re.search(r'channel_id=([^"]+)', url)
+        if m:
+            # old versions of gpodder allowed newlines and whitespace in feed URLs, strip here to avoid a 404
+            channel_id = m.group(1).strip()
+            channel_url = 'https://www.youtube.com/channel/{}'.format(channel_id)
+            return channel_url
+
         try:
             if feed_data is None:
                 r = util.urlopen(url, cookies={'SOCS': 'CAI'})


### PR DESCRIPTION
The youtube-dl extension extracts channel ID from the feed URL to update channel description and coverart. When the feed URL is temporarily not available, these checks throw an error. This not only fixes the error, but also eliminates two network requests per feed update when using the extension.