### PR TITLE
MSYS2 no longer installs Ada and ObjC components for GCC.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,8 +18,6 @@ build_script:
   - set
   - set PATH=C:\msys64\%MSYSTEM%\bin;C:\msys64\usr\bin;%PATH%
   - set CHERE_INVOKING=yes
-  # remove precisely conflicting packages
-  - bash -lc "pacman --noconfirm --ask 20 --remove mingw-w64-x86_64-gcc-ada mingw-w64-x86_64-gcc-objc mingw-w64-i686-gcc-ada mingw-w64-i686-gcc-objc"
   # workaround updating msys2-runtime breaks all programs until last one exited
   - bash -lc "pacman -Syuu --noconfirm"
   - Powershell.exe "Stop-Process -name dirmngr -Erroraction silentlycontinue; echo killing_dirmng"


### PR DESCRIPTION
https://www.msys2.org/news/#2024-02-19-removal-of-non-cc-packages-from-the-mingw-w64-toolchain-group