### PR TITLE
Fix an empty `mygpo.device.uid` to avoid mygpod failures.

### DIFF
--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -48,7 +48,7 @@ defaults = {
         'username': '',
         'password': '',
         'device': {
-            'uid': util.get_hostname(),
+            'uid': util.get_hostname_uid(),
             'type': 'desktop',
             'caption': _('gPodder on %s') % util.get_hostname(),
         },

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -202,6 +202,11 @@ class MygPoClient(object):
         self._worker_thread = None
         atexit.register(self._at_exit)
 
+        # Old versions could set uid to an empty string which causes mygpo to always fail
+        if self._config.mygpo.device.uid == '':
+            self._config.mygpo.device.uid = util.get_hostname_uid()
+            logger.warning('mygpo.device.uid was empty, initializing to "%s"' % self._config.mygpo.device.uid)
+
     def create_device(self):
         """Upload the device changes to the server.
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -41,6 +41,7 @@ import mimetypes
 import os
 import os.path
 import platform
+import random
 import re
 import shlex
 import shutil
@@ -1777,17 +1778,33 @@ def relpath(p1, p2):
 
 def get_hostname():
     """Return the hostname of this computer.
-
-    This can be implemented in a different way on each
-    platform and should yield a unique-per-user device ID.
     """
-    nodename = platform.node()
 
+    nodename = platform.node()
     if nodename:
         return nodename
 
     # Fallback - but can this give us "localhost"?
-    return socket.gethostname()
+    nodename = socket.gethostname()
+    if nodename:
+        return nodename
+
+    return 'unknown'
+
+
+def get_hostname_uid():
+    """Return the hostname of this computer and a random identifier.
+
+    This can be implemented in a different way on each
+    platform and should yield a unique-per-user device ID.
+    """
+
+    # Generate a 32-bit random identifier
+    random.seed()
+    uid = '%X' % random.getrandbits(32)
+
+    hostname = get_hostname()
+    return f'{hostname}-{uid}'
 
 
 def detect_device_type():

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1803,7 +1803,9 @@ def get_hostname_uid():
     random.seed()
     uid = '%X' % random.getrandbits(32)
 
-    hostname = get_hostname()
+    # conform to mygpo device uid limit
+    # (https://github.com/gpodder/mygpo/blob/master/mygpo/users/models.py#L235)
+    hostname = get_hostname()[:64 - len(uid) - 1]
     return f'{hostname}-{uid}'
 
 


### PR DESCRIPTION
Some platforms could return an empty hostname string. This resulted in mygpo always failing because it depends on the uid to be non-empty.

If hostname is empty, it now returns 'unknown'. It also appends a 32 digit identifier to the end of it to increase uniqueness of the uid.

Old installs are fixed by detecting an empty uid and generated a new value.

Fixes #751.
Fixes #1663.

@elelay Hostnames can be 64 to 255 characters in length, and this now appends 33 additional characters to that. It looks like uid on the server is limited to 50 characters, which doesn't even hold a valid hostname. Should I reduce the random identifier length?