### PR TITLE
Fix #1405 Group subscriptions in exported OPML files

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -313,7 +313,7 @@ class gPodderCli(object):
 
     def import_(self, url):
         for channel in opml.Importer(url).items:
-            self.subscribe(channel['url'], channel.get('title'))
+            self.subscribe(channel['url'], channel.get('title'), channel.get('section'))
 
     def export(self, filename):
         podcasts = self._model.get_podcasts()
@@ -369,7 +369,7 @@ class gPodderCli(object):
             self._error(_('You are not subscribed to %s.') % url)
         return None
 
-    def subscribe(self, url, title=None):
+    def subscribe(self, url, title=None, section=None):
         existing = self.get_podcast(url, check_only=True)
         if existing is not None:
             self._error(_('Already subscribed to %s.') % existing.url)
@@ -814,7 +814,7 @@ class gPodderCli(object):
 
             title, url = results[index - 1]
             self._info(_('Adding %s...') % title)
-            self.subscribe(url)
+            self.subscribe(url, title=title)
             if not multiple:
                 break
 

--- a/src/gpodder/directory.py
+++ b/src/gpodder/directory.py
@@ -44,12 +44,13 @@ class JustAWarning(Exception):
 
 
 class DirectoryEntry(object):
-    def __init__(self, title, url, image=None, subscribers=-1, description=None):
+    def __init__(self, title, url, image=None, subscribers=-1, description=None, section=None):
         self.title = title
         self.url = url
         self.image = image
         self.subscribers = subscribers
         self.description = description
+        self.section = section
 
 
 class DirectoryTag(object):
@@ -92,7 +93,7 @@ class Provider(object):
 
 
 def directory_entry_from_opml(url):
-    return [DirectoryEntry(d['title'], d['url'], description=d['description']) for d in opml.Importer(url).items]
+    return [DirectoryEntry(d['title'], d['url'], description=d['description'], section=d['section']) for d in opml.Importer(url).items]
 
 
 def directory_entry_from_mygpo_json(url):

--- a/src/gpodder/gtkui/desktop/podcastdirectory.py
+++ b/src/gpodder/gtkui/desktop/podcastdirectory.py
@@ -53,11 +53,15 @@ class DirectoryPodcastsModel(Gtk.ListStore):
         self.clear()
         for entry in directory_entries:
             if entry.subscribers != -1:
-                self.append((False, '%s (%d)\n<small>%s</small>' % (html.escape(entry.title),
-                    entry.subscribers, html.escape(entry.url)), entry.title, entry.url, entry.section))
+                subscribers_part = '(%d)' % entry.subscribers
             else:
-                self.append((False, '%s\n<small>%s</small>' % (html.escape(entry.title),
-                    html.escape(entry.url)), entry.title, entry.url, entry.section))
+                subscribers_part = ''
+            if entry.section:
+                section_part = '%s\n' % (html.escape(entry.section))
+            else:
+                section_part = ''
+            self.append((False, '%s%s%s\n<small>%s</small>' % (section_part, html.escape(entry.title),
+                subscribers_part, html.escape(entry.url)), entry.title, entry.url, entry.section))
         self.callback_can_subscribe(len(self.get_selected_podcasts()) > 0)
 
     def toggle(self, path):

--- a/src/gpodder/gtkui/desktop/podcastdirectory.py
+++ b/src/gpodder/gtkui/desktop/podcastdirectory.py
@@ -43,10 +43,10 @@ logger = logging.getLogger(__name__)
 
 
 class DirectoryPodcastsModel(Gtk.ListStore):
-    C_SELECTED, C_MARKUP, C_TITLE, C_URL = list(range(4))
+    C_SELECTED, C_MARKUP, C_TITLE, C_URL, C_SECTION = list(range(5))
 
     def __init__(self, callback_can_subscribe):
-        Gtk.ListStore.__init__(self, bool, str, str, str)
+        Gtk.ListStore.__init__(self, bool, str, str, str, str)
         self.callback_can_subscribe = callback_can_subscribe
 
     def load(self, directory_entries):
@@ -54,10 +54,10 @@ class DirectoryPodcastsModel(Gtk.ListStore):
         for entry in directory_entries:
             if entry.subscribers != -1:
                 self.append((False, '%s (%d)\n<small>%s</small>' % (html.escape(entry.title),
-                    entry.subscribers, html.escape(entry.url)), entry.title, entry.url))
+                    entry.subscribers, html.escape(entry.url)), entry.title, entry.url, entry.section))
             else:
                 self.append((False, '%s\n<small>%s</small>' % (html.escape(entry.title),
-                    html.escape(entry.url)), entry.title, entry.url))
+                    html.escape(entry.url)), entry.title, entry.url, entry.section))
         self.callback_can_subscribe(len(self.get_selected_podcasts()) > 0)
 
     def toggle(self, path):
@@ -70,7 +70,7 @@ class DirectoryPodcastsModel(Gtk.ListStore):
         self.callback_can_subscribe(len(self.get_selected_podcasts()) > 0)
 
     def get_selected_podcasts(self):
-        return [(row[self.C_TITLE], row[self.C_URL]) for row in self if row[self.C_SELECTED]]
+        return [(row[self.C_TITLE], row[self.C_URL], row[self.C_SECTION]) for row in self if row[self.C_SELECTED]]
 
 
 class DirectoryProvidersModel(Gtk.ListStore):
@@ -159,7 +159,7 @@ class gPodderPodcastDirectory(BuilderWidget):
         self.tv_podcasts.append_column(column)
 
         self.tv_podcasts.set_model(self.podcasts_model)
-        self.podcasts_model.append((False, 'a', 'b', 'c'))
+        self.podcasts_model.append((False, 'a', 'b', 'c', 'd'))
 
     def setup_providers_treeview(self):
         column = Gtk.TreeViewColumn('')

--- a/src/gpodder/gtkui/interface/addpodcast.py
+++ b/src/gpodder/gtkui/interface/addpodcast.py
@@ -92,4 +92,4 @@ class gPodderAddPodcast(BuilderWidget):
         self.on_btn_close_clicked(widget)
         if self.add_podcast_list is not None:
             title = None  # FIXME: Add title GUI element
-            self.add_podcast_list([(title, url)])
+            self.add_podcast_list([(title, url, None)])

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -657,11 +657,11 @@ class Directory(object):
         self.client = public.PublicClient()
 
     def toplist(self):
-        return [(p.title or p.url, p.url)
+        return [(p.title or p.url, p.url, None)
                 for p in self.client.get_toplist()
                 if p.url]
 
     def search(self, query):
-        return [(p.title or p.url, p.url)
+        return [(p.title or p.url, p.url, None)
                 for p in self.client.search_podcasts(query)
                 if p.url]

--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -75,7 +75,6 @@ class Importer(object):
             # Make sure we are dealing with a valid link type (ignore case)
             otl_type = outline.getAttribute('type')
             if otl_type is None or otl_type.lower() not in self.VALID_TYPES:
-                breakpoint()
                 otl_title = outline.getAttribute('title')
                 otl_text = outline.getAttribute('text')
                 # gPodder sections will have name == text, if OPML accepts it type=section
@@ -97,7 +96,7 @@ class Importer(object):
                         outline.getAttribute('text')
                         or outline.getAttribute('xmlUrl')
                         or outline.getAttribute('url'),
-                    'section': section or 'audio',
+                    'section': section,
                 }
 
                 if channel['description'] == channel['title']:

--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -70,10 +70,17 @@ class Importer(object):
         else:
             doc = xml.dom.minidom.parse(io.BytesIO(util.urlopen(url).content))
 
+        section = None
         for outline in doc.getElementsByTagName('outline'):
             # Make sure we are dealing with a valid link type (ignore case)
             otl_type = outline.getAttribute('type')
             if otl_type is None or otl_type.lower() not in self.VALID_TYPES:
+                breakpoint()
+                otl_title = outline.getAttribute('title')
+                otl_text = outline.getAttribute('text')
+                # gPodder sections will have name == text, if OPML accepts it type=section
+                if otl_title is not None and otl_title == otl_text:
+                    section = otl_title
                 continue
 
             if outline.getAttribute('xmlUrl') or outline.getAttribute('url'):
@@ -90,6 +97,7 @@ class Importer(object):
                         outline.getAttribute('text')
                         or outline.getAttribute('xmlUrl')
                         or outline.getAttribute('url'),
+                    'section': section or 'audio',
                 }
 
                 if channel['description'] == channel['title']:
@@ -143,6 +151,15 @@ class Exporter(object):
         outline.setAttribute('type', self.FEED_TYPE)
         return outline
 
+    def create_section(self, doc, name):
+        """
+        Creates an empty OPML outline element used to divide sections.
+        """
+        section = doc.createElement('outline')
+        section.setAttribute('title', name)
+        section.setAttribute('text', name)
+        return section
+
     def write(self, channels):
         """
         Creates a XML document containing metadata for each
@@ -169,8 +186,16 @@ class Exporter(object):
         opml.appendChild(head)
 
         body = doc.createElement('body')
+
+        sections = {}
         for channel in channels:
-            body.appendChild(self.create_outline(doc, channel))
+            if channel.section not in sections.keys():
+                sections[channel.section] = self.create_section(doc, channel.section)
+            sections[channel.section].appendChild(self.create_outline(doc, channel))
+
+        for section in sections.values():
+            body.appendChild(section)
+
         opml.appendChild(body)
 
         try:


### PR DESCRIPTION
Fix #1405 Group subscriptions in exported OPML files

also implement sections in OPML import.
Adapted from the same feature by Keeper-of-the-Keys in gpodder-core, thanks!

Now any DirectoryProvider can set the channel['section'] to have it added as is.