### PR TITLE
Add view menu podcast and episode list checkboxes to preferences

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -324,6 +324,115 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkBox" id="vbox_view">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="border-width">12</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_podcast_list_hide_empty">
+                                <property name="label" translatable="yes">Hide podcasts without episodes</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_podcast_list_all_episodes">
+                                <property name="label" translatable="yes">"All episodes" in podcast list</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_podcast_list_sections">
+                                <property name="label" translatable="yes">Use sections for podcast list</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_episode_list_always_show_new">
+                                <property name="label" translatable="yes">Always show New Episodes</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_episode_list_trim_title_prefix">
+                                <property name="label" translatable="yes">Trim episode title prefix</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_episode_list_descriptions">
+                                <property name="label" translatable="yes">Episode descriptions</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">6</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="name">view</property>
+                            <property name="title" translatable="yes">View</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkBox" id="mygpo_config">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -488,7 +597,7 @@
                           <packing>
                             <property name="name">gpodder.net</property>
                             <property name="title" translatable="yes">gpodder.net</property>
-                            <property name="position">1</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <child>
@@ -699,7 +808,7 @@
                           <packing>
                             <property name="name">updating</property>
                             <property name="title" translatable="yes">Updating</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -788,7 +897,7 @@
                           <packing>
                             <property name="name">cleanup</property>
                             <property name="title" translatable="yes">Clean-up</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                         <child>
@@ -1083,7 +1192,7 @@
                           <packing>
                             <property name="name">devices</property>
                             <property name="title" translatable="yes">Devices</property>
-                            <property name="position">4</property>
+                            <property name="position">5</property>
                           </packing>
                         </child>
                         <child>
@@ -1192,7 +1301,7 @@
                           <packing>
                             <property name="name">video</property>
                             <property name="title" translatable="yes">Video</property>
-                            <property name="position">5</property>
+                            <property name="position">6</property>
                           </packing>
                         </child>
                         <child>
@@ -1439,7 +1548,7 @@
                           <packing>
                             <property name="name">network</property>
                             <property name="title" translatable="yes">Network</property>
-                            <property name="position">6</property>
+                            <property name="position">7</property>
                           </packing>
                         </child>
                         <child>
@@ -1470,7 +1579,7 @@
                           <packing>
                             <property name="name">extensions</property>
                             <property name="title" translatable="yes">Extensions</property>
-                            <property name="position">7</property>
+                            <property name="position">8</property>
                           </packing>
                         </child>
                       </object>

--- a/share/gpodder/ui/gtk/menus.ui
+++ b/share/gpodder/ui/gtk/menus.ui
@@ -189,14 +189,17 @@
       </section>
       <section>
         <item>
+          <!-- Also in 'vbox_view' page in preferences -->
           <attribute name="action">win.viewHideBoringPodcasts</attribute>
           <attribute name="label" translatable="yes">Hide podcasts without episodes</attribute>
         </item>
         <item>
+          <!-- Also in 'vbox_view' page in preferences -->
           <attribute name="action">win.viewShowAllEpisodes</attribute>
           <attribute name="label" translatable="yes">"All episodes" in podcast list</attribute>
         </item>
         <item>
+          <!-- Also in 'vbox_view' page in preferences -->
           <attribute name="action">win.viewShowPodcastSections</attribute>
           <attribute name="label" translatable="yes">Use sections for podcast list</attribute>
         </item>
@@ -229,14 +232,17 @@
       </section>
       <section>
         <item>
+          <!-- Also in 'vbox_view' page in preferences -->
           <attribute name="action">win.viewAlwaysShowNewEpisodes</attribute>
           <attribute name="label" translatable="yes">Always show New Episodes</attribute>
         </item>
         <item>
+          <!-- Also in 'vbox_view' page in preferences -->
           <attribute name="action">win.viewTrimEpisodeTitlePrefix</attribute>
           <attribute name="label" translatable="yes">Trim episode title prefix</attribute>
         </item>
         <item>
+          <!-- Also in 'vbox_view' page in preferences -->
           <attribute name="action">win.viewShowEpisodeDescription</attribute>
           <attribute name="label" translatable="yes">Episode descriptions</attribute>
           <attribute name="accel">&lt;Primary&gt;d</attribute>

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -268,6 +268,20 @@ class gPodderPreferences(BuilderWidget):
         self._config.connect_gtk_togglebutton('ui.gtk.find_as_you_type',
                                               self.checkbutton_find_as_you_type)
 
+        self._config.connect_gtk_togglebutton('ui.gtk.podcast_list.hide_empty',
+                                              self.checkbutton_podcast_list_hide_empty)
+        self._config.connect_gtk_togglebutton('ui.gtk.podcast_list.all_episodes',
+                                              self.checkbutton_podcast_list_all_episodes)
+        self._config.connect_gtk_togglebutton('ui.gtk.podcast_list.sections',
+                                              self.checkbutton_podcast_list_sections)
+
+        self._config.connect_gtk_togglebutton('ui.gtk.episode_list.always_show_new',
+                                              self.checkbutton_episode_list_always_show_new)
+        self._config.connect_gtk_togglebutton('ui.gtk.episode_list.trim_title_prefix',
+                                              self.checkbutton_episode_list_trim_title_prefix)
+        self._config.connect_gtk_togglebutton('ui.gtk.episode_list.descriptions',
+                                              self.checkbutton_episode_list_descriptions)
+
         self.update_interval_presets = [0, 10, 30, 60, 2 * 60, 6 * 60, 12 * 60]
         adjustment_update_interval = self.hscale_update_interval.get_adjustment()
         adjustment_update_interval.set_upper(len(self.update_interval_presets) - 1)


### PR DESCRIPTION
The View menu is pretty crowded with preference-like check boxes which control the podcast and episode list appearance. Maybe they could be added, or even moved completely to the preferences UI?

I made this patch to the adaptive version, which had no way to change these, except the config var editor. The last two episode list check boxes from the View menu are missing, because they are not applicable for the adaptive UI.

Things to be decided:

 * Should these options be moved from the View menu to Preferences, or is duplication OK?
 * If these are moved, then the `Ctrl+D` keyboard shortcut for `Episode descriptions` probably needs to be removed.
 * Should the `Right align...` and `Require control click...` items also be included?