### PR TITLE
Fix docstring formatting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,4 +10,4 @@ known_first_party=gpodder,soco
 
 [flake8]
 max-line-length = 142
-ignore = BLK100, CCR001, CNL100, D1, E126, E128, E402, I, W503, Q000
+ignore = BLK100, CCR001, CNL100, D1, E126, E128, E402, I, W503, Q000, SC

--- a/share/gpodder/examples/hello_world.py
+++ b/share/gpodder/examples/hello_world.py
@@ -40,9 +40,7 @@ class gPodderExtension:
         logger.info('Extension is being unloaded.')
 
     def on_ui_object_available(self, name, ui_object):
-        """
-        Called by gPodder when ui is ready.
-        """
+        """Called by gPodder when ui is ready."""
         if name == 'gpodder-gtk':
             self.gpodder = ui_object
 

--- a/share/gpodder/examples/hello_world.py
+++ b/share/gpodder/examples/hello_world.py
@@ -40,7 +40,7 @@ class gPodderExtension:
         logger.info('Extension is being unloaded.')
 
     def on_ui_object_available(self, name, ui_object):
-        """Called by gPodder when ui is ready."""
+        """Called by gPodder when ui is ready."""  # noqa: D401
         if name == 'gpodder-gtk':
             self.gpodder = ui_object
 

--- a/share/gpodder/extensions/enqueue_in_mediaplayer.py
+++ b/share/gpodder/extensions/enqueue_in_mediaplayer.py
@@ -81,9 +81,7 @@ class Win32Player(Player):
 
 
 class MPRISResumer(FreeDesktopPlayer):
-    """
-    resume episod playback at saved time
-    """
+    """Resume episode playback at saved time."""
     OBJECT_PLAYER = '/org/mpris/MediaPlayer2'
     OBJECT_DBUS = '/org/freedesktop/DBus'
     INTERFACE_PLAYER = 'org.mpris.MediaPlayer2.Player'

--- a/share/gpodder/extensions/enqueue_in_mediaplayer.py
+++ b/share/gpodder/extensions/enqueue_in_mediaplayer.py
@@ -82,6 +82,7 @@ class Win32Player(Player):
 
 class MPRISResumer(FreeDesktopPlayer):
     """Resume episode playback at saved time."""
+
     OBJECT_PLAYER = '/org/mpris/MediaPlayer2'
     OBJECT_DBUS = '/org/freedesktop/DBus'
     INTERFACE_PLAYER = 'org.mpris.MediaPlayer2.Player'

--- a/share/gpodder/extensions/filter.py
+++ b/share/gpodder/extensions/filter.py
@@ -24,13 +24,15 @@ DefaultConfig = {
 
 
 class BlockExceptFrame:
-    """
-    Utility class to manage a Block or Except frame, with sub-widgets:
+    """Utility class to manage a Block or Except frame.
+
+    With sub-widgets:
      - Creation as well as internal UI change is handled;
      - Changes to the other widget and to the model have to be handled outside.
     It's less optimized than mapping each widget to a different signal handler,
     but makes shorter code.
     """
+
     def __init__(self, value, enable_re, enable_ic, on_change_cb):
         self.on_change_cb = on_change_cb
         self.frame = Gtk.Frame()

--- a/share/gpodder/extensions/mpris-listener.py
+++ b/share/gpodder/extensions/mpris-listener.py
@@ -51,9 +51,11 @@ def subsecond_difference(usec1, usec2):
 
 
 class CurrentTrackTracker(object):
-    """An instance of this class is responsible for tracking the state of the
-    currently playing track -- it's playback status, playing position, etc.
+    """This class tracks the state of the currently playing track.
+
+    Playback status, playing position, etc.
     """
+
     def __init__(self, notifier):
         self.uri = None
         self.length = None

--- a/share/gpodder/extensions/notification-win32.py
+++ b/share/gpodder/extensions/notification-win32.py
@@ -17,9 +17,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Notification implementation for Windows
 # Sean Munkel; 2012-12-29
-"""
+"""Notification implementation for Windows.
+
 Current state (2018/07/29 ELL):
  - I can't get pywin32 to work in msys2 (the platform used for this python3/gtk3 installer)
    so existing code using COM doesn't work.

--- a/share/gpodder/extensions/podverse.py
+++ b/share/gpodder/extensions/podverse.py
@@ -61,7 +61,8 @@ class PodverseDirectoryProvider(Provider):
 
 
 class gPodderExtension:
-    """ (un)register a podverse search provider """
+    """Register and unregister a podverse search provider."""
+
     def __init__(self, container):
         pass
 

--- a/share/gpodder/extensions/rockbox_convert2mp4.py
+++ b/share/gpodder/extensions/rockbox_convert2mp4.py
@@ -101,7 +101,6 @@ class gPodderExtension:
 
     def _convert_mp4(self, episode, from_file):
         """Convert MP4 file to rockbox mpg file"""
-
         # generate new filename and check if the file already exists
         to_file = self._get_rockbox_filename(from_file)
         if to_file is None:

--- a/share/gpodder/extensions/rockbox_convert2mp4.py
+++ b/share/gpodder/extensions/rockbox_convert2mp4.py
@@ -100,7 +100,7 @@ class gPodderExtension:
         return (int(round(dest_width)), round(int(dest_height)))
 
     def _convert_mp4(self, episode, from_file):
-        """Convert MP4 file to rockbox mpg file"""
+        """Convert MP4 file to rockbox mpg file."""
         # generate new filename and check if the file already exists
         to_file = self._get_rockbox_filename(from_file)
         if to_file is None:

--- a/share/gpodder/extensions/sonos.py
+++ b/share/gpodder/extensions/sonos.py
@@ -50,8 +50,7 @@ class gPodderExtension:
                 self.speakers[uid] = speaker
 
     def _stream_to_speaker(self, speaker_uid, episodes):
-        """ Play or enqueue selected episodes """
-
+        """Play or enqueue selected episodes."""
         urls = [episode.url for episode in episodes if SONOS_CAN_PLAY(episode)]
         logger.info('Streaming to Sonos %s: %s' % (self.speakers[speaker_uid].ip_address, ', '.join(urls)))
 
@@ -65,8 +64,7 @@ class gPodderExtension:
         controller.play()
 
     def on_episodes_context_menu(self, episodes):
-        """ Adds a context menu for each Sonos speaker group """
-
+        """Add a context menu for each Sonos speaker group."""
         # Only show context menu if we can play at least one file
         if not any(SONOS_CAN_PLAY(e) for e in episodes):
             return []

--- a/share/gpodder/extensions/tagging.py
+++ b/share/gpodder/extensions/tagging.py
@@ -125,12 +125,12 @@ class AudioFile(object):
             audio.save()
 
     def insert_coverart(self):
-        """ implement the cover art logic in the subclass
-        """
+        """Implement the cover art logic in the subclass."""
         None
 
     def get_cover_picture(self, cover):
-        """ Returns mutagen Picture class for the cover image
+        """Return mutagen Picture class for the cover image.
+
         Useful for OGG and FLAC format
 
         Picture type = cover image

--- a/share/gpodder/extensions/taskbar_progress.py
+++ b/share/gpodder/extensions/taskbar_progress.py
@@ -151,7 +151,7 @@ assert alignment(tagTHUMBBUTTON) in [4, 8], alignment(tagTHUMBBUTTON)
 
 
 def consume_events():
-    """ consume pending events """
+    """Consume pending events."""
     while Gtk.events_pending():
         Gtk.main_iteration()
 

--- a/share/gpodder/extensions/ted_subtitles.py
+++ b/share/gpodder/extensions/ted_subtitles.py
@@ -31,7 +31,7 @@ class gPodderExtension(object):
         self.container = container
 
     def milli_to_srt(self, time):
-        """Converts milliseconds to srt time format."""
+        """Convert milliseconds to srt time format."""
         srt_time = timedelta(milliseconds=time)
         srt_time = str(srt_time)
         if '.' in srt_time:
@@ -43,7 +43,7 @@ class gPodderExtension(object):
         return srt_time
 
     def ted_to_srt(self, jsonstring, introduration):
-        """Converts the json object to srt format."""
+        """Convert the json object to srt format."""
         jsonobject = json.loads(jsonstring)
 
         srtContent = ''

--- a/share/gpodder/extensions/ted_subtitles.py
+++ b/share/gpodder/extensions/ted_subtitles.py
@@ -22,10 +22,11 @@ __only_for__ = 'gtk, cli'
 
 
 class gPodderExtension(object):
+    """TED Subtitle Download Extension.
+
+    Downloads ted subtitles.
     """
-    TED Subtitle Download Extension
-    Downloads ted subtitles
-    """
+
     def __init__(self, container):
         self.container = container
 

--- a/share/gpodder/extensions/ted_subtitles.py
+++ b/share/gpodder/extensions/ted_subtitles.py
@@ -31,7 +31,7 @@ class gPodderExtension(object):
         self.container = container
 
     def milli_to_srt(self, time):
-        """Converts milliseconds to srt time format"""
+        """Converts milliseconds to srt time format."""
         srt_time = timedelta(milliseconds=time)
         srt_time = str(srt_time)
         if '.' in srt_time:
@@ -43,7 +43,7 @@ class gPodderExtension(object):
         return srt_time
 
     def ted_to_srt(self, jsonstring, introduration):
-        """Converts the json object to srt format"""
+        """Converts the json object to srt format."""
         jsonobject = json.loads(jsonstring)
 
         srtContent = ''

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -60,7 +60,7 @@ PLAYLIST_RE = re.compile(r'https://www.youtube.com/feeds/videos.xml\?playlist_id
 
 
 def youtube_parsedate(s):
-    """Parse a string into a unix timestamp
+    """Parse a string into a unix timestamp.
 
     Only strings provided by youtube-dl API are
     parsed with this function (20170920).

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -98,7 +98,7 @@ class YoutubeCustomDownload(download.CustomDownload):
         self._partial_filename = val
 
     def retrieve_resume(self, tempname, reporthook=None):
-        """Called by download.DownloadTask to perform the download."""
+        """Called by download.DownloadTask to perform the download."""  # noqa: D401
         self._reporthook = reporthook
         # outtmpl: use given tempname by DownloadTask
         # (escape % because outtmpl used as a string template by youtube-dl)
@@ -495,7 +495,7 @@ class gPodderYoutubeDL(download.CustomDownloader):
         return False
 
     def custom_downloader(self, unused_config, episode):
-        """Called from registry.custom_downloader.resolve."""
+        """Called from registry.custom_downloader.resolve."""  # noqa: D401
         if not self.force and not self.my_config.manage_downloads:
             return None
 

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -71,9 +71,7 @@ def youtube_parsedate(s):
 
 
 def video_guid(video_id):
-    """
-    generate same guid as youtube
-    """
+    """Generate same guid as youtube."""
     return 'yt:video:{}'.format(video_id)
 
 
@@ -100,9 +98,7 @@ class YoutubeCustomDownload(download.CustomDownload):
         self._partial_filename = val
 
     def retrieve_resume(self, tempname, reporthook=None):
-        """
-        called by download.DownloadTask to perform the download.
-        """
+        """Called by download.DownloadTask to perform the download."""
         self._reporthook = reporthook
         # outtmpl: use given tempname by DownloadTask
         # (escape % because outtmpl used as a string template by youtube-dl)
@@ -177,9 +173,8 @@ class YoutubeCustomDownload(download.CustomDownload):
 
 
 class YoutubeFeed(model.Feed):
-    """
-    Represents the youtube feed for model.PodcastChannel
-    """
+    """Represents the youtube feed for model.PodcastChannel."""
+
     def __init__(self, url, cover_url, description, max_episodes, ie_result, downloader):
         self._url = url
         self._cover_url = cover_url
@@ -493,9 +488,7 @@ class gPodderYoutubeDL(download.CustomDownloader):
         return False
 
     def custom_downloader(self, unused_config, episode):
-        """
-        called from registry.custom_downloader.resolve
-        """
+        """Called from registry.custom_downloader.resolve."""
         if not self.force and not self.my_config.manage_downloads:
             return None
 

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -269,8 +269,8 @@ class YoutubeFeed(model.Feed):
         return episodes, all_seen_guids
 
     def get_next_page(self, channel, max_episodes):
-        """
-        Paginated feed support (RFC 5005).
+        """Paginated feed support (RFC 5005).
+
         If the feed is paged, return the next feed page.
         Returned page will in turn be asked for the next page, until None is returned.
         :return feedcore.Result: the next feed's page,
@@ -442,9 +442,10 @@ class gPodderYoutubeDL(download.CustomDownloader):
             YoutubeFeed(url, cover_url, description, max_episodes, ie_result, self))
 
     def fetch_channel(self, channel, max_episodes=0):
-        """
-        called by model.gPodderFetcher to get a custom feed.
-        :returns feedcore.Result: a YoutubeFeed or None if channel is not a youtube channel or playlist
+        """Return a custom feed. Called by model.gPodderFetcher.
+
+        :returns feedcore.Result: A YoutubeFeed or None if channel is not
+                                  a youtube channel or playlist
         """
         if not self.my_config.manage_channel:
             return None

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -76,11 +76,11 @@ def video_guid(video_id):
 
 
 class YoutubeCustomDownload(download.CustomDownload):
-    """
-    Represents the download of a single episode using youtube-dl.
+    """Represents the download of a single episode using youtube-dl.
 
     Actual youtube-dl interaction via gPodderYoutubeDL.
     """
+
     def __init__(self, ytdl, url, episode):
         self._ytdl = ytdl
         self._url = url

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -217,12 +217,18 @@ class YoutubeFeed(model.Feed):
         return self._cover_url
 
     def get_http_etag(self):
-        """ :return str: optional -- last HTTP etag header, for conditional request next time """
+        """Return the last HTTP etag header, for conditional request next time.
+
+        :return str: optional.
+        """
         # youtube-dl doesn't provide it!
         return None
 
     def get_http_last_modified(self):
-        """ :return str: optional -- last HTTP Last-Modified header, for conditional request next time """
+        """Return the last HTTP Last-Modified header, for conditional request next time.
+
+        :return str: optional
+        """
         # youtube-dl doesn't provide it!
         return None
 
@@ -317,7 +323,7 @@ class gPodderYoutubeDL(download.CustomDownloader):
             self._ydl_opts['logger'] = logger
 
     def add_format(self, gpodder_config, opts, fallback=None):
-        """ construct youtube-dl -f argument from configured format. """
+        """Construct youtube-dl -f argument from configured format."""
         # You can set a custom format or custom formats by editing the config for key
         # `youtube.preferred_fmt_ids`
         #

--- a/src/gpodder/__init__.py
+++ b/src/gpodder/__init__.py
@@ -233,11 +233,12 @@ DEFAULT_PLUGINS = [
 
 
 def load_plugins():
-    """Load (non-essential) plugin modules
+    """Load (non-essential) plugin modules.
 
     This loads a default set of plugins, but you can use
     the environment variable "GPODDER_PLUGINS" to modify
-    the list of plugins."""
+    the list of plugins.
+    """
     PLUGINS = os.environ.get('GPODDER_PLUGINS', None)
     if PLUGINS is None:
         PLUGINS = DEFAULT_PLUGINS

--- a/src/gpodder/build_info.py
+++ b/src/gpodder/build_info.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 3 of the License, or
 # (at your option) any later version.
 
-"""This file gets edited at build time to add build specific data"""
+"""This file gets edited at build time to add build specific data."""
 
 BUILD_TYPE = u"default"
 """Either 'windows', 'windows-portable', 'osx' or 'default'"""

--- a/src/gpodder/common.py
+++ b/src/gpodder/common.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 def clean_up_downloads(delete_partial=False):
-    """Clean up temporary files left behind by old gPodder versions
+    """Clean up temporary files left behind by old gPodder versions.
 
     delete_partial - If True, also delete in-progress downloads
     """
@@ -48,7 +48,7 @@ def clean_up_downloads(delete_partial=False):
 
 
 def find_partial_downloads(channels, start_progress_callback, progress_callback, final_progress_callback, finish_progress_callback):
-    """Find partial downloads and match them with episodes
+    """Find partial downloads and match them with episodes.
 
     channels - A list of all model.PodcastChannel objects
     start_progress_callback - A callback(count) when partial files are searched

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -358,9 +358,7 @@ class Config(object):
             logger.warning('Observer already added: %s', repr(callback))
 
     def remove_observer(self, callback):
-        """
-        Remove an observer previously added to this object.
-        """
+        """Remove an observer previously added to this object."""
         if callback in self.__observers:
             self.__observers.remove(callback)
         else:

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -342,9 +342,9 @@ class Config(object):
         self.__json_config._merge_keys(defaults)
 
     def add_observer(self, callback):
-        """
-        Add a callback function as observer. This callback
-        will be called when a setting changes. It should
+        """Add a callback function as observer.
+
+        This callback will be called when a setting changes. It should
         have this signature:
 
             observer(name, old_value, new_value)

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -332,8 +332,7 @@ class Config(object):
             logger.info('Appending alternate PATH: %s' % self.path.alternate)
 
     def register_defaults(self, defaults):
-        """
-        Register default configuration options (e.g. for extensions)
+        """Register default configuration options (e.g. for extensions).
 
         This function takes a dictionary that will be merged into the
         current configuration if the keys don't yet exist. This can
@@ -423,7 +422,7 @@ class Config(object):
         setattr(self, name, not getattr(self, name))
 
     def update_field(self, name, new_value):
-        """Update a config field, converting strings to the right types"""
+        """Update a config field, converting strings to the right types."""
         old_value = self._lookup(name)
         new_value = string_to_config_value(new_value, old_value)
         setattr(self, name, new_value)

--- a/src/gpodder/config.py
+++ b/src/gpodder/config.py
@@ -453,7 +453,7 @@ class Config(object):
         setattr(self.__json_config, name, value)
 
     def migrate_defaults(self):
-        """ change default values in config """
+        """Change default values in config."""
         if self.device_sync.max_filename_length == 999:
             logger.debug("setting config.device_sync.max_filename_length=120"
                          " (999 is bad for NTFS and ext{2-4})")

--- a/src/gpodder/dbsqlite.py
+++ b/src/gpodder/dbsqlite.py
@@ -57,9 +57,9 @@ class Database(object):
         self._db = None
 
     def purge(self, max_episodes, podcast_id):
-        """
-        Deletes old episodes.  Should be called
-        before adding new episodes to a podcast.
+        """Delete old episodes.
+
+        Should be called before adding new episodes to a podcast.
         """
         if max_episodes == 0:
             return
@@ -240,8 +240,8 @@ class Database(object):
             return row[0]
 
     def podcast_download_folder_exists(self, foldername):
-        """
-        Returns True if a foldername for a channel exists.
+        """Return True if a foldername for a channel exists.
+
         False otherwise.
         """
         foldername = util.convert_bytes(foldername)
@@ -250,8 +250,8 @@ class Database(object):
                 self.TABLE_PODCAST, (foldername,)) is not None
 
     def episode_filename_exists(self, podcast_id, filename):
-        """
-        Returns True if a filename for an episode exists.
+        """Return True if a filename for an episode exists.
+
         False otherwise.
         """
         filename = util.convert_bytes(filename)
@@ -264,10 +264,9 @@ class Database(object):
         return self.get('SELECT MAX(published) FROM %s WHERE podcast_id = ?' % self.TABLE_EPISODE, (podcast.id,))
 
     def delete_episode_by_guid(self, guid, podcast_id):
-        """
-        Deletes episodes that have a specific GUID for
-        a given channel. Used after feed updates for
-        episodes that have disappeared from the feed.
+        """Delete the episode which has a specific GUID for a given channel.
+
+        Used after feed updates for episodes that have disappeared from the feed.
         """
         guid = util.convert_bytes(guid)
 

--- a/src/gpodder/dbsqlite.py
+++ b/src/gpodder/dbsqlite.py
@@ -105,7 +105,7 @@ class Database(object):
                 logger.error('Cannot commit: %s', e, exc_info=True)
 
     def get_content_types(self, pid):
-        """Given a podcast ID, returns the content types"""
+        """Given a podcast ID, returns the content types."""
         with self.lock:
             cur = self.cursor()
             cur.execute('SELECT mime_type FROM %s WHERE podcast_id = ?' % self.TABLE_EPISODE, (pid,))
@@ -114,7 +114,7 @@ class Database(object):
             cur.close()
 
     def get_podcast_statistics(self, podcast_id=None):
-        """Given a podcast ID, returns the statistics for it
+        """Given a podcast ID, returns the statistics for it.
 
         If the podcast_id is omitted (using the default value), the
         statistics will be calculated over all podcasts.

--- a/src/gpodder/dbsqlite.py
+++ b/src/gpodder/dbsqlite.py
@@ -222,9 +222,7 @@ class Database(object):
             cur.close()
 
     def get(self, sql, params=None):
-        """
-        Returns the first cell of a query result, useful for COUNT()s.
-        """
+        """Return the first cell of a query result, useful for COUNT()s."""
         with self.lock:
             cur = self.cursor()
 
@@ -262,9 +260,7 @@ class Database(object):
                 self.TABLE_EPISODE, (podcast_id, filename,)) is not None
 
     def get_last_published(self, podcast):
-        """
-        Look up the most recent publish date of a podcast.
-        """
+        """Look up the most recent publish date of a podcast."""
         return self.get('SELECT MAX(published) FROM %s WHERE podcast_id = ?' % self.TABLE_EPISODE, (podcast.id,))
 
     def delete_episode_by_guid(self, guid, podcast_id):

--- a/src/gpodder/dbusproxy.py
+++ b/src/gpodder/dbusproxy.py
@@ -67,7 +67,7 @@ class DBusPodcastsProxy(dbus.service.Object):
                 bus_name=bus_name)
 
     def _get_episode_refs(self, urls):
-        """Get Episode instances associated with URLs"""
+        """Get Episode instances associated with URLs."""
         episodes = []
         for p in self._get_podcasts():
             for e in p.get_all_episodes():
@@ -77,7 +77,7 @@ class DBusPodcastsProxy(dbus.service.Object):
 
     @dbus.service.method(dbus_interface=gpodder.dbus_podcasts, in_signature='', out_signature='a(ssss)')
     def get_podcasts(self):
-        """Get all podcasts in gPodder's subscription list"""
+        """Get all podcasts in gPodder's subscription list."""
         def podcast_to_tuple(podcast):
             title = safe_str(podcast.title)
             url = safe_str(podcast.url)
@@ -99,7 +99,7 @@ class DBusPodcastsProxy(dbus.service.Object):
 
     @dbus.service.method(dbus_interface=gpodder.dbus_podcasts, in_signature='s', out_signature='a(sssssbbb)')
     def get_episodes(self, url):
-        """Return all episodes of the podcast with the given URL"""
+        """Return all episodes of the podcast with the given URL."""
         podcast = None
         for channel in self._get_podcasts():
             if channel.url == url:
@@ -125,7 +125,7 @@ class DBusPodcastsProxy(dbus.service.Object):
 
     @dbus.service.method(dbus_interface=gpodder.dbus_podcasts, in_signature='as', out_signature='(bs)')
     def play_or_download_episode(self, urls):
-        """Play (or download) a list of episodes given by URL"""
+        """Play (or download) a list of episodes given by URL."""
         episodes = self._get_episode_refs(urls)
         if not episodes:
             return (0, 'No episodes found')
@@ -143,5 +143,5 @@ class DBusPodcastsProxy(dbus.service.Object):
 
     @dbus.service.method(dbus_interface=gpodder.dbus_podcasts, in_signature='', out_signature='')
     def check_for_updates(self):
-        """Check for new episodes or offer subscriptions"""
+        """Check for new episodes or offer subscriptions."""
         self._on_check_for_updates()

--- a/src/gpodder/dbusproxy.py
+++ b/src/gpodder/dbusproxy.py
@@ -45,7 +45,7 @@ def safe_first_line(txt):
 
 
 class DBusPodcastsProxy(dbus.service.Object):
-    """ Implements API accessible through D-Bus
+    """Implements API accessible through D-Bus.
 
     Methods on DBusPodcastsProxy can be called by D-Bus clients. They implement
     safe-guards to work safely over D-Bus while having type signatures applied

--- a/src/gpodder/deviceplaylist.py
+++ b/src/gpodder/deviceplaylist.py
@@ -73,9 +73,7 @@ class gPodderDevicePlaylist(object):
         return "#EXTINF:0,%s%s" % (title.strip(), self.linebreak)
 
     def read_m3u(self):
-        """
-        read all files from the existing playlist
-        """
+        """Read all files from the existing playlist."""
         tracks = []
         logger.info("Read data from the playlistfile %s" % self.playlist_absolute_filename.get_uri())
         if self.playlist_absolute_filename.query_exists():
@@ -90,15 +88,11 @@ class gPodderDevicePlaylist(object):
         return tracks
 
     def get_filename_for_playlist(self, episode):
-        """
-        get the filename for the given episode for the playlist
-        """
+        """Get the filename for the given episode for the playlist."""
         return episode_filename_on_device(self._config, episode)
 
     def get_absolute_filename_for_playlist(self, episode):
-        """
-        get the filename including full path for the given episode for the playlist
-        """
+        """Get the filename including full path for the given episode for the playlist."""
         filename = self.get_filename_for_playlist(episode)
         foldername = episode_foldername_on_device(self._config, episode)
         if foldername:
@@ -108,9 +102,7 @@ class gPodderDevicePlaylist(object):
         return filename
 
     def write_m3u(self, episodes):
-        """
-        write the list into the playlist on the device
-        """
+        """Write the list into the playlist on the device."""
         logger.info('Writing playlist file: %s', self.playlist_file)
         if not util.make_directory(self.playlist_folder):
             raise IOError(_('Folder %s could not be created.') % self.playlist_folder, _('Error writing playlist'))

--- a/src/gpodder/directory.py
+++ b/src/gpodder/directory.py
@@ -34,10 +34,11 @@ _ = gpodder.gettext
 
 
 class JustAWarning(Exception):
-    """
-    Use this exception in providers to avoid a stack trace shown to the user.
+    """Use this exception in providers to avoid a stack trace shown to the user.
+
     Warning should be an already localized error message.
     """
+
     def __init__(self, warning):
         super().__init__(self, warning)
         self.warning = warning

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -58,9 +58,9 @@ class CustomDownload(ABC):
     @property
     @abstractmethod
     def partial_filename(self):
-        """
-        Full path to the temporary file actually being downloaded (downloaders
-        may not support setting a tempname).
+        """Full path to the temporary file actually being downloaded.
+
+        (downloaders may not support setting a tempname).
         """
         ...
 
@@ -71,7 +71,8 @@ class CustomDownload(ABC):
 
     @abstractmethod
     def retrieve_resume(self, tempname, reporthook):
-        """
+        """Download files, return (headers, real_url).
+
         :param str tempname: temporary filename for the download
         :param func(number, number, number) reporthook: callback for download progress (count, blockSize, totalSize)
         :return dict(str, str), str: (headers, real_url)
@@ -88,12 +89,11 @@ class CustomDownloader(ABC):
 
     @abstractmethod
     def custom_downloader(self, config, episode):
-        """
-        if this custom downloader has a custom download method (e.g. youtube-dl),
-        return a CustomDownload. Else return None
+        """Return a CustomDownload if this downloader has a custom download method.
+
         :param config: gpodder config (e.g. to get preferred video format)
         :param model.PodcastEpisode episode: episode to download
-        :return CustomDownload: object used to download the episode
+        :return CustomDownload: object used to download the episode or None
         """
         return None
 

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -163,9 +163,7 @@ class ContentRange(object):
 
     @classmethod
     def parse(cls, value):
-        """
-        Parse the header.  May return None if it cannot parse.
-        """
+        """Parse the header.  May return None if it cannot parse."""
         if value is None:
             return None
         value = value.strip()
@@ -471,8 +469,7 @@ class DownloadQueueManager(object):
                 return True
 
     def __spawn_threads(self):
-        """Spawn new worker threads if necessary
-        """
+        """Spawn new worker threads if necessary."""
         if not self.tasks.enabled:
             return
 
@@ -505,8 +502,7 @@ class DownloadQueueManager(object):
                 util.run_in_background(worker.run)
 
     def queue_task(self, task):
-        """Marks a task as queued
-        """
+        """Marks a task as queued."""
         self.tasks.queue_task(task)
         self.__spawn_threads()
 

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -501,7 +501,7 @@ class DownloadQueueManager(object):
                 util.run_in_background(worker.run)
 
     def queue_task(self, task):
-        """Marks a task as queued."""
+        """Mark a task as queued."""
         self.tasks.queue_task(task)
         self.__spawn_threads()
 

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -510,7 +510,7 @@ class DownloadQueueManager(object):
 
 
 class DownloadTask(object):
-    """An object representing the download task of an episode
+    """An object representing the download task of an episode.
 
     You can create a new download task like this:
 
@@ -577,12 +577,13 @@ class DownloadTask(object):
 
     The UI can call the method "notify_as_finished()" to determine if
     this episode still has still to be shown as "finished" download
-    in a notification window. This will return True only the first time
+    in a notification window. This will return True only the first time.
     it is called when the status is DONE. After returning True once,
     it will always return False afterwards.
 
     The same thing works for failed downloads ("notify_as_failed()").
     """
+
     # Possible states this download task can be in
     STATUS_MESSAGE = (_('Queued'), _('Queued'), _('Downloading'),
             _('Finished'), _('Failed'), _('Cancelling'), _('Cancelled'), _('Pausing'), _('Paused'))

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -251,7 +251,6 @@ class DownloadURLOpener:
         Resumes a download if the local filename exists and
         the server supports download resuming.
         """
-
         current_size = 0
         tfp = None
         headers = {

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -122,8 +122,7 @@ class ContentRange(object):
     # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
     # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
     # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-    """
-    Represents the Content-Range header
+    """Represents the Content-Range header.
 
     This header is ``start-stop/length``, where stop and length can be
     ``*`` (represented as None in the attributes).
@@ -154,7 +153,8 @@ class ContentRange(object):
         return 'bytes %s-%s/%s' % (self.start, stop, length)
 
     def __iter__(self):
-        """
+        """Iterate through a ContentRange.
+
         Mostly so you can unpack this, like:
 
             start, stop, length = res.content_range
@@ -246,7 +246,7 @@ class DownloadURLOpener:
 # Also based on http://mail.python.org/pipermail/python-list/2001-October/110069.html
 
     def retrieve_resume(self, url, filename, reporthook=None, data=None, disable_auth=False):
-        """Download files from an URL; return (headers, real_url)
+        """Download files from an URL; return (headers, real_url).
 
         Resumes a download if the local filename exists and
         the server supports download resuming.

--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -53,7 +53,7 @@ REDIRECT_RETRIES = 3
 
 
 class CustomDownload(ABC):
-    """ abstract class for custom downloads. DownloadTask call retrieve_resume() on it """
+    """Abstract class for custom downloads. DownloadTask call retrieve_resume() on it."""
 
     @property
     @abstractmethod
@@ -226,7 +226,7 @@ class DownloadURLOpener:
         self.max_retries = max_retries
 
     def init_session(self):
-        """ init a session with our own retry codes + retry count """
+        """Init a session with our own retry codes + retry count."""
         # I add a few retries for redirects but it means that I will allow max_retries + REDIRECT_RETRIES
         # if encountering max_retries connect and REDIRECT_RETRIES read for instance
         retry_strategy = Retry(

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -485,8 +485,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_all_episodes_downloaded(self):
-        """Called when all episodes has been downloaded
-        """
+        """Called when all episodes has been downloaded."""
 
     @call_extensions
     def on_episode_synced(self, device, episode):

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -411,14 +411,14 @@ class ExtensionManager(object):
         @param model: A gpodder.model.Model instance
         @param update_podcast_callback: Function to update a podcast feed
         @param download_episode_callback: Function to download an episode
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_podcast_subscribe(self, podcast):
         """Called when the user subscribes to a new podcast feed.
 
         @param podcast: A gpodder.model.PodcastChannel instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_podcast_updated(self, podcast):
@@ -427,7 +427,7 @@ class ExtensionManager(object):
         This extension will be called even if there were no new episodes.
 
         @param podcast: A gpodder.model.PodcastChannel instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_podcast_update_failed(self, podcast, exception):
@@ -436,7 +436,7 @@ class ExtensionManager(object):
         @param podcast: A gpodder.model.PodcastChannel instance
 
         @param exception: The reason.
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_podcast_save(self, podcast):
@@ -446,14 +446,14 @@ class ExtensionManager(object):
         the podcast or when the feed was updated.
 
         @param podcast: A gpodder.model.PodcastChannel instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_podcast_delete(self, podcast):
         """Called when a podcast is deleted from the database.
 
         @param podcast: A gpodder.model.PodcastChannel instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_episode_playback(self, episode):
@@ -463,7 +463,7 @@ class ExtensionManager(object):
         "Open" in the GUI to open an episode with the media player.
 
         @param episode: A gpodder.model.PodcastEpisode instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_episode_save(self, episode):
@@ -473,7 +473,7 @@ class ExtensionManager(object):
         database or when the state of an existing episode is changed.
 
         @param episode: A gpodder.model.PodcastEpisode instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_episode_downloaded(self, episode):
@@ -482,11 +482,11 @@ class ExtensionManager(object):
         You can retrieve the filename via episode.local_filename(False)
 
         @param episode: A gpodder.model.PodcastEpisode instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_all_episodes_downloaded(self):
-        """Called when all episodes has been downloaded."""
+        """Called when all episodes has been downloaded."""  # noqa: D401
 
     @call_extensions
     def on_episode_synced(self, device, episode):
@@ -501,7 +501,7 @@ class ExtensionManager(object):
 
         @param device: A gpodder.sync.Device instance
         @param episode: A gpodder.model.PodcastEpisode instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_create_menu(self):
@@ -514,7 +514,7 @@ class ExtensionManager(object):
         Example return value:
 
         [('Sync to Smartphone', lambda : ...)]
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_episodes_context_menu(self, episodes):
@@ -530,7 +530,7 @@ class ExtensionManager(object):
         [('Mark as new', lambda episodes: ...)]
 
         @param episodes: A list of gpodder.model.PodcastEpisode instances
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_channel_context_menu(self, channel):
@@ -544,11 +544,11 @@ class ExtensionManager(object):
 
         [('Update channel', lambda channel: ...)]
         @param channel: A gpodder.model.PodcastChannel instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_episode_delete(self, episode, filename):
-        """Called before the episode's disk file is about to be deleted."""
+        """Called before the episode's disk file is about to be deleted."""  # noqa: D401
 
     @call_extensions
     def on_episode_removed_from_podcast(self, episode):
@@ -557,7 +557,7 @@ class ExtensionManager(object):
         E.g., when the episode has not been downloaded and it disappears from the feed.
 
         @param podcast: A gpodder.model.PodcastChannel instance
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_notification_show(self, title, message):
@@ -565,14 +565,14 @@ class ExtensionManager(object):
 
         @param title: title of the notification
         @param message: message of the notification
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_download_progress(self, progress):
         """Called when the overall download progress changes.
 
         @param progress: The current progress value (0..1)
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_ui_object_available(self, name, ui_object):
@@ -583,7 +583,7 @@ class ExtensionManager(object):
 
         @param name: The name/ID of the object
         @param ui_object: The object itself
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_application_started(self):
@@ -595,7 +595,7 @@ class ExtensionManager(object):
         enabled but only on following startups.
 
         It is called after on_ui_object_available and on_ui_initialized.
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_find_partial_downloads_done(self):
@@ -605,7 +605,7 @@ class ExtensionManager(object):
         to prevent race conditions with the find_partial_downloads method.
 
         It is called after on_application_started.
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_preferences(self):
@@ -618,7 +618,7 @@ class ExtensionManager(object):
         Example return value:
 
         [('Tab name', lambda: ...)]
-        """
+        """  # noqa: D401
 
     @call_extensions
     def on_channel_settings(self, channel):
@@ -634,4 +634,4 @@ class ExtensionManager(object):
         [('Tab name', lambda channel: ...)]
 
         @param channel: A gpodder.model.PodcastChannel instance
-        """
+        """  # noqa: D401

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""
-Loads and executes user extensions
+"""Loads and executes user extensions.
 
 Extensions are Python scripts in "$GPODDER_HOME/Extensions". Each script must
 define a class named "gPodderExtension", otherwise it will be ignored.
@@ -54,7 +53,7 @@ DEFAULT_CATEGORY = _('Other')
 
 
 def call_extensions(func):
-    """Decorator to create handler functions in ExtensionManager
+    """Decorator to create handler functions in ExtensionManager.
 
     Calls the specified function in all user extensions that define it.
     """
@@ -190,7 +189,7 @@ class MissingCommand(MissingDependency):
 
 
 class ExtensionContainer(object):
-    """An extension container wraps one extension module"""
+    """An extension container wraps one extension module."""
 
     def __init__(self, manager, name, config, filename=None, module=None):
         self.manager = manager
@@ -207,7 +206,7 @@ class ExtensionContainer(object):
         self.metadata = ExtensionMetadata(self, self._load_metadata(filename))
 
     def require_command(self, command):
-        """Checks if the given command is installed on the system
+        """Checks if the given command is installed on the system.
 
         Returns the complete path of the command
 
@@ -220,7 +219,7 @@ class ExtensionContainer(object):
         return result
 
     def require_any_command(self, command_list):
-        """Checks if any of the given commands is installed on the system
+        """Checks if any of the given commands is installed on the system.
 
         Returns the complete path of first found command in the list
 
@@ -285,7 +284,7 @@ class ExtensionContainer(object):
             self.enabled = False
 
     def load_extension(self):
-        """Load and initialize the gPodder extension module"""
+        """Load and initialize the gPodder extension module."""
         if self.module is not None:
             logger.info('Module already loaded.')
             return
@@ -320,7 +319,7 @@ class ExtensionContainer(object):
 
 
 class ExtensionManager(object):
-    """Loads extensions and manages self-registering plugins"""
+    """Loads extensions and manages self-registering plugins."""
 
     def __init__(self, core):
         self.core = core
@@ -393,7 +392,7 @@ class ExtensionManager(object):
         return sorted(extensions.items())
 
     def get_extensions(self):
-        """Get a list of all loaded extensions and their enabled flag"""
+        """Get a list of all loaded extensions and their enabled flag."""
         return [c for c in self.containers
             if c.metadata.available_for_current_ui
             and not c.metadata.mandatory_in_current_ui
@@ -423,7 +422,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_podcast_updated(self, podcast):
-        """Called when a podcast feed was updated
+        """Called when a podcast feed was updatedi.
 
         This extension will be called even if there were no new episodes.
 
@@ -441,7 +440,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_podcast_save(self, podcast):
-        """Called when a podcast is saved to the database
+        """Called when a podcast is saved to the database.
 
         This extensions will be called when the user edits the metadata of
         the podcast or when the feed was updated.
@@ -451,14 +450,14 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_podcast_delete(self, podcast):
-        """Called when a podcast is deleted from the database
+        """Called when a podcast is deleted from the database.
 
         @param podcast: A gpodder.model.PodcastChannel instance
         """
 
     @call_extensions
     def on_episode_playback(self, episode):
-        """Called when an episode is played back
+        """Called when an episode is played back.
 
         This function will be called when the user clicks on "Play" or
         "Open" in the GUI to open an episode with the media player.
@@ -468,7 +467,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_episode_save(self, episode):
-        """Called when an episode is saved to the database
+        """Called when an episode is saved to the database.
 
         This extension will be called when a new episode is added to the
         database or when the state of an existing episode is changed.
@@ -478,7 +477,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_episode_downloaded(self, episode):
-        """Called when an episode has been downloaded
+        """Called when an episode has been downloaded.
 
         You can retrieve the filename via episode.local_filename(False)
 
@@ -491,7 +490,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_episode_synced(self, device, episode):
-        """Called when an episode has been synced to device
+        """Called when an episode has been synced to device.
 
         You can retrieve the filename via episode.local_filename(False)
         For MP3PlayerDevice:
@@ -506,7 +505,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_create_menu(self):
-        """Called when the Extras menu is created
+        """Called when the Extras menu is created.
 
         You can add additional Extras menu entries here. You have to return a
         list of tuples, where the first item is a label and the second item is a
@@ -519,7 +518,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_episodes_context_menu(self, episodes):
-        """Called when the episode list context menu is opened
+        """Called when the episode list context menu is opened.
 
         You can add additional context menu entries here. You have to
         return a list of tuples, where the first item is a label and
@@ -535,7 +534,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_channel_context_menu(self, channel):
-        """Called when the channel list context menu is opened
+        """Called when the channel list context menu is opened.
 
         You can add additional context menu entries here. You have to return a
         list of tuples, where the first item is a label and the second item is a
@@ -562,7 +561,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_notification_show(self, title, message):
-        """Called when a notification should be shown
+        """Called when a notification should be shown.
 
         @param title: title of the notification
         @param message: message of the notification
@@ -570,14 +569,14 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_download_progress(self, progress):
-        """Called when the overall download progress changes
+        """Called when the overall download progress changes.
 
         @param progress: The current progress value (0..1)
         """
 
     @call_extensions
     def on_ui_object_available(self, name, ui_object):
-        """Called when an UI-specific object becomes available
+        """Called when an UI-specific object becomes available.
 
         XXX: Experimental. This hook might go away without notice (and be
         replaced with something better). Only use for in-tree extensions.
@@ -600,7 +599,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_find_partial_downloads_done(self):
-        """Called when the application started and the lookout for resume is done
+        """Called when the application started and the lookout for resume is done.
 
         This is mainly for extensions scheduling refresh or downloads at startup,
         to prevent race conditions with the find_partial_downloads method.
@@ -610,7 +609,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_preferences(self):
-        """Called when the preferences dialog is opened
+        """Called when the preferences dialog is opened.
 
         You can add additional tabs to the preferences dialog here. You have to
         return a list of tuples, where the first item is a label and the second
@@ -623,7 +622,7 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_channel_settings(self, channel):
-        """Called when a channel settings dialog is opened
+        """Called when a channel settings dialog is opened.
 
         You can add additional tabs to the channel settings dialog here. You
         have to return a list of tuples, where the first item is a label and the

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -53,7 +53,7 @@ DEFAULT_CATEGORY = _('Other')
 
 
 def call_extensions(func):
-    """Decorator to create handler functions in ExtensionManager.
+    """Decorate a function to create handler in ExtensionManager.
 
     Calls the specified function in all user extensions that define it.
     """
@@ -206,7 +206,7 @@ class ExtensionContainer(object):
         self.metadata = ExtensionMetadata(self, self._load_metadata(filename))
 
     def require_command(self, command):
-        """Checks if the given command is installed on the system.
+        """Check if the given command is installed on the system.
 
         Returns the complete path of the command
 
@@ -219,7 +219,7 @@ class ExtensionContainer(object):
         return result
 
     def require_any_command(self, command_list):
-        """Checks if any of the given commands is installed on the system.
+        """Check if any of the given commands is installed on the system.
 
         Returns the complete path of first found command in the list
 

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -128,7 +128,9 @@ class ExtensionMetadata(object):
         return sorted([(k, v) for k, v in list(self.__dict__.items())], key=kf)
 
     def check_ui(self, target, default):
-        """Checks metadata information like
+        """Check metadata information.
+
+        Metadata information:
             __only_for__ = 'gtk'
             __mandatory_in__ = 'gtk'
             __disable_in__ = 'gtk'
@@ -547,14 +549,13 @@ class ExtensionManager(object):
 
     @call_extensions
     def on_episode_delete(self, episode, filename):
-        """Called just before the episode's disk file is about to be
-        deleted."""
+        """Called before the episode's disk file is about to be deleted."""
 
     @call_extensions
     def on_episode_removed_from_podcast(self, episode):
-        """Called just before the episode is about to be removed from
-        the podcast channel, e.g., when the episode has not been
-        downloaded and it disappears from the feed.
+        """Called before the episode is about to be removed from a channel.
+
+        E.g., when the episode has not been downloaded and it disappears from the feed.
 
         @param podcast: A gpodder.model.PodcastChannel instance
         """

--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -177,7 +177,7 @@ class Fetcher(object):
         raise NotImplementedError("Implement parse_feed()")
 
     def fetch(self, url, etag=None, modified=None, autodiscovery=True, **kwargs):
-        """ use kwargs to pass extra data to parse_feed in Fetcher subclasses """
+        """Use kwargs to pass extra data to parse_feed in Fetcher subclasses."""
         # handle local file first
         if url.startswith('file://'):
             url = url[len('file://'):]

--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -165,7 +165,8 @@ class Fetcher(object):
             raise UnknownStatusCode(status)
 
     def parse_feed(self, url, feed_data, data_stream, headers, status, **kwargs):
-        """
+        """Parse feed.
+
         kwargs are passed from Fetcher.fetch
         :param str url: real url
         :param data_stream: file-like object to read from (bytes mode)

--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -131,7 +131,7 @@ class Fetcher(object):
                   'text/xml')
 
     def _resolve_url(self, url):
-        """Provide additional ways of resolving an URL
+        """Provide additional ways of resolving an URL.
 
         Subclasses can override this method to provide more
         ways of resolving a given URL to a feed URL. If the

--- a/src/gpodder/feedcore.py
+++ b/src/gpodder/feedcore.py
@@ -33,7 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExceptionWithData(Exception):
-    """Base exception with additional payload"""
+    """Base exception with additional payload."""
+
     def __init__(self, data):
         Exception.__init__(self)
         self.data = data

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -48,8 +48,8 @@ N_ = gpodder.ngettext
 
 
 def parse_app_menu_for_accels(filename):
-    """
-    grab (accelerator, action) bindings from menus.ui.
+    """Grab (accelerator, action) bindings from menus.ui.
+
     See #815 Ctrl-Q doesn't quit for justification.
     Unfortunately it's not available from the Gio.MenuModel we get from the Gtk.Builder,
     so we get it ourself.

--- a/src/gpodder/gtkui/base.py
+++ b/src/gpodder/gtkui/base.py
@@ -29,9 +29,7 @@ from gi.repository import Gtk
 
 class GtkBuilderWidget(object):
     def __init__(self, ui_folders, textdomain, parent, **kwargs):
-        """
-        Loads the UI file from the specified folder (with translations
-        from the textdomain) and initializes attributes.
+        """Load the UI file from the specified folders and initialize attributes.
 
         ui_folders:
             List of folders with GtkBuilder .ui files in search order
@@ -98,14 +96,14 @@ class GtkBuilderWidget(object):
         return getattr(self, self.__class__.__name__)
 
     def new(self):
-        """
-        Method called when the user interface is loaded and ready to be used.
+        """Called when the user interface is loaded and ready to be used.
+
         At this moment, the widgets are loaded and can be referred as self.widget_name
         """
 
     def main(self):
-        """
-        Starts the main loop of processing events.
+        """Start the main loop of processing events.
+
         The default implementation calls Gtk.main()
 
         Useful for applications that needs a non gtk main loop.
@@ -118,8 +116,8 @@ class GtkBuilderWidget(object):
         Gtk.main()
 
     def quit(self):
-        """
-        Quit processing events.
+        """Quit processing events.
+
         The default implementation calls Gtk.main_quit()
 
         Useful for applications that needs a non gtk main loop.
@@ -129,8 +127,7 @@ class GtkBuilderWidget(object):
         Gtk.main_quit()
 
     def run(self):
-        """
-        Starts the main loop of processing events checking for Control-C.
+        """Start the main loop of processing events checking for Control-C.
 
         The default implementation checks whether a Control-C is pressed,
         then calls on_keyboard_interrupt().
@@ -143,7 +140,4 @@ class GtkBuilderWidget(object):
             self.on_keyboard_interrupt()
 
     def on_keyboard_interrupt(self):
-        """
-        This method is called by the default implementation of run()
-        after a program is finished by pressing Control-C.
-        """
+        """Called by the default implementation of run() after pressing Control-C."""

--- a/src/gpodder/gtkui/base.py
+++ b/src/gpodder/gtkui/base.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-UI Base Module for GtkBuilder
+"""UI Base Module for GtkBuilder.
 
 Based on SimpleGladeApp.py Copyright (C) 2004 Sandino Flores Moreno
 """
@@ -92,7 +91,7 @@ class GtkBuilderWidget(object):
 
     @property
     def main_window(self):
-        """Returns the main window of this GtkBuilderWidget"""
+        """Returns the main window of this GtkBuilderWidget."""
         return getattr(self, self.__class__.__name__)
 
     def new(self):

--- a/src/gpodder/gtkui/base.py
+++ b/src/gpodder/gtkui/base.py
@@ -98,7 +98,7 @@ class GtkBuilderWidget(object):
         """Called when the user interface is loaded and ready to be used.
 
         At this moment, the widgets are loaded and can be referred as self.widget_name
-        """
+        """  # noqa: D401
 
     def main(self):
         """Start the main loop of processing events.
@@ -139,4 +139,4 @@ class GtkBuilderWidget(object):
             self.on_keyboard_interrupt()
 
     def on_keyboard_interrupt(self):
-        """Called by the default implementation of run() after pressing Control-C."""
+        """Called by the default implementation of run() after pressing Control-C."""  # noqa: D401

--- a/src/gpodder/gtkui/base.py
+++ b/src/gpodder/gtkui/base.py
@@ -91,7 +91,7 @@ class GtkBuilderWidget(object):
 
     @property
     def main_window(self):
-        """Returns the main window of this GtkBuilderWidget."""
+        """Return the main window of this GtkBuilderWidget."""
         return getattr(self, self.__class__.__name__)
 
     def new(self):

--- a/src/gpodder/gtkui/config.py
+++ b/src/gpodder/gtkui/config.py
@@ -113,8 +113,7 @@ class UIConfig(config.Config):
         editable.connect('changed', _editable_changed)
 
     def connect_gtk_spinbutton(self, name, spinbutton, forced_upper=None):
-        """
-        bind a Gtk.SpinButton to a configuration entry.
+        """Bind a Gtk.SpinButton to a configuration entry.
 
         It's now possible to specify an upper value (forced_upper).
         It's not done automatically (always look for name + '_max') because it's

--- a/src/gpodder/gtkui/desktop/episodeselector.py
+++ b/src/gpodder/gtkui/desktop/episodeselector.py
@@ -28,7 +28,7 @@ N_ = gpodder.ngettext
 
 
 class gPodderEpisodeSelector(BuilderWidget):
-    """Episode selection dialog
+    """Episode selection dialog.
 
     Optional keyword arguments that modify the behaviour of this dialog:
 
@@ -80,6 +80,7 @@ class gPodderEpisodeSelector(BuilderWidget):
                            the text for the tooltips when hovering
                            over an episode (default is 'description')
     """
+
     COLUMN_INDEX = 0
     COLUMN_TOOLTIP = 1
     COLUMN_TOGGLE = 2

--- a/src/gpodder/gtkui/desktop/exportlocal.py
+++ b/src/gpodder/gtkui/desktop/exportlocal.py
@@ -26,7 +26,8 @@ N_ = gpodder.ngettext
 
 
 class gPodderExportToLocalFolder(BuilderWidget):
-    """ Export to Local Folder UI: file dialog + checkbox to save all to same folder """
+    """Export to Local Folder UI: file dialog + checkbox to save all to same folder."""
+
     def new(self):
         self.gPodderExportToLocalFolder.set_transient_for(self.parent_widget)
         self.RES_CANCEL = -6

--- a/src/gpodder/gtkui/desktop/exportlocal.py
+++ b/src/gpodder/gtkui/desktop/exportlocal.py
@@ -38,8 +38,8 @@ class gPodderExportToLocalFolder(BuilderWidget):
                                         'export_to_local_folder', True)
 
     def save_as(self, initial_directory, filename, remaining=0):
-        """
-        blocking method: prompt for save to local folder
+        """Prompt for save to local folder, blocking method.
+
         :param str initial_directory: folder to show to user or None
         :param str filename: default export filename
         :param int remaining: remaining episodes (to show/hide and customize checkbox label)

--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -207,7 +207,8 @@ class DownloadStatusModel(Gtk.ListStore):
 
 
 class DownloadTaskMonitor(object):
-    """A helper class that abstracts download events"""
+    """A helper class that abstracts download events."""
+
     def __init__(self, episode, on_can_resume, on_can_pause, on_finished):
         self.episode = episode
         self._status = None

--- a/src/gpodder/gtkui/download.py
+++ b/src/gpodder/gtkui/download.py
@@ -163,10 +163,7 @@ class DownloadStatusModel(Gtk.ListStore):
                         task.removed_from_list()
 
     def are_downloads_in_progress(self):
-        """
-        Returns True if there are any downloads in the
-        QUEUED or DOWNLOADING status, False otherwise.
-        """
+        """Return True if there are any downloads with QUEUED or DOWNLOADING status."""
         for row in self:
             task = row[DownloadStatusModel.C_TASK]
             if task is not None and \

--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -78,7 +78,7 @@ def draw_rounded_rectangle(ctx, x, y, w, h, r=10, left_side_width=None,
 
 
 def rounded_rectangle(ctx, x, y, width, height, radius=4.):
-    """Simple rounded rectangle algorithm.
+    """Return a rounded rectangle.
 
     http://www.cairographics.org/samples/rounded_rectangle/
     """

--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -78,7 +78,7 @@ def draw_rounded_rectangle(ctx, x, y, w, h, r=10, left_side_width=None,
 
 
 def rounded_rectangle(ctx, x, y, width, height, radius=4.):
-    """Simple rounded rectangle algorithm
+    """Simple rounded rectangle algorithm.
 
     http://www.cairographics.org/samples/rounded_rectangle/
     """

--- a/src/gpodder/gtkui/draw.py
+++ b/src/gpodder/gtkui/draw.py
@@ -311,9 +311,9 @@ def cake_size_from_widget(widget=None):
 
 
 def cairo_surface_to_pixbuf(s):
-    """
-    Converts a Cairo surface to a Gtk Pixbuf by
-    encoding it as PNG and using the PixbufLoader.
+    """Convert a Cairo surface to a Gtk Pixbuf.
+
+    Conversion is made by encoding it as PNG and using the PixbufLoader.
     """
     bio = io.BytesIO()
     try:
@@ -378,7 +378,8 @@ def progressbar_pixbuf(width, height, percentage):
 
 
 def get_background_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
-    """
+    """Get the background color.
+
     @param state state flag (e.g. Gtk.StateFlags.SELECTED to get selected background)
     @param widget specific widget to get info from.
            defaults to TreeView which has all one usually wants.
@@ -394,7 +395,8 @@ def get_background_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
 
 
 def get_foreground_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
-    """
+    """Get the foreground color.
+
     @param state state flag (e.g. Gtk.StateFlags.SELECTED to get selected text color)
     @param widget specific widget to get info from
            defaults to TreeView which has all one usually wants.
@@ -410,8 +412,8 @@ def get_foreground_color(state=Gtk.StateFlags.NORMAL, widget=Gtk.TreeView()):
 
 
 def investigate_widget_colors(type_classes_and_widgets):
-    """
-    investigate using Gtk.StyleContext to get widget style properties
+    """Investigate using Gtk.StyleContext to get widget style properties.
+
     I tried to compare values from static and live widgets.
     To sum up, better use the live widget, because you'll get the correct path, classes, regions automatically.
     See "CSS Nodes" in widget documentation for classes and sub-nodes (=regions).
@@ -484,9 +486,9 @@ def investigate_widget_colors(type_classes_and_widgets):
 
 
 def draw_iconcell_scale(column, cell, model, iterator, scale):
-    """
-    Draw cell's pixbuf to a surface with proper scaling for high resolution
-    displays. To be used as gtk.TreeViewColumn.set_cell_data_func.
+    """Draw cell's pixbuf to a surface with proper scaling for high resolution displays.
+
+    To be used as gtk.TreeViewColumn.set_cell_data_func.
 
     :param column: gtk.TreeViewColumn (ignored)
     :param cell: gtk.CellRenderer

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -284,6 +284,7 @@ class BuilderWidget(GtkBuilderWidget):
 
 class TreeViewHelper(object):
     """Container for gPodder-specific TreeView attributes."""
+
     LAST_TOOLTIP = '_gpodder_last_tooltip'
     CAN_TOOLTIP = '_gpodder_can_tooltip'
     ROLE = '_gpodder_role'
@@ -413,6 +414,7 @@ class ExtensionMenuHelper(object):
 
 
 class Dummy:
-    """A class for objects with arbitrary attributes (for imitating Gtk Events etc.)"""
+    """Class with arbitrary attributes (for imitating e.g. Gtk Events)."""
+
     def __init__(self, **kwds):
         self.__dict__.update(kwds)

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -325,7 +325,8 @@ class TreeViewHelper(object):
 
     @staticmethod
     def make_popup_position_func(widget):
-        """
+        """Make a function suitable for Gtk.Menu.popup().
+
         :return: suitable function to pass to Gtk.Menu.popup()
         It's used for instance when the popup trigger is the Menu key:
         it will position the menu on top of the selected row even if the mouse is elsewhere

--- a/src/gpodder/gtkui/interface/common.py
+++ b/src/gpodder/gtkui/interface/common.py
@@ -74,7 +74,7 @@ class BuilderWidget(GtkBuilderWidget):
         util.idle_add(self.show_message, message, title, important, widget)
 
     def get_dialog_parent(self):
-        """Return a Gtk.Window that should be the parent of dialogs"""
+        """Return a Gtk.Window that should be the parent of dialogs."""
         return self.main_window
 
     def show_message_details(self, title, message, details):
@@ -350,8 +350,7 @@ class TreeViewHelper(object):
 
     @staticmethod
     def get_popup_rectangle(treeview, event, column=0):
-        """
-        :return: Gdk.Rectangle to pass to Gtk.Popover.set_pointing_to()
+        """Return a Gdk.Rectangle to pass to Gtk.Popover.set_pointing_to().
 
         If event is given, return a zero-width and height rectangle with the
         event coordinates. If event is None, get the area of the column in the
@@ -382,7 +381,7 @@ class TreeViewHelper(object):
 
 
 class ExtensionMenuHelper(object):
-    """A helper class to handle extension submenus"""
+    """A helper class to handle extension submenus."""
 
     def __init__(self, gpodder, menu, action_prefix, gen_callback_func=None):
         self.gPodder = gpodder

--- a/src/gpodder/gtkui/interface/searchtree.py
+++ b/src/gpodder/gtkui/interface/searchtree.py
@@ -23,11 +23,12 @@ from gi.repository import Gdk, GLib  # isort:skip
 
 
 class SearchTree:
+    """Handle showing/hiding the search box for podcast or episode treeviews.
+
+    Also handles searching for text entered in the search entry.
+    Automatically attaches to entry signals on creation.
     """
-        handle showing/hiding the search box for podcast or episode treeviews,
-        as well as searching for text entered in the search entry.
-        Automatically attaches to entry signals on creation.
-    """
+
     def __init__(self, search_box, search_entry, tree, model, config):
         self.search_box = search_box
         self.search_entry = search_entry

--- a/src/gpodder/gtkui/macosx.py
+++ b/src/gpodder/gtkui/macosx.py
@@ -46,7 +46,9 @@ try:
     from AppKit import NSAppleEventDescriptor, NSAppleEventManager, NSObject
 
     class gPodderEventHandler(NSObject):
-        """ handles Apple Events for :
+        """Handle Apple Events.
+
+        Handles Apple Events for:
             - Open With... (and dropping a file on the icon)
             - "subscribe to podcast" from firefox
         The code was largely inspired by gedit-osx-delegate.m, from the

--- a/src/gpodder/gtkui/macosx.py
+++ b/src/gpodder/gtkui/macosx.py
@@ -60,7 +60,7 @@ try:
         gp = None
 
         def register(self, gp):
-            """ register all handlers with NSAppleEventManager """
+            """Register all handlers with NSAppleEventManager."""
             self.gp = gp
             aem = NSAppleEventManager.sharedAppleEventManager()
             aem.setEventHandler_andSelector_forEventClass_andEventID_(
@@ -69,7 +69,7 @@ try:
                 self, 'subscribeEvent:reply:', aeKeyword('GURL'), aeKeyword('GURL'))
 
         def openFileEvent_reply_(self, event, reply):
-            """ handles an 'Open With...' event"""
+            """Handle an 'Open With...' event."""
             urls = []
             filelist = event.paramDescriptorForKeyword_(aeKeyword(keyDirectObject))  # noqa: F405
             numberOfItems = filelist.numberOfItems()
@@ -87,7 +87,7 @@ try:
             reply.setParamDescriptor_forKeyword_(result, aeKeyword('----'))
 
         def subscribeEvent_reply_(self, event, reply):
-            """ handles a 'Subscribe to...' event"""
+            """Handle a 'Subscribe to...' event."""
             filelist = event.paramDescriptorForKeyword_(aeKeyword(keyDirectObject))  # noqa: F405
             fileURLData = filelist.data()
             url = memoryview(fileURLData.bytes(), 0, fileURLData.length())
@@ -108,6 +108,6 @@ except ImportError:
 
 
 def register_handlers(gp):
-    """ register the events handlers (and keep a reference to gPodder's instance)"""
+    """Register the events handlers (and keep a reference to gPodder's instance)."""
     if handler is not None:
         handler.register(gp)

--- a/src/gpodder/gtkui/macosx.py
+++ b/src/gpodder/gtkui/macosx.py
@@ -24,7 +24,7 @@ from gpodder import util
 
 
 def aeKeyword(fourCharCode):
-    """transform four character code into a long"""
+    """Transform four character code into a long."""
     return struct.unpack('I', fourCharCode)[0]
 
 

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2192,8 +2192,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.gPodder.set_title(new_title)
 
     def update_episode_list_icons(self, urls=None, selected=False, update_all=False):
-        """
-        Updates the status icons in the episode list.
+        """Update the status icons in the episode list.
 
         If urls is given, it should be a list of URLs
         of episodes that should be updated.

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1949,7 +1949,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
         Also called after registering a new channel cover, which is ready
         for displaying, if the cover is already downloaded.
-        """
+        """  # noqa: D401
         util.idle_add(self.podcast_list_model.add_cover_by_channel,
                 channel, pixbuf)
 
@@ -2958,7 +2958,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         """Called when the GUI wants to close the window.
 
         Displays a confirmation dialog (and closes/hides gPodder).
-        """
+        """  # noqa: D401
         if self.confirm_quit():
             self.close_gpodder()
 
@@ -2968,7 +2968,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         """Called when the GUI wants to close the window.
 
         Displays a confirmation dialog.
-        """
+        """  # noqa: D401
         downloading = self.download_status_model.are_downloads_in_progress()
 
         if downloading:
@@ -3422,7 +3422,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 [e for e in c.get_all_episodes() if e.check_is_new()]]
 
     def commit_changes_to_database(self):
-        """Called after the sync process is finished."""
+        """Called after the sync process is finished."""  # noqa: D401
         self.db.commit()
 
     def on_itemShowToolbar_activate(self, action, param):

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2993,8 +2993,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             return True
 
     def close_gpodder(self):
-        """ clean everything and exit properly
-        """
+        """Clean everything and exit properly."""
         # Cancel any running background updates of the episode list model
         self.episode_list_model.background_update = None
 

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2549,11 +2549,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
         return False
 
     def add_podcast_list(self, podcasts, auth_tokens=None):
-        """Subscribe to a list of podcast given (title, url) pairs
+        """Subscribe to a list of podcast given (title, url) pairs.
 
         If auth_tokens is given, it should be a dictionary
-        mapping URLs to (username, password) tuples."""
-
+        mapping URLs to (username, password) tuples.
+        """
         if auth_tokens is None:
             auth_tokens = {}
 
@@ -2957,20 +2957,20 @@ class gPodder(BuilderWidget, dbus.service.Object):
             util.idle_add(update_feed_cache_finish_callback, new_episodes)
 
     def on_gPodder_delete_event(self, *args):
-        """Called when the GUI wants to close the window
-        Displays a confirmation dialog (and closes/hides gPodder)
-        """
+        """Called when the GUI wants to close the window.
 
+        Displays a confirmation dialog (and closes/hides gPodder).
+        """
         if self.confirm_quit():
             self.close_gpodder()
 
         return True
 
     def confirm_quit(self):
-        """Called when the GUI wants to close the window
-        Displays a confirmation dialog
-        """
+        """Called when the GUI wants to close the window.
 
+        Displays a confirmation dialog.
+        """
         downloading = self.download_status_model.are_downloads_in_progress()
 
         if downloading:

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -491,7 +491,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 finish_progress_callback)
 
     def episode_object_by_uri(self, uri):
-        """Get an episode object given a local or remote URI
+        """Get an episode object given a local or remote URI.
 
         This can be used to quickly access an episode object
         when all we have is its download filename or episode
@@ -540,7 +540,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         return self.wNotebook.get_current_page() == 1
 
     def on_played(self, start, end, total, file_uri):
-        """Handle the "played" signal from a media player"""
+        """Handle the "played" signal from a media player."""
         if start == 0 and end == 0 and total == 0:
             # Ignore bogus play event
             return
@@ -1732,8 +1732,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.update_podcast_list_model()
 
     def format_episode_list(self, episode_list, max_episodes=10):
-        """
-        Format a list of episode names for notifications
+        """Format a list of episode names for notifications.
 
         Will truncate long episode names and limit the amount of
         episodes displayed (max_episodes=10).
@@ -2424,7 +2423,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
     def update_podcast_list_model(self, urls=None, selected=False, select_url=None,
             sections_changed=False):
-        """Update the podcast list treeview model
+        """Update the podcast list treeview model.
 
         If urls is given, it should list the URLs of each
         podcast that has to be updated in the list.
@@ -2740,7 +2739,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             util.idle_add(on_after_update)
 
     def find_episode(self, podcast_url, episode_url):
-        """Find an episode given its podcast and episode URL
+        """Find an episode given its podcast and episode URL.
 
         The function will return a PodcastEpisode object if
         the episode is found, or None if it's not found.
@@ -2754,7 +2753,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         return None
 
     def process_received_episode_actions(self):
-        """Process/merge episode actions from gpodder.net
+        """Process/merge episode actions from gpodder.net.
 
         This function will merge all changes received from
         the server to the local database and update the
@@ -3098,7 +3097,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.show_delete_episodes_window()
 
     def show_delete_episodes_window(self, channel=None):
-        """Offer deletion of episodes
+        """Offer deletion of episodes.
 
         If channel is None, offer deletion of all episodes.
         Otherwise only offer deletion of episodes in the channel.
@@ -3424,7 +3423,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 [e for e in c.get_all_episodes() if e.check_is_new()]]
 
     def commit_changes_to_database(self):
-        """This will be called after the sync process is finished"""
+        """Called after the sync process is finished."""
         self.db.commit()
 
     def on_itemShowToolbar_activate(self, action, param):
@@ -3735,7 +3734,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.show_message(message, title, important=True)
 
     def check_for_updates(self, silent):
-        """Check for updates and (optionally) show a message
+        """Check for updates and (optionally) show a message.
 
         If silent=False, a message will be shown even if no updates are
         available (set silent=False when the check is manually triggered).
@@ -3787,7 +3786,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
             self.on_itemEditChannel_activate(None)
 
     def get_selected_channels(self):
-        """Get a list of selected channels from treeChannels"""
+        """Get a list of selected channels from treeChannels."""
         selection = self.treeChannels.get_selection()
         model, paths = selection.get_selected_rows()
 
@@ -3817,11 +3816,11 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self.update_episode_list_model()
 
     def get_podcast_urls_from_selected_episodes(self):
-        """Get a set of podcast URLs based on the selected episodes"""
+        """Get a set of podcast URLs based on the selected episodes."""
         return {episode.channel.url for episode in self.get_selected_episodes()}
 
     def get_selected_episodes(self):
-        """Get a list of selected episodes from treeAvailable"""
+        """Get a list of selected episodes from treeAvailable."""
         selection = self.treeAvailable.get_selection()
         model, paths = selection.get_selected_rows()
 
@@ -3907,7 +3906,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         self._for_each_task_set_status(selected_tasks, None, False)
 
     def on_treeAvailable_row_activated(self, widget, path, view_column):
-        """Double-click/enter action handler for treeAvailable"""
+        """Double-click/enter action handler for treeAvailable."""
         self.on_shownotes_selected_episodes(widget)
 
     def restart_auto_update_timer(self):

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1946,10 +1946,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
             return True
 
     def cover_download_finished(self, channel, pixbuf):
-        """
-        The Cover Downloader calls this when it has finished
-        downloading (or registering, if already downloaded)
-        a new channel cover, which is ready for displaying.
+        """Called by Cover Downloader when it has finished downloading.
+
+        Also called after registering a new channel cover, which is ready
+        for displaying, if the cover is already downloaded.
         """
         util.idle_add(self.podcast_list_model.add_cover_by_channel,
                 channel, pixbuf)

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -262,10 +262,11 @@ class EpisodeListModel(Gtk.ListStore):
         return bool(len(self._filter))
 
     def set_view_mode(self, new_mode):
-        """Sets a new view mode for this model
+        """Sets a new view mode for this model.
 
         After setting the view mode, the filtered model
-        might be updated to reflect the new mode."""
+        might be updated to reflect the new mode.
+        """
         if self._view_mode != new_mode:
             self._view_mode = new_mode
             self._filter.refilter()
@@ -632,10 +633,11 @@ class PodcastListModel(Gtk.ListStore):
         return self._filter
 
     def set_view_mode(self, new_mode):
-        """Sets a new view mode for this model
+        """Sets a new view mode for this model.
 
         After setting the view mode, the filtered model
-        might be updated to reflect the new mode."""
+        might be updated to reflect the new mode.
+        """
         if self._view_mode != new_mode:
             self._view_mode = new_mode
             self._filter.refilter()

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -309,11 +309,10 @@ class EpisodeListModel(Gtk.ListStore):
         return ''.join(d)
 
     def replace_from_channel(self, channel):
-        """
-        Add episode from the given channel to this model.
+        """Add episode from the given channel to this model.
+
         Downloading should be a callback.
         """
-
         # Remove old episodes in the list store
         self.clear()
 

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -245,7 +245,7 @@ class EpisodeListModel(Gtk.ListStore):
         return True
 
     def get_filtered_model(self):
-        """Returns a filtered version of this episode model
+        """Return a filtered version of this episode model.
 
         The filtered version should be displayed in the UI,
         as this model can have some filters set that should
@@ -254,7 +254,7 @@ class EpisodeListModel(Gtk.ListStore):
         return self._sorter
 
     def has_episodes(self):
-        """Returns True if episodes are visible (filtered)
+        """Return True if episodes are visible (filtered).
 
         If episodes are visible with the current filter
         applied, return True (otherwise return False).
@@ -262,7 +262,7 @@ class EpisodeListModel(Gtk.ListStore):
         return bool(len(self._filter))
 
     def set_view_mode(self, new_mode):
-        """Sets a new view mode for this model.
+        """Set a new view mode for this model.
 
         After setting the view mode, the filtered model
         might be updated to reflect the new mode.
@@ -273,7 +273,7 @@ class EpisodeListModel(Gtk.ListStore):
             self._on_filter_changed(self.has_episodes())
 
     def get_view_mode(self):
-        """Returns the currently-set view mode"""
+        """Return the currently-set view mode."""
         return self._view_mode
 
     def set_search_term(self, new_term):
@@ -540,7 +540,7 @@ class PodcastChannelProxy:
             return total, deleted, new, downloaded, unplayed
 
     def get_all_episodes(self):
-        """Returns a generator that yields every episode"""
+        """Return a generator that yields every episode."""
         if self.model._search_term is not None:
             def matches(channel):
                 columns = (getattr(channel, c) for c in PodcastListModel.SEARCH_ATTRS)
@@ -624,7 +624,7 @@ class PodcastListModel(Gtk.ListStore):
         return True
 
     def get_filtered_model(self):
-        """Returns a filtered version of this episode model
+        """Return a filtered version of this episode model.
 
         The filtered version should be displayed in the UI,
         as this model can have some filters set that should
@@ -633,7 +633,7 @@ class PodcastListModel(Gtk.ListStore):
         return self._filter
 
     def set_view_mode(self, new_mode):
-        """Sets a new view mode for this model.
+        """Set a new view mode for this model.
 
         After setting the view mode, the filtered model
         might be updated to reflect the new mode.
@@ -643,7 +643,7 @@ class PodcastListModel(Gtk.ListStore):
             self._filter.refilter()
 
     def get_view_mode(self):
-        """Returns the currently-set view mode"""
+        """Return the currently-set view mode."""
         return self._view_mode
 
     def set_search_term(self, new_term):

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -494,7 +494,8 @@ class EpisodeListModel(Gtk.ListStore):
 
 
 class PodcastChannelProxy:
-    """ a bag of podcasts: 'All Episodes' or each section """
+    """A bag of podcasts: 'All Episodes' or each section."""
+
     def __init__(self, db, config, channels, section, model):
         self.ALL_EPISODES_PROXY = not bool(section)
         self._db = db

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -658,8 +658,8 @@ class PodcastListModel(Gtk.ListStore):
         self._cover_cache = {}
 
     def _resize_pixbuf_keep_ratio(self, url, pixbuf):
-        """
-        Resizes a GTK Pixbuf but keeps its aspect ratio.
+        """Resizes a GTK Pixbuf but keeps its aspect ratio.
+
         Returns None if the pixbuf does not need to be
         resized or the newly resized pixbuf if it does.
         """
@@ -739,11 +739,12 @@ class PodcastListModel(Gtk.ListStore):
         channel.save()
 
     def _get_cover_image(self, channel, add_overlay=False, pixbuf_overlay=None):
-        """ get channel's cover image. Callable from gtk thread.
-            :param channel: channel model
-            :param bool add_overlay: True to add a pause/error overlay
-            :param GdkPixbuf.Pixbux pixbuf_overlay: existing pixbuf if already loaded, as an optimization
-            :return GdkPixbuf.Pixbux: channel's cover image as pixbuf
+        """Get channel's cover image. Callable from gtk thread.
+
+        :param channel: channel model
+        :param bool add_overlay: True to add a pause/error overlay
+        :param GdkPixbuf.Pixbux pixbuf_overlay: existing pixbuf if already loaded, as an optimization
+        :return GdkPixbuf.Pixbux: channel's cover image as pixbuf
         """
         if self._cover_downloader is None:
             return pixbuf_overlay

--- a/src/gpodder/gtkui/model.py
+++ b/src/gpodder/gtkui/model.py
@@ -89,7 +89,7 @@ class GPodcast(model.PodcastChannel):
 
     @property
     def title_markup(self):
-        """ escaped title for the mass unsubscribe dialog """
+        """Escaped title for the mass unsubscribe dialog."""
         return html.escape(self.title)
 
 

--- a/src/gpodder/gtkui/services.py
+++ b/src/gpodder/gtkui/services.py
@@ -37,10 +37,9 @@ logger = logging.getLogger(__name__)
 
 
 class CoverDownloader(ObservableService):
-    """
-    This class manages downloading cover art and notification
-    of other parts of the system. Downloading cover art can
-    happen either synchronously via get_cover() or in
+    """Manages downloading cover art and notification of other parts of the system.
+
+    Downloading cover art can happen either synchronously via get_cover() or in
     asynchronous mode via request_cover(). When in async mode,
     the cover downloader will send the cover via the
     'cover-available' message (via the ObservableService).
@@ -52,9 +51,7 @@ class CoverDownloader(ObservableService):
         ObservableService.__init__(self, signal_names)
 
     def request_cover(self, channel, custom_url=None, avoid_downloading=False):
-        """
-        Sends an asynchronous request to download a
-        cover for the specific channel.
+        """Send an asynchronous request to download a cover for the specific channel.
 
         After the cover has been downloaded, the
         "cover-available" signal will be sent with
@@ -74,9 +71,7 @@ class CoverDownloader(ObservableService):
             custom_url, True, avoid_downloading))
 
     def get_cover(self, channel, custom_url=None, avoid_downloading=False):
-        """
-        Sends a synchronous request to download a
-        cover for the specified channel.
+        """Send a synchronous request to download a cover for the specified channel.
 
         The cover will be returned to the caller.
 
@@ -92,11 +87,7 @@ class CoverDownloader(ObservableService):
         return pixbuf
 
     def replace_cover(self, channel, custom_url=None):
-        """
-        This is a convenience function that deletes
-        the current cover file and requests a new
-        cover from the URL specified.
-        """
+        """Delete the current cover file and request a new cover from the URL."""
         self.request_cover(channel, custom_url)
 
     def __get_cover(self, channel, url, async_mode=False, avoid_downloading=False):

--- a/src/gpodder/gtkui/shownotes.py
+++ b/src/gpodder/gtkui/shownotes.py
@@ -272,7 +272,8 @@ class gPodderShownotesText(gPodderShownotes):
         return False
 
     def hyperlink_at_pos(self, pos):
-        """
+        """Return the hyperlink in the given position, or None.
+
         :param int pos: offset in text buffer
         :return str: hyperlink target at pos if any or None
         """

--- a/src/gpodder/jsonconfig.py
+++ b/src/gpodder/jsonconfig.py
@@ -66,8 +66,7 @@ class JsonConfig(object):
     _INDENT = 2
 
     def __init__(self, data=None, default=None, on_key_changed=None):
-        """
-        Create a new JsonConfig object
+        """Create a new JsonConfig object.
 
         data: A JSON string that contains the data to load (optional)
         default: A dict that contains default config values (optional)
@@ -111,8 +110,7 @@ class JsonConfig(object):
             self._restore(data)
 
     def _restore(self, backup):
-        """
-        Restore a previous state saved with repr()
+        """Restore a previous state saved with repr().
 
         This function allows you to "snapshot" the current values of
         the configuration and reload them later on. Any missing
@@ -142,7 +140,7 @@ class JsonConfig(object):
         return False
 
     def _merge_keys(self, merge_source):
-        """Merge keys from merge_source into this config object
+        """Merge keys from merge_source into this config object.
 
         Return True if new keys were merged, False otherwise
         """

--- a/src/gpodder/jsonconfig.py
+++ b/src/gpodder/jsonconfig.py
@@ -168,7 +168,8 @@ class JsonConfig(object):
         return added_new_key
 
     def __repr__(self):
-        """
+        """Return a string representation of this config object.
+
         >>> c = JsonConfig('{"a": 1}')
         >>> print(c)
         {

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -77,8 +77,8 @@ class Feed:
         return None
 
     def get_new_episodes(self, channel, existing_guids):
-        """
-        Produce new episodes and update old ones.
+        """Produce new episodes and update old ones.
+
         Feed is a class to present results, so the feed shall have already been fetched.
         Existing episodes not in all_seen_guids will be purged from the database.
         :param PodcastChannel channel: the updated channel
@@ -88,8 +88,8 @@ class Feed:
         return ([], set())
 
     def get_next_page(self, channel, max_episodes):
-        """
-        Paginated feed support (RFC 5005).
+        """Paginated feed support (RFC 5005).
+
         If the feed is paged, return the next feed page.
         Returned page will in turn be asked for the next page, until None is returned.
         :return feedcore.Result: the next feed's page,
@@ -245,9 +245,10 @@ class PodcastModelObject(object):
 
     @classmethod
     def create_from_dict(cls, d, *args):
-        """
-        Create a new object, passing "args" to the constructor
-        and then updating the object with the values from "d".
+        """Create a podcast model from constructor args and dict.
+
+        Passes "args" to the constructor and then updates the object with
+        the values from "d".
         """
         o = cls(*args)
 
@@ -498,7 +499,8 @@ class PodcastEpisode(PodcastModelObject):
                 and os.path.exists(self.download_task.custom_downloader.partial_filename))
 
     def can_stream(self, config):
-        """
+        """Return True if episode can be streamed.
+
         Don't try streaming if the user has not defined a player
         or else we would probably open the browser when giving a URL to xdg-open.
         We look at the audio or video player depending on its file type.
@@ -507,7 +509,8 @@ class PodcastEpisode(PodcastModelObject):
         return player and player != 'default'
 
     def can_download(self):
-        """
+        """Return True if episode can be downloaded.
+
         gPodder.on_download_selected_episodes() filters selection with this method.
         PAUSING and PAUSED tasks can be resumed.
         """
@@ -525,12 +528,17 @@ class PodcastEpisode(PodcastModelObject):
         return self.download_task is not None and self.download_task.can_cancel()
 
     def can_delete(self):
-        """gPodder.delete_episode_list() filters out locked episodes, and cancels all unlocked tasks in selection."""
+        """Return True, if episode can be deleted.
+
+        gPodder.delete_episode_list() filters out locked episodes,
+        and cancels all unlocked tasks in selection.
+        """
         return self.state != gpodder.STATE_DELETED and not self.archive and (
             self.download_task is None or self.download_task.status == self.download_task.FAILED)
 
     def can_lock(self):
-        """
+        """Return True, if episode can be locked.
+
         gPodder.on_item_toggle_lock_activate() unlocks deleted episodes and toggles all others.
         Locked episodes can always be unlocked.
         """
@@ -1127,7 +1135,8 @@ class PodcastChannel(PodcastModelObject):
             return tmp
 
     def episode_factory(self, d):
-        """
+        """Create a PodcastEpisode from a dict.
+
         This function takes a dictionary containing key-value pairs for
         episodes and returns a new PodcastEpisode object that is connected
         to this object.

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -46,34 +46,34 @@ _ = gpodder.gettext
 
 
 class Feed:
-    """ abstract class for presenting a parsed feed to PodcastChannel """
+    """Abstract class for presenting a parsed feed to PodcastChannel."""
 
     def get_title(self):
-        """ :return str: the feed's title """
+        """Return the feeds title or None."""
         return None
 
     def get_link(self):
-        """ :return str: link to the feed's website """
+        """Return the link to the feeds website or None."""
         return None
 
     def get_description(self):
-        """ :return str: feed's textual description """
+        """Return the feeds textual description or None."""
         return None
 
     def get_cover_url(self):
-        """ :return str: url of the feed's cover image """
+        """Return the URL of the feeds cover image or None."""
         return None
 
     def get_payment_url(self):
-        """ :return str: optional -- feed's payment url """
+        """Return the feeds payment url or None."""
         return None
 
     def get_http_etag(self):
-        """ :return str: optional -- last HTTP etag header, for conditional request next time """
+        """Return the last HTTP etag header, for conditional request next time, or None."""
         return None
 
     def get_http_last_modified(self):
-        """ :return str: optional -- last HTTP Last-Modified header, for conditional request next time """
+        """Return the last HTTP Last-Modified header, for conditional request next time, or None"""
         return None
 
     def get_new_episodes(self, channel, existing_guids):

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -197,10 +197,8 @@ class PodcastParserFeed(Feed):
 
 
 class gPodderFetcher(feedcore.Fetcher):
-    """
-    This class implements fetching a channel from custom feed handlers
-    or the default using podcastparser
-    """
+    """Implements fetching a channel from custom feed handlers or the default using podcastparser."""
+
     def fetch_channel(self, channel, max_episodes):
         custom_feed = registry.feed_handler.resolve(channel, None, max_episodes)
         if custom_feed is not None:
@@ -241,10 +239,8 @@ class gPodderFetcher(feedcore.Fetcher):
 
 
 class PodcastModelObject(object):
-    """
-    A generic base class for our podcast model providing common helper
-    and utility functions.
-    """
+    """A generic base class for our podcast model providing common helper and utility functions."""
+
     __slots__ = ('id', 'parent', 'children')
 
     @classmethod
@@ -263,7 +259,8 @@ class PodcastModelObject(object):
 
 
 class PodcastEpisode(PodcastModelObject):
-    """holds data for one object in a channel"""
+    """Holds data for one object in a channel."""
+
     # In theory, Linux can have 255 bytes (not characters!) in a filename, but
     # filesystems like eCryptFS store metadata in the filename, making the
     # effective number of characters less than that. eCryptFS recommends

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -489,9 +489,7 @@ class PodcastEpisode(PodcastModelObject):
         return player
 
     def can_play(self, config):
-        """
-        # gPodder.playback_episodes() filters selection with this method.
-        """
+        """# gPodder.playback_episodes() filters selection with this method."""
         return (self.was_downloaded(and_exists=True)
                 or self.can_preview()
                 or self.can_stream(config))
@@ -522,21 +520,15 @@ class PodcastEpisode(PodcastModelObject):
             or self.download_task.status == self.download_task.PAUSING)
 
     def can_pause(self):
-        """
-        gPodder.on_pause_selected_episodes() filters selection with this method.
-        """
+        """gPodder.on_pause_selected_episodes() filters selection with this method."""
         return self.download_task is not None and self.download_task.can_pause()
 
     def can_cancel(self):
-        """
-        DownloadTask.cancel() only cancels the following tasks.
-        """
+        """DownloadTask.cancel() only cancels the following tasks."""
         return self.download_task is not None and self.download_task.can_cancel()
 
     def can_delete(self):
-        """
-        gPodder.delete_episode_list() filters out locked episodes, and cancels all unlocked tasks in selection.
-        """
+        """gPodder.delete_episode_list() filters out locked episodes, and cancels all unlocked tasks in selection."""
         return self.state != gpodder.STATE_DELETED and not self.archive and (
             self.download_task is None or self.download_task.status == self.download_task.FAILED)
 
@@ -821,9 +813,7 @@ class PodcastEpisode(PodcastModelObject):
 
     @property
     def pubtime(self):
-        """
-        Returns published time as HHMM (or 0000 if not available)
-        """
+        """Return published time as HHMM (or 0000 if not available)."""
         try:
             return datetime.datetime.fromtimestamp(self.published).strftime('%H%M')
         except:

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -73,7 +73,7 @@ class Feed:
         return None
 
     def get_http_last_modified(self):
-        """Return the last HTTP Last-Modified header, for conditional request next time, or None"""
+        """Return the last HTTP Last-Modified header, for conditional request next time, or None."""
         return None
 
     def get_new_episodes(self, channel, existing_guids):
@@ -418,7 +418,7 @@ class PodcastEpisode(PodcastModelObject):
 
     @property
     def trimmed_title(self):
-        """Return the title with the common prefix trimmed"""
+        """Return the title with the common prefix trimmed."""
         # Minimum amount of leftover characters after trimming. This
         # avoids things like "Common prefix 123" to become just "123".
         # If there are LEFTOVER_MIN or less characters after trimming,
@@ -629,7 +629,7 @@ class PodcastEpisode(PodcastModelObject):
         self.set_state(gpodder.STATE_DELETED)
 
     def get_playback_url(self, config=None, allow_partial=False):
-        """Local (or remote) playback/streaming filename/URL
+        """Local (or remote) playback/streaming filename/URL.
 
         Returns either the local filename or a streaming URL that
         can be used to playback this episode.
@@ -658,7 +658,7 @@ class PodcastEpisode(PodcastModelObject):
 
     def local_filename(self, create, force_update=False, check_only=False,
             template=None, return_wanted_filename=False):
-        """Get (and possibly generate) the local saving filename
+        """Get (and possibly generate) the local saving filename.
 
         Pass create=True if you want this function to generate a
         new filename if none exists. You only want to do this when
@@ -826,7 +826,7 @@ class PodcastEpisode(PodcastModelObject):
             return '0000'
 
     def playlist_title(self):
-        """Return a title for this episode in a playlist
+        """Return a title for this episode in a playlist.
 
         The title will be composed of the podcast name, the
         episode name and the publication date. The return
@@ -873,7 +873,7 @@ class PodcastEpisode(PodcastModelObject):
         return self.published_datetime().strftime('%y')
 
     def is_finished(self):
-        """Return True if this episode is considered "finished playing"
+        """Return True if this episode is considered "finished playing".
 
         An episode is considered "finished" when there is a
         current position mark on the track, and when the
@@ -1000,7 +1000,7 @@ class PodcastChannel(PodcastModelObject):
         return new_url
 
     def check_download_folder(self):
-        """Check the download folder for externally-downloaded files
+        """Check the download folder for externally-downloaded files.
 
         This will try to assign downloaded files with episodes in the
         database.
@@ -1540,9 +1540,9 @@ class Model(object):
 
     @classmethod
     def sort_episodes_by_pubdate(cls, episodes, reverse=False):
-        """Sort a list of PodcastEpisode objects chronologically
+        """Sort a list of PodcastEpisode objects chronologically.
 
-        Returns a iterable, sorted sequence of the episodes
+        Returns a iterable, sorted sequence of the episodes.
         """
         return sorted(episodes, key=cls.episode_sort_key, reverse=reverse)
 

--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -487,7 +487,7 @@ class PodcastEpisode(PodcastModelObject):
         return player
 
     def can_play(self, config):
-        """# gPodder.playback_episodes() filters selection with this method."""
+        """gPodder.playback_episodes() filters selection with this method."""
         return (self.was_downloaded(and_exists=True)
                 or self.can_preview()
                 or self.can_stream(config))

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -203,7 +203,7 @@ class MygPoClient(object):
         atexit.register(self._at_exit)
 
     def create_device(self):
-        """Uploads the device changes to the server
+        """Uploads the device changes to the server.
 
         This should be called when device settings change
         or when the mygpo client functionality is enabled.
@@ -218,7 +218,7 @@ class MygPoClient(object):
         self._store.save(action)
 
     def get_rewritten_urls(self):
-        """Returns a list of rewritten URLs for uploads
+        """Returns a list of rewritten URLs for uploads.
 
         This should be called regularly. Every object returned
         should be merged into the database, and the old_url
@@ -229,7 +229,7 @@ class MygPoClient(object):
         return rewritten_urls
 
     def process_episode_actions(self, find_episode, on_updated=None):
-        """Process received episode actions
+        """Process received episode actions.
 
         The parameter "find_episode" should be a function accepting
         two parameters (podcast_url and episode_url). It will be used
@@ -284,7 +284,7 @@ class MygPoClient(object):
         logger.debug('Received episode actions processed.')
 
     def get_received_actions(self):
-        """Returns a list of ReceivedSubscribeAction objects
+        """Returns a list of ReceivedSubscribeAction objects.
 
         The list might be empty. All these actions have to
         be processed. The user should confirm which of these
@@ -297,7 +297,7 @@ class MygPoClient(object):
         return self._store.load(ReceivedSubscribeAction)
 
     def confirm_received_actions(self, actions):
-        """Confirm that a list of actions has been processed
+        """Confirm that a list of actions has been processed.
 
         The UI should call this with a list of actions that
         have been accepted by the user and processed by the
@@ -307,7 +307,7 @@ class MygPoClient(object):
         self._store.remove(actions)
 
     def reject_received_actions(self, actions):
-        """Reject (undo) a list of ReceivedSubscribeAction objects
+        """Reject (undo) a list of ReceivedSubscribeAction objects.
 
         The UI should call this with a list of actions that
         have been rejected by the user. A reversed set of

--- a/src/gpodder/my.py
+++ b/src/gpodder/my.py
@@ -203,7 +203,7 @@ class MygPoClient(object):
         atexit.register(self._at_exit)
 
     def create_device(self):
-        """Uploads the device changes to the server.
+        """Upload the device changes to the server.
 
         This should be called when device settings change
         or when the mygpo client functionality is enabled.
@@ -218,7 +218,7 @@ class MygPoClient(object):
         self._store.save(action)
 
     def get_rewritten_urls(self):
-        """Returns a list of rewritten URLs for uploads.
+        """Return a list of rewritten URLs for uploads.
 
         This should be called regularly. Every object returned
         should be merged into the database, and the old_url
@@ -284,7 +284,7 @@ class MygPoClient(object):
         logger.debug('Received episode actions processed.')
 
     def get_received_actions(self):
-        """Returns a list of ReceivedSubscribeAction objects.
+        """Return a list of ReceivedSubscribeAction objects.
 
         The list might be empty. All these actions have to
         be processed. The user should confirm which of these

--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -151,9 +151,7 @@ class Exporter(object):
         return outline
 
     def create_section(self, doc, name):
-        """
-        Creates an empty OPML outline element used to divide sections.
-        """
+        """Create an empty OPML outline element used to divide sections."""
         section = doc.createElement('outline')
         section.setAttribute('title', name)
         section.setAttribute('text', name)

--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -26,7 +26,7 @@
 #            libopmlwriter.py (2005-12-08)
 #
 
-"""OPML import and export functionality
+"""OPML import and export functionality.
 
 This module contains helper classes to import subscriptions
 from OPML files on the web and to export a list of channel

--- a/src/gpodder/opml.py
+++ b/src/gpodder/opml.py
@@ -48,7 +48,8 @@ logger = logging.getLogger(__name__)
 
 
 class Importer(object):
-    """
+    """Import an OPML feed and return a GTK ListStore.
+
     Helper class to import an OPML feed from protocols
     supported by urllib2 (e.g. HTTP) and return a GTK
     ListStore that can be displayed in the GUI.
@@ -60,9 +61,9 @@ class Importer(object):
     VALID_TYPES = ('rss', 'link')
 
     def __init__(self, url):
-        """
-        Parses the OPML feed from the given URL into
-        a local data structure containing channel metadata.
+        """Parse an OPML feed from an URL.
+
+        Parses the feed into a local data structure containing channel metadata.
         """
         self.items = []
         if os.path.exists(url):
@@ -111,9 +112,7 @@ class Importer(object):
 
 
 class Exporter(object):
-    """
-    Helper class to export a list of channel objects
-    to a local file in OPML 1.1 format.
+    """Export a list of channel objects to a local file in OPML 1.1 format.
 
     See www.opml.org for the OPML specification.
     """
@@ -129,20 +128,16 @@ class Exporter(object):
             self.filename = '%s.opml' % (filename, )
 
     def create_node(self, doc, name, content):
-        """
-        Creates a simple XML Element node in a document
-        with tag name "name" and text content "content",
-        as in <name>content</name> and returns the element.
+        """Return an XML Element node with tag name "name" and text content "content".
+
+        E.g. <name>content</name>.
         """
         node = doc.createElement(name)
         node.appendChild(doc.createTextNode(content))
         return node
 
     def create_outline(self, doc, channel):
-        """
-        Creates a OPML outline as XML Element node in a
-        document for the supplied channel.
-        """
+        """Return an OPML outline as XML Element node in the supplied document."""
         outline = doc.createElement('outline')
         outline.setAttribute('title', channel.title)
         outline.setAttribute('text', channel.description)
@@ -158,10 +153,7 @@ class Exporter(object):
         return section
 
     def write(self, channels):
-        """
-        Creates a XML document containing metadata for each
-        channel object in the "channels" parameter, which
-        should be a list of channel objects.
+        """Write an XML document containing metadata for each channel in channels.
 
         OPML 2.0 specification: http://www.opml.org/spec2
 

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 def soundcloud_parsedate(s):
-    """Parse a string into a unix timestamp
+    """Parse a string into a unix timestamp.
 
     Only strings provided by Soundcloud's API are
     parsed with this function (2009/11/03 13:37:00).
@@ -53,7 +53,7 @@ def soundcloud_parsedate(s):
 
 
 def get_metadata(url):
-    """Get file download metadata
+    """Get file download metadata.
 
     Returns a (size, type, name) from the given download
     URL. Will use the network connection to determine the

--- a/src/gpodder/plugins/soundcloud.py
+++ b/src/gpodder/plugins/soundcloud.py
@@ -125,10 +125,11 @@ class SoundcloudUser(object):
         return user_info.get('id', None)
 
     def get_tracks(self, feed):
-        """Get a generator of tracks from a SC user
+        """Get a generator of tracks from a SC user.
 
         The generator will give you a dictionary for every
-        track it can find for its user."""
+        track it can find for its user.
+        """
         global CONSUMER_KEY
         try:
             json_url = ('https://api.soundcloud.com/users/%(user)s/%(feed)s.'

--- a/src/gpodder/query.py
+++ b/src/gpodder/query.py
@@ -29,7 +29,7 @@ import gpodder
 
 
 class Matcher(object):
-    """Match implementation for EQL
+    """Match implementation for EQL.
 
     This class implements the low-level matching of
     EQL statements against episode objects.
@@ -137,7 +137,7 @@ class Matcher(object):
 
 
 class EQL(object):
-    """A Query in EQL
+    """A Query in EQL.
 
     Objects of this class represent a query on episodes
     using EQL. Example usage:

--- a/src/gpodder/query.py
+++ b/src/gpodder/query.py
@@ -235,13 +235,12 @@ class EQL(object):
 
 
 def UserEQL(query):
-    """EQL wrapper for user input
+    """EQL wrapper for user input.
 
     Automatically adds missing quotes around a
     non-EQL string for user-based input. In this
     case, EQL queries need to be enclosed in ().
     """
-
     if query is None:
         return None
 

--- a/src/gpodder/schema.py
+++ b/src/gpodder/schema.py
@@ -243,12 +243,11 @@ def upgrade(db, filename):
 
 
 def convert_gpodder2_db(old_db, new_db):
-    """Convert gPodder 2.x databases to the new format
+    """Convert gPodder 2.x databases to the new format.
 
     Both arguments should be SQLite3 connections to the
     corresponding databases.
     """
-
     old_db = sqlite.connect(old_db)
     new_db_filename = new_db
     new_db = sqlite.connect(new_db)

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -106,7 +106,8 @@ def get_track_length(filename):
 
 
 def episode_filename_on_device(config, episode):
-    """
+    """Return the basename of the episode file to save on device.
+
     :param gpodder.config.Config config: configuration (for sync options)
     :param gpodder.model.PodcastEpisode episode: episode to get filename for
     :return str: basename minus extension to use to save episode on device
@@ -130,7 +131,8 @@ def episode_filename_on_device(config, episode):
 
 
 def episode_foldername_on_device(config, episode):
-    """
+    """Return the folder name to which the episode is saved on device.
+
     :param gpodder.config.Config config: configuration (for sync options)
     :param gpodder.model.PodcastEpisode episode: episode to get folder name for
     :return str: folder name to save episode to on device

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -146,9 +146,9 @@ def episode_foldername_on_device(config, episode):
 
 
 class SyncTrack(object):
-    """
-    This represents a track that is on a device. You need
-    to specify at least the following keyword arguments,
+    """Class representing a track that is on a device.
+
+    You need to specify at least the following keyword arguments,
     because these will be used to display the track in the
     GUI. All other keyword arguments are optional and can
     be used to reference internal objects, etc... See the
@@ -162,6 +162,7 @@ class SyncTrack(object):
     passed to the function (the values will default to None
     for all required fields).
     """
+
     def __init__(self, title, length, modified, **kwargs):
         self.title = title
         self.length = length

--- a/src/gpodder/syncui.py
+++ b/src/gpodder/syncui.py
@@ -66,7 +66,7 @@ class gPodderSyncUI(object):
         self.mount_volume_for_file = mount_volume_for_file
 
     def _filter_sync_episodes(self, channels, only_downloaded=False):
-        """Return a list of episodes for device synchronization
+        """Return a list of episodes for device synchronization.
 
         If only_downloaded is True, this will skip episodes that
         have not been downloaded yet and podcasts that are marked

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -152,9 +152,7 @@ _MIME_TYPES_EXT = dict(_MIME_TYPE_LIST)
 
 
 def is_absolute_url(url):
-    """
-    Check if url is an absolute url (i.e. has a scheme)
-    """
+    """Check if url is an absolute url (i.e. has a scheme)."""
     try:
         parsed = urllib.parse.urlparse(url)
         # fix #1190: when parsing a windows path, scheme=drive_letter, path=\rest_of_path
@@ -164,9 +162,7 @@ def is_absolute_url(url):
 
 
 def new_gio_file(path):
-    """
-    Create a new Gio.File given a path or uri
-    """
+    """Create a new Gio.File given a path or uri."""
     from gi.repository import Gio
 
     if is_absolute_url(path):
@@ -476,9 +472,7 @@ def file_age_to_string(days):
 
 
 def is_system_file(filename):
-    """
-    Checks to see if the given file is a system file.
-    """
+    """Check if the given file is a system file."""
     if gpodder.ui.win32 and win32file is not None:
         result = win32file.GetFileAttributes(filename)
         # -1 / 0xffffffff is returned by GetFileAttributes when an error occurs
@@ -841,9 +835,7 @@ def extract_hyperlinked_text(html):
 
 
 def nice_html_description(img, description):
-    """
-    basic html formatting + hyperlink highlighting + video thumbnail
-    """
+    """Basic html formatting + hyperlink highlighting + video thumbnail."""
     description = re.sub(r'https?://[^\s]+', r'<a href="\g<0>">\g<0></a>', description)
     description = description.replace('\n', '<br>')
     html = """<style type="text/css">
@@ -1240,9 +1232,7 @@ def url_add_authentication(url, username, password):
 
 
 def urlopen(url, headers=None, data=None, timeout=None, **kwargs):
-    """
-    An URL opener with the User-agent set to gPodder (with version)
-    """
+    """Open an URL with the User-agent set to gPodder (with version)."""
     from gpodder import config
     if headers is None:
         headers = {}
@@ -1266,9 +1256,7 @@ def urlopen(url, headers=None, data=None, timeout=None, **kwargs):
 
 
 def get_real_url(url):
-    """
-    Gets the real URL of a file and resolves all redirects.
-    """
+    """Get the real URL of a file and resolves all redirects."""
     try:
         return urlopen(url).url
     except:
@@ -1380,16 +1368,12 @@ class IdleTimeout(object):
 
 
 def lerp(a, b, f):
-    """Linear interpolation between 'a' and 'b', where 'f' is between 0.0 and 1.0
-    """
+    """Linear interpolation between 'a' and 'b', where 'f' is between 0.0 and 1.0."""
     return ((1.0 - f) * a) + (f * b)
 
 
 def bluetooth_available():
-    """
-    Returns True or False depending on the availability
-    of bluetooth functionality on the system.
-    """
+    """Return True or False depending on the availability of bluetooth functionality on the system."""
     if find_command('bluetooth-sendto') or \
             find_command('gnome-obex-send'):
         return True
@@ -1596,9 +1580,7 @@ def open_website(url):
 
 
 def copy_text_to_clipboard(text):
-    """
-    Copies the specified text to both clipboards.
-    """
+    """Copies the specified text to both clipboards."""
     import gi
     gi.require_version('Gtk', '3.0')
     from gi.repository import Gdk, Gtk
@@ -1610,8 +1592,7 @@ def copy_text_to_clipboard(text):
 
 
 def convert_bytes(d):
-    """
-    Convert byte strings to unicode strings
+    """Convert byte strings to unicode strings.
 
     This function will decode byte strings into unicode
     strings. Any other data types will be left alone.
@@ -2066,9 +2047,7 @@ def connection_available():
 
 
 def website_reachable(url):
-    """
-    Check if a specific website is available.
-    """
+    """Check if a specific website is available."""
     if not connection_available():
         # No network interfaces up - assume website not reachable
         return (False, None)

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -499,14 +499,12 @@ def get_free_disk_space_win32(path):
 
 
 def get_free_disk_space(path):
-    """
-    Calculates the free disk space available to the current user
+    """Calculates the free disk space available to the current user
     on the file system that contains the given path.
 
     If the path (or its parent folder) does not yet exist, this
     function returns zero.
     """
-
     if not os.path.exists(path):
         return -1
 
@@ -1265,16 +1263,15 @@ def get_real_url(url):
 
 
 def find_command(command):
-    """
-    Searches the system's PATH for a specific command that is
-    executable by the user. Returns the first occurrence of an
+    """Search the PATH for a specific command that is executable by the user.
+
+    Returns the first occurrence of an
     executable binary in the PATH, or None if the command is
     not available.
 
     On Windows, this also looks for "<command>.bat" and
     "<command>.exe" files if "<command>" itself doesn't exist.
     """
-
     if 'PATH' not in os.environ:
         return None
 
@@ -1476,9 +1473,7 @@ def parse_time(value):
 
 
 def format_seconds_to_hour_min_sec(seconds):
-    """
-    Take the number of seconds and format it into a
-    human-readable string (duration).
+    """Format the number of seconds into a human-readable string (duration).
 
     >>> format_seconds_to_hour_min_sec(3834)
     '1 hour, 3 minutes and 54 seconds'
@@ -1487,7 +1482,6 @@ def format_seconds_to_hour_min_sec(seconds):
     >>> format_seconds_to_hour_min_sec(62)
     '1 minute and 2 seconds'
     """
-
     if seconds < 1:
         return N_('%(count)d second', '%(count)d seconds',
                   seconds) % {'count': seconds}
@@ -1867,7 +1861,7 @@ def generate_names(filename):
 
 
 def is_known_redirecter(url):
-    """Check if a URL redirect is expected, and no filenames should be updated
+    """Check if a URL redirect is expected, and no filenames should be updated.
 
     We usually honor URL redirects, and update filenames accordingly.
     In some cases (e.g. Soundcloud) this results in a worse filename,
@@ -1878,7 +1872,6 @@ def is_known_redirecter(url):
     with the new filename determined by the URL, we cannot really determine
     which one is the "better" URL (e.g. "n5rMSpXrqmR9.128.mp3" for Soundcloud).
     """
-
     # Soundcloud-hosted media downloads (we take the track name as filename)
     if url.startswith('http://ak-media.soundcloud.com/'):
         return True

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -172,8 +172,8 @@ def new_gio_file(path):
 
 
 def make_directory(path):
-    """
-    Tries to create a directory if it does not exist already.
+    """Tries to create a directory if it does not exist already.
+
     Returns True if the directory exists after the function
     call, False otherwise.
     """
@@ -197,10 +197,9 @@ def make_directory(path):
 
 
 def normalize_feed_url(url):
-    """
-    Converts any URL to http:// or ftp:// so that it can be
-    used with "wget". If the URL cannot be converted (invalid
-    or unknown scheme), "None" is returned.
+    """Convert any URL to http:// or ftp:// so that it can be used with "wget".
+
+    If the URL cannot be converted (invalid or unknown scheme), "None" is returned.
 
     This will also normalize feed:// and itpc:// to http://.
 
@@ -295,10 +294,9 @@ def normalize_feed_url(url):
 
 
 def username_password_from_url(url):
-    r"""
-    Returns a tuple (username,password) containing authentication
-    data from the specified URL or (None,None) if no authentication
-    data can be found in the URL.
+    r"""Return (username,password) tuple from the specified URL.
+
+    Returns (None,None) if no authentication data can be found in the URL.
 
     See Section 3.1 of RFC 1738 (http://www.ietf.org/rfc/rfc1738.txt)
 
@@ -365,19 +363,15 @@ def username_password_from_url(url):
 
 
 def directory_is_writable(path):
-    """
-    Returns True if the specified directory exists and is writable
-    by the current user.
-    """
+    """Return True if the path exists and is writable by the current user."""
     return os.path.isdir(path) and os.access(path, os.W_OK)
 
 
 def calculate_size(path):
-    """
-    Tries to calculate the size of a directory, including any
-    subdirectories found. The returned value might not be
-    correct if the user doesn't have appropriate permissions
-    to list all subdirectories of the given path.
+    """Calculate the size of a directory, including any subdirectories found.
+
+    The returned value might not be correct if the user doesn't have appropriate
+    permissions to list all subdirectories of the given path.
     """
     if path is None:
         return 0
@@ -406,9 +400,9 @@ def calculate_size(path):
 
 
 def file_modification_datetime(filename):
-    """
-    Returns the modification date of the specified file
-    as a datetime.datetime object or None if the modification
+    """Return the modification date of the specified file.
+
+    Return value is a datetime.datetime object or None if the modification
     date cannot be determined.
     """
     if filename is None:
@@ -427,9 +421,9 @@ def file_modification_datetime(filename):
 
 
 def file_age_in_days(filename):
-    """
-    Returns the age of the specified filename in days or
-    zero if the modification date cannot be determined.
+    """Return the age of the specified filename in days.
+
+    Returns zero if the modification date cannot be determined.
     """
     dt = file_modification_datetime(filename)
     if dt is None:
@@ -439,9 +433,9 @@ def file_age_in_days(filename):
 
 
 def file_modification_timestamp(filename):
-    """
-    Returns the modification date of the specified file as a number
-    or -1 if the modification date cannot be determined.
+    """Return the modification date of the specified file as a number.
+
+    Return -1 if the modification date cannot be determined.
     """
     if filename is None:
         return -1
@@ -454,9 +448,9 @@ def file_modification_timestamp(filename):
 
 
 def file_age_to_string(days):
-    """
-    Converts a "number of days" value to a string that
-    can be used in the UI to display the file age.
+    """Convert a "number of days" value to a string.
+
+    The return value can be used in the UI to display the file age.
 
     >>> file_age_to_string(0)
     ''
@@ -483,10 +477,9 @@ def is_system_file(filename):
 
 
 def get_free_disk_space_win32(path):
-    """
-    Win32-specific code to determine the free disk space remaining
-    for a given path. Uses code from:
+    """Return the free disk space remaining for a given path on Win32.
 
+    Uses code from:
     http://mail.python.org/pipermail/python-list/2003-May/203223.html
     """
     if win32file is None:
@@ -499,8 +492,7 @@ def get_free_disk_space_win32(path):
 
 
 def get_free_disk_space(path):
-    """Calculates the free disk space available to the current user
-    on the file system that contains the given path.
+    """Return the free disk space remaining for a given path.
 
     If the path (or its parent folder) does not yet exist, this
     function returns zero.
@@ -517,9 +509,9 @@ def get_free_disk_space(path):
 
 
 def format_date(timestamp):
-    """
-    Converts a UNIX timestamp to a date representation. This
-    function returns "Today", "Yesterday", a weekday name or
+    """Convert a UNIX timestamp to a date representation.
+
+    This function returns "Today", "Yesterday", a weekday name or
     the date in %x format, which (according to the Python docs)
     is the "Locale's appropriate date representation".
 
@@ -567,8 +559,7 @@ def format_date(timestamp):
 
 
 def format_filesize(bytesize, use_si_units=False, digits=2):
-    """
-    Formats the given size in bytes to be human-readable,
+    """Format the given size in bytes to be human-readable,
 
     Returns a localized "(unknown)" string when the bytesize
     has a negative value.
@@ -609,7 +600,7 @@ def format_filesize(bytesize, use_si_units=False, digits=2):
 
 
 def delete_file(filename):
-    """Delete a file from the filesystem
+    """Delete a file from the filesystem.
 
     Errors (permissions errors or file not found)
     are silently ignored.
@@ -621,7 +612,7 @@ def delete_file(filename):
 
 
 def is_html(text):
-    """Heuristically tell if text is HTML
+    """Heuristically tell if text is HTML.
 
     By looking for an open tag (more or less:)
     >>> is_html('<h1>HELLO</h1>')
@@ -634,10 +625,9 @@ def is_html(text):
 
 
 def remove_html_tags(html):
-    """
-    Remove HTML tags from a string and replace numeric and
-    named entities with the corresponding character, so the
-    HTML text can be displayed in a simple text view.
+    """Remove HTML tags and replace numeric and named entities with characters.
+
+    Converts HTML text so that it can be displayed in a simple text view.
     """
     if html is None:
         return None
@@ -847,9 +837,7 @@ def nice_html_description(img, description):
 
 
 def wrong_extension(extension):
-    """
-    Determine if a given extension looks like it's
-    wrong (e.g. empty, extremely long or spaces)
+    """Determine if a file extension seems wrong (empty, extremely long or spaces).
 
     Returns True if the extension most likely is a
     wrong one and should be replaced.
@@ -938,9 +926,9 @@ def mimetype_from_extension(extension):
 
 def extension_correct_for_mimetype(extension, mimetype):
     """
-    Check if the given filename extension (e.g. ".ogg") is a possible
-    extension for a given mimetype (e.g. "application/ogg") and return
-    a boolean value (True if it's possible, False if not). Also do
+    Check if the filename extension is a possible extension for a mimetype.
+
+    Returns a boolean value (True if it's possible, False if not). Also do
 
     >>> extension_correct_for_mimetype('.ogg', 'application/ogg')
     True
@@ -975,9 +963,9 @@ def extension_correct_for_mimetype(extension, mimetype):
 
 
 def filename_from_url(url):
-    """
-    Extracts the filename and (lowercase) extension (with dot)
-    from a URL, e.g. http://server.com/file.MP3?download=yes
+    """Extract the filename and (lowercase) extension (with dot) from an URL.
+
+    E.g. http://server.com/file.MP3?download=yes
     will result in the string ("file", ".mp3") being returned.
 
     This function will also try to best-guess the "real"
@@ -1013,10 +1001,9 @@ def filename_from_url(url):
 
 
 def file_type_by_extension(extension):
-    """
-    Tries to guess the file type by looking up the filename
-    extension from a table of known file types. Will return
-    "audio", "video" or None.
+    """Guess the file type from the filename extension.
+
+    Uses a table of known file types. Will return "audio", "video" or None.
 
     >>> file_type_by_extension('.aif')
     'audio'
@@ -1056,9 +1043,9 @@ def file_type_by_extension(extension):
 
 
 def get_first_line(s):
-    """
-    Returns only the first line of a string, stripped so
-    that it doesn't have whitespace before or after.
+    """Return the first line of a string.
+
+    The line is stripped so that it doesn't have whitespace before or after.
     """
     if s:
         return s.strip().split('\n')[0].strip()
@@ -1066,7 +1053,8 @@ def get_first_line(s):
 
 
 def object_string_formatter(s, **kwargs):
-    """
+    """Format a string with object attributes.
+
     Makes attributes of object passed in as keyword
     arguments available as {OBJECTNAME.ATTRNAME} in
     the passed-in string and returns a string with
@@ -1101,9 +1089,9 @@ def object_string_formatter(s, **kwargs):
 
 
 def format_desktop_command(command, filenames, start_position=None):
-    """
-    Formats a command template from the "Exec=" line of a .desktop
-    file to a string that can be invoked in a shell.
+    """Format a command template from the "Exec=" line of a .desktop file.
+
+    The returned string can be invoked in a shell.
 
     Handled format strings: %U, %u, %F, %f and a fallback that
     appends the filename as first parameter of the command.
@@ -1147,9 +1135,9 @@ def format_desktop_command(command, filenames, start_position=None):
 
 
 def url_strip_authentication(url):
-    """
-    Strips authentication data from an URL. Returns the URL with
-    the authentication data removed from it.
+    """Strip authentication data from an URL.
+
+    Returns the URL with the authentication data removed from it.
 
     >>> url_strip_authentication('https://host.com/')
     'https://host.com/'
@@ -1181,9 +1169,9 @@ def url_strip_authentication(url):
 
 
 def url_add_authentication(url, username, password):
-    """
-    Adds authentication data (username, password) to a given
-    URL in order to construct an authenticated URL.
+    """Add authentication data (username, password) to a given URL.
+
+    The returned string is an authenticated URL.
 
     >>> url_add_authentication('https://host.com/', '', None)
     'https://host.com/'
@@ -1527,12 +1515,12 @@ def http_request(url, method='HEAD'):
 
 
 def gui_open(filename, gui=None):
-    """
-    Open a file or folder with the default application set
-    by the Desktop environment. This uses "xdg-open" on all
-    systems with a few exceptions:
+    """Open a file or folder with the default application from the Desktop environment.
+
+    Uses "xdg-open" on all systems with a few exceptions:
 
        on Win32, os.startfile() is used
+       on OSX, "open" is used
     """
     try:
         if gpodder.ui.win32:
@@ -1565,17 +1553,17 @@ def gui_open(filename, gui=None):
 
 
 def open_website(url):
-    """
-    Opens the specified URL using the default system web
-    browser. This uses Python's "webbrowser" module, so
-    make sure your system is set up correctly.
+    """Open the specified URL using the default system web browser.
+
+    Uses Python's "webbrowser" module, so make sure your system is set up
+    correctly.
     """
     run_in_background(lambda: webbrowser.open(url))
     return True
 
 
 def copy_text_to_clipboard(text):
-    """Copies the specified text to both clipboards."""
+    """Copy the specified text to both clipboards."""
     import gi
     gi.require_version('Gtk', '3.0')
     from gi.repository import Gdk, Gtk
@@ -1616,9 +1604,9 @@ def convert_bytes(d):
 
 
 def sanitize_filename(filename, max_length):
-    """
-    Generate a sanitized version of a filename; trim filename
-    if greater than max_length (0 = no limit).
+    """Generate a sanitized version of a filename.
+
+    Trim the filename if it is longer than max_length (0 = no limit).
 
     >>> sanitize_filename('https://www.host.name/feed', 0)
     'https___www.host.name_feed'
@@ -1650,8 +1638,8 @@ def sanitize_filename(filename, max_length):
 
 
 def sanitize_filename_ext(filename, ext, max_length, max_length_with_ext):
-    """
-    Generate a sanitized version of a filename and extension.
+    """Generate a sanitized version of a filename and extension.
+
     Truncate filename if greater than max_length.
     Truncate extension if filename.extension is greater than max_length_with_ext.
     :param str filename: filename without extension
@@ -1669,8 +1657,8 @@ def sanitize_filename_ext(filename, ext, max_length, max_length_with_ext):
 
 
 def find_mount_point(directory):
-    """
-    Try to find the mount point for a given directory.
+    """Try to find the mount point for a given directory.
+
     If the directory is itself a mount point, return
     it. If not, remove the last part of the path and
     re-check if it's a mount point. If the directory
@@ -1761,10 +1749,10 @@ protocolPattern = re.compile(r'^\w+://')
 
 
 def isabs(string):
-    """
-    @return true if string is an absolute path or protocoladdress
-    for addresses beginning in http:// or ftp:// or ldap:// -
-    they are considered "absolute" paths.
+    """Return true if string is an absolute path or protocol address.
+
+    Addresses beginning in http:// or ftp:// or ldap:// are considered
+    absolute paths.
     Source: http://code.activestate.com/recipes/208993/
     """
     if protocolPattern.match(string):
@@ -1773,10 +1761,12 @@ def isabs(string):
 
 
 def relpath(p1, p2):
-    """
-    Finds relative path from p2 to p1, like os.path.relpath but handles
-    uris. Returns None if no such path exists due to the paths being on
-    different devices.
+    """Find relative path from p2 to p1.
+
+    Like os.path.relpath but handles uris.
+
+    Returns None if no such path exists due to the paths being on different
+    devices.
     """
     u1 = urllib.parse.urlparse(p1)
     u2 = urllib.parse.urlparse(p2)
@@ -1786,7 +1776,7 @@ def relpath(p1, p2):
 
 
 def get_hostname():
-    """Return the hostname of this computer
+    """Return the hostname of this computer.
 
     This can be implemented in a different way on each
     platform and should yield a unique-per-user device ID.
@@ -2064,8 +2054,8 @@ def delete_empty_folders(top):
 
 
 def guess_encoding(filename):
-    """
-    read filename encoding as defined in PEP 263
+    """Read filename encoding as defined in PEP 263.
+
     - BOM marker => utf-8
     - coding: xxx comment in first 2 lines
     - else return None
@@ -2096,8 +2086,8 @@ def guess_encoding(filename):
 
 
 def iri_to_url(url):
-    """
-    Properly escapes Unicode characters in the URL path section
+    """Escape Unicode characters in the URL path section.
+
     TODO: Explore if this should also handle the domain
     Based on: http://stackoverflow.com/a/18269491/1072626
     In response to issue: https://github.com/gpodder/gpodder/issues/232
@@ -2220,9 +2210,9 @@ def _parse_mimetype_sorted_dictitems(mimetype):
 
 
 def parse_mimetype(mimetype):
-    """
-    parse mimetype into (type, subtype, parameters)
-    see RFC 2045 §5.1
+    """Parse mimetype into (type, subtype, parameters).
+
+    See RFC 2045 §5.1
     TODO: unhandled comments and continuations
 
     >>> _parse_mimetype_sorted_dictitems('application/atom+xml;profile=opds-catalog;type=feed;kind=acquisition')
@@ -2334,8 +2324,8 @@ def get_header_param(headers, param, header_name):
 
 
 def response_text(response, default_encoding='utf-8'):
-    """
-    Utility method to return urlopen response's text.
+    """Return text from urlopen response.
+
     Requests uses only the charset info in content-type, then defaults to ISO-8859-1
     when content-type=text/*.
     We could use chardet (via response.apparent_encoding) but it's slow so often it's
@@ -2349,10 +2339,7 @@ def response_text(response, default_encoding='utf-8'):
 
 
 def mount_volume_for_file(file, op=None):
-    """
-    Utility method to mount the enclosing volume for the given file in a blocking
-    fashion
-    """
+    """Mount the enclosing volume for the given file in a blocking fashion."""
     import gi
     gi.require_version('Gio', '2.0')
     from gi.repository import Gio, GLib

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1324,12 +1324,13 @@ def idle_timeout_add(milliseconds, func, *args):
 
 
 class IdleTimeout(object):
-    """Run a function in the main GUI thread at regular intervals since the last run, at idle priority
+    """Run a function in the main GUI thread at regular intervals since the last run, at idle priority.
 
     A simple timeout_add() continuously calls the function if it exceeds the interval,
     which lags the UI and prevents idle_add() calls from happening. This class restarts
     the timer after the function finishes, allowing other callbacks to run.
     """
+
     def __init__(self, milliseconds, func, *args):
         if not gpodder.ui.gtk:
             raise Exception('util.IdleTimeout() is only supported by Gtk+')

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -2111,7 +2111,6 @@ def iri_to_url(url):
 
 
 class Popen(subprocess.Popen):
-
     """A Popen process that tries not to leak file descriptors.
 
     This is a drop-in replacement for subprocess.Popen(), which takes the same

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -23,7 +23,7 @@
 #  Thomas Perl <thp@perli.net> 2007-08-04
 #
 
-"""Miscellaneous helper functions for gPodder
+"""Miscellaneous helper functions for gPodder.
 
 This module provides helper and utility functions for gPodder that
 are not tied to any specific part of gPodder.
@@ -559,7 +559,7 @@ def format_date(timestamp):
 
 
 def format_filesize(bytesize, use_si_units=False, digits=2):
-    """Format the given size in bytes to be human-readable,
+    """Format the given size in bytes to be human-readable.
 
     Returns a localized "(unknown)" string when the bytesize
     has a negative value.
@@ -881,8 +881,7 @@ def wrong_extension(extension):
 
 
 def extension_from_mimetype(mimetype):
-    """
-    Simply guesses what the file extension should be from the mimetype
+    """Simply guesses what the file extension should be from the mimetype.
 
     >>> extension_from_mimetype('audio/mp4')
     '.m4a'
@@ -902,7 +901,7 @@ def extension_from_mimetype(mimetype):
 
 def mimetype_from_extension(extension):
     """
-    Simply guesses what the mimetype should be from the file extension
+    Simply guesses what the mimetype should be from the file extension.
 
     >>> mimetype_from_extension('.m4a')
     'audio/mp4'
@@ -1278,7 +1277,7 @@ def find_command(command):
 
 
 def idle_add(func, *args):
-    """Run a function in the main GUI thread
+    """Run a function in the main GUI thread.
 
     This is a wrapper function that does the Right Thing depending on if we are
     running on Gtk+, Qt or CLI.
@@ -1295,7 +1294,7 @@ def idle_add(func, *args):
 
 
 def idle_timeout_add(milliseconds, func, *args):
-    """Run a function in the main GUI thread at regular intervals, at idle priority
+    """Run a function in the main GUI thread at regular intervals, at idle priority.
 
     PRIORITY_HIGH           -100
     PRIORITY_DEFAULT        0        timeout_add()
@@ -1390,7 +1389,7 @@ def bluetooth_send_file(filename):
 
 
 def format_time(seconds):
-    """Format a seconds value to a string
+    """Format a seconds value to a string.
 
     >>> format_time(0)
     '00:00'
@@ -1419,7 +1418,7 @@ def format_time(seconds):
 
 
 def parse_time(value):
-    """Parse a time string into seconds
+    """Parse a time string into seconds.
 
     >>> parse_time('00:00')
     0
@@ -1791,7 +1790,7 @@ def get_hostname():
 
 
 def detect_device_type():
-    """Device type detection for gpodder.net
+    """Device type detection for gpodder.net.
 
     This function tries to detect on which
     kind of device gPodder is running on.
@@ -1807,7 +1806,7 @@ def detect_device_type():
 
 
 def write_m3u_playlist(m3u_filename, episodes, extm3u=True):
-    """Create an M3U playlist from a episode list
+    """Create an M3U playlist from a episode list.
 
     If the parameter "extm3u" is False, the list of
     episodes should be a list of filenames, and no
@@ -1871,7 +1870,7 @@ def is_known_redirecter(url):
 
 
 def atomic_rename(old_name, new_name):
-    """Atomically rename/move a (temporary) file
+    """Atomically rename/move a (temporary) file.
 
     This is usually used when updating a file safely by writing
     the new contents into a temporary file and then moving the
@@ -1885,14 +1884,14 @@ def atomic_rename(old_name, new_name):
 
 
 def check_command(self, cmd):
-    """Check if a command line command/program exists"""
+    """Check if a command line command/program exists."""
     # Prior to Python 2.7.3, this module (shlex) did not support Unicode input.
     program = shlex.split(cmd)[0]
     return (find_command(program) is not None)
 
 
 def rename_episode_file(episode, filename):
-    """Helper method to update a PodcastEpisode object
+    """Helper method to update a PodcastEpisode object.
 
     Useful after renaming/converting its download file.
     """
@@ -1950,7 +1949,7 @@ def run_in_background(function, daemon=False):
 
 
 def linux_get_active_interfaces():
-    """Get active network interfaces using 'ip addr'
+    """Get active network interfaces using 'ip addr'.
 
     A generator function yielding network interface
     names with an inet (or inet6) and a broadcast
@@ -1969,7 +1968,7 @@ def linux_get_active_interfaces():
 
 
 def osx_get_active_interfaces():
-    """Get active network interfaces using 'ifconfig'
+    """Get active network interfaces using 'ifconfig'.
 
     Returns a list of active network interfaces or an
     empty list if the device is offline. The loopback
@@ -1984,7 +1983,7 @@ def osx_get_active_interfaces():
 
 
 def unix_get_active_interfaces():
-    """Get active network interfaces using 'ifconfig'
+    """Get active network interfaces using 'ifconfig'.
 
     Returns a list of active network interfaces or an
     empty list if the device is offline. The loopback
@@ -1999,7 +1998,7 @@ def unix_get_active_interfaces():
 
 
 def connection_available():
-    """Check if an Internet connection is available
+    """Check if an Internet connection is available.
 
     Returns True if a connection is available (or if there
     is no way to determine the connection). Returns False
@@ -2299,7 +2298,7 @@ def parse_mimetype(mimetype):
 
 
 def get_header_param(headers, param, header_name):
-    """Extract a HTTP header parameter from a dict
+    """Extract a HTTP header parameter from a dict.
 
     Uses the "email" module to retrieve parameters
     from HTTP headers. This can be used to get the

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -172,7 +172,7 @@ def new_gio_file(path):
 
 
 def make_directory(path):
-    """Tries to create a directory if it does not exist already.
+    """Create a directory if it does not exist already.
 
     Returns True if the directory exists after the function
     call, False otherwise.
@@ -805,8 +805,7 @@ class ExtractHyperlinkedTextHTMLParser(HTMLParser):
 
 
 def extract_hyperlinked_text(html):
-    """
-    Convert HTML to hyperlinked text.
+    """Convert HTML to hyperlinked text.
 
     The output is a list of (target, text) tuples, where target is either a URL
     or None, and text is a piece of plain text for rendering in a TextView.
@@ -823,7 +822,10 @@ def extract_hyperlinked_text(html):
 
 
 def nice_html_description(img, description):
-    """Basic html formatting + hyperlink highlighting + video thumbnail."""
+    """Create HTML from a text description.
+
+    Basic html formatting + hyperlink highlighting + video thumbnail.
+    """
     description = re.sub(r'https?://[^\s]+', r'<a href="\g<0>">\g<0></a>', description)
     description = description.replace('\n', '<br>')
     html = """<style type="text/css">
@@ -1367,8 +1369,7 @@ def bluetooth_available():
 
 
 def bluetooth_send_file(filename):
-    """
-    Sends a file via bluetooth.
+    """Send a file via bluetooth.
 
     This function tries to use "bluetooth-sendto", and if
     it is not available, it also tries "gnome-obex-send".
@@ -1891,7 +1892,7 @@ def check_command(self, cmd):
 
 
 def rename_episode_file(episode, filename):
-    """Helper method to update a PodcastEpisode object.
+    """Update a PodcastEpisode object after a file rename.
 
     Useful after renaming/converting its download file.
     """
@@ -1908,8 +1909,7 @@ def rename_episode_file(episode, filename):
 
 
 def get_update_info():
-    """
-    Get up to date release information from gpodder.org.
+    """Get up to date release information from gpodder.org.
 
     Returns a tuple: (up_to_date, latest_version, release_date, days_since)
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -2204,7 +2204,7 @@ class Popen(subprocess.Popen):
 
 
 def _parse_mimetype_sorted_dictitems(mimetype):
-    """ python 3.5 unordered dict compat for doctest. don't use! """
+    """Python 3.5 unordered dict compat for doctest. Don't use."""
     r = parse_mimetype(mimetype)
     return r[0], r[1], sorted(r[2].items())
 
@@ -2227,7 +2227,7 @@ def parse_mimetype(mimetype):
     ('application', 'x-myapp', [('a', 'b'), ('quoted', 'a quoted string with ; etc.')])
     """
     class MIMETypeException(Exception):
-        """ when an exception is encountered parsing mime type """
+        """Raised when an exception is encountered parsing mime type."""
 
     if not mimetype or '/' not in mimetype:
         return (None, None, {})

--- a/src/gpodder/utilwin32locale.py
+++ b/src/gpodder/utilwin32locale.py
@@ -299,8 +299,7 @@ def _localefromlcid(lcid):
 
 
 def _getscreenlanguage():
-    """
-    :returns: the locale for this session.
+    """Return the locale for this session.
 
     If the LANGUAGE environment variable is set, it's value overrides the
     screen language detection. Otherwise the screen language is determined by

--- a/src/gpodder/utilwin32locale.py
+++ b/src/gpodder/utilwin32locale.py
@@ -18,7 +18,8 @@
 # along with elib.intl. If not, see <http://www.gnu.org/licenses/>.
 
 
-"""
+"""Localization utilities for Win32.
+
 This code is adapted from the elib.intl module available on GitHub at
 https://github.com/dieterv/elib.intl, commit 49d5797 on 1 Sep 2017.
 
@@ -55,7 +56,8 @@ logger = getLogger(__name__)
 
 
 def _localefromlcid(lcid):
-    """
+    """Return locale from Windows LCID.
+
     :param lcid: Microsoft Windows LCID
     :returns: name of the supported gPodder locale or ISO 639-1 language code for a given lcid. If there is no
               ISO 639-1 language code assigned to the language specified by lcid,
@@ -334,7 +336,8 @@ def _getscreenlanguage():
 
 
 def install(domain, localedir):
-    """
+    """Install a translation domain from locale directory.
+
     :param domain: translation domain
     :param localedir: locale directory
     """

--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -393,8 +393,8 @@ def is_youtube_guid(guid):
 
 
 def for_each_feed_pattern(func, url, fallback_result):
-    """
-    Try to find the username for all possible YouTube feed/webpage URLs
+    """Try to find the username for all possible YouTube feed/webpage URLs.
+
     Will call func(url, channel) for each match, and if func() returns
     a result other than None, returns this. If no match is found or
     func() returns None, return fallback_result.
@@ -517,8 +517,8 @@ def get_cover(url, feed_data=None):
 
 
 def get_gdpr_consent_url(html_data):
-    """
-    Creates the URL for automatically accepting GDPR consents
+    """Create the URL for automatically accepting GDPR consents.
+
     EU GDPR redirects to a form that needs to be posted to be redirected to a get request
     with the form data as input to the youtube video URL. This extracts that form data from
     the GDPR form and builds up the URL the posted form results.
@@ -595,8 +595,8 @@ def get_channel_desc(url, feed_data=None):
 
 
 def parse_youtube_url(url):
-    """
-    Youtube Channel Links are parsed into youtube feed links
+    """Parse Youtube Channel Links into youtube feed links.
+
     >>> parse_youtube_url("https://www.youtube.com/channel/CHANNEL_ID")
     'https://www.youtube.com/feeds/videos.xml?channel_id=CHANNEL_ID'
 

--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -479,7 +479,8 @@ def get_cover(url, feed_data=None):
     if 'youtube.com' in url:
 
         class YouTubeHTMLCoverParser(HTMLParser):
-            """This custom html parser searches for the youtube channel thumbnail/avatar"""
+            """This custom html parser searches for the youtube channel thumbnail/avatar."""
+
             def __init__(self):
                 super().__init__()
                 self.url = []
@@ -560,6 +561,7 @@ def get_channel_desc(url, feed_data=None):
 
         class YouTubeHTMLDesc(HTMLParser):
             """This custom html parser searches for the YouTube channel description."""
+
             def __init__(self):
                 super().__init__()
                 self.description = ''

--- a/tests/test_feedcore.py
+++ b/tests/test_feedcore.py
@@ -90,7 +90,7 @@ def test_redirect(httpserver):
 
 
 def test_redirect_loop(httpserver):
-    """ verify that feedcore fetching will not loop indefinitely on redirects """
+    """Verify that feedcore fetching will not loop indefinitely on redirects."""
     redir_headers = {
         'Location': '/feed',  # it loops
     }

--- a/tools/github_release.py
+++ b/tools/github_release.py
@@ -30,7 +30,7 @@ def debug_requests():
 
 
 def error_exit(msg, code=1):
-    """ print msg and exit with code """
+    """Print msg and exit with code."""
     print(msg, file=sys.stderr)
     sys.exit(code)
 
@@ -48,7 +48,7 @@ def download_items(urls, prefix):
 
 
 def download_mac_github(github_workflow, prefix, version):
-    """ download mac workflow artifacts from github and exit """
+    """Download mac workflow artifacts from github and exit."""
     headers = {'Accept': 'application/vnd.github+json', 'Authorization': 'token %s' % github_token}
 
     print("I: downloading release artifacts for workflow %d" % github_workflow)
@@ -80,7 +80,7 @@ def download_mac_github(github_workflow, prefix, version):
 
 
 def download_appveyor(appveyor_build, prefix):
-    """ download build artifacts from appveyor and exit """
+    """Download build artifacts from appveyor and exit."""
     print("I: downloading release artifacts from appveyor")
     build = requests.get("https://ci.appveyor.com/api/projects/elelay/gpodder/build/%s" % appveyor_build).json()
     job_id = build.get("build", {}).get("jobs", [{}])[0].get("jobId")
@@ -96,7 +96,7 @@ def download_appveyor(appveyor_build, prefix):
 
 
 def checksums():
-    """ compute artifact checksums """
+    """Compute artifact checksums."""
     ret = {}
     for f in os.listdir("_build"):
         archive = os.path.join("_build", f)
@@ -166,7 +166,7 @@ Thanks to {{contributors[0]}}{% for c in contributors[1:-1] %}, {{c}}{% endfor %
 
 
 def upload(repo, tag, previous_tag, mac_github, appveyor):
-    """ create github release (draft) and upload assets """
+    """Create github release (draft) and upload assets."""
     print("I: creating release %s" % tag)
     items = os.listdir('_build')
     if len(items) == 0:

--- a/tools/github_release.py
+++ b/tools/github_release.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-"""
-Prepare release and upload Windows and macOS artifacts
-"""
+"""Prepare release and upload Windows and macOS artifacts."""
 import argparse
 import hashlib
 import os
@@ -15,7 +13,7 @@ from jinja2 import Template
 
 
 def debug_requests():
-    """ turn requests debug on """
+    """Turn requests debug on."""
     # These two lines enable debugging at httplib level (requests->urllib3->http.client)
     # You will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.
     # The only thing missing will be the response.body which is not logged.
@@ -115,9 +113,7 @@ def checksums():
 
 
 def get_contributors(tag, previous_tag):
-    """
-    list contributor logins '@...' for every commit in range
-    """
+    """List contributor logins '@...' for every commit in range."""
     cmp = repo.compare_commits(previous_tag, tag)
     logins = [c.author.login for c in cmp.commits() if c.author] + [c.committer.login for c in cmp.commits()]
     return sorted({"@{}".format(n) for n in logins})

--- a/tools/mac-osx/launcher.py
+++ b/tools/mac-osx/launcher.py
@@ -12,13 +12,13 @@ from subprocess import PIPE, CalledProcessError, Popen
 
 
 class MakeCertPem:
-    """ create openssl cert bundle from system certificates """
+    """Create openssl cert bundle from system certificates."""
 
     def __init__(self, openssl):
         self.openssl = openssl
 
     def is_valid_cert(self, cert):
-        """ check if cert is valid according to openssl"""
+        """Check if cert is valid according to openssl."""
         cmd = [self.openssl, "x509", "-inform", "pem", "-checkend", "0", "-noout"]
         # print("D: is_valid_cert %r" % cmd)
         proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -53,12 +53,12 @@ class MakeCertPem:
 
     @staticmethod
     def write_certs(certs, dest):
-        """ write concatenated certs to dest """
+        """Write concatenated certs to dest."""
         with open(dest, "wb") as output:
             output.write(b"\n".join(certs))
 
     def regen(self, dest):
-        """ main program """
+        """Regenerate the certificates."""
         print("I: make_cert_pem %s %s" % (self.openssl, dest))
         certs = self.get_certs()
         if certs is None:

--- a/tools/mac-osx/launcher.py
+++ b/tools/mac-osx/launcher.py
@@ -27,8 +27,9 @@ class MakeCertPem:
         return proc.returncode == 0
 
     def get_certs(self):
-        """ extract System's certificates then filter them by validity
-            and return a list of text of valid certs
+        """Extract System's certificates and filter them by validity.
+
+        Return a list of texts of valid certs
         """
         cmd = ["security", "find-certificate", "-a", "-p",
                "/System/Library/Keychains/SystemRootCertificates.keychain"]

--- a/tools/mac-osx/make_cert_pem.py
+++ b/tools/mac-osx/make_cert_pem.py
@@ -15,8 +15,7 @@ from subprocess import PIPE, CalledProcessError, Popen
 
 
 def is_valid_cert(openssl, cert):
-    """ check if cert is valid according to openssl"""
-
+    """Check if cert is valid according to openssl."""
     cmd = [openssl, "x509", "-inform", "pem", "-checkend", "0", "-noout"]
     # print("D: is_valid_cert %r" % cmd)
     proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -26,10 +25,10 @@ def is_valid_cert(openssl, cert):
 
 
 def get_certs(openssl):
-    """ extract System's certificates then filter them by validity
-        and return a list of text of valid certs
-    """
+    """Extract System's certificates then filter them by validity.
 
+    Return a list of text of valid certs
+    """
     cmd = ["security", "find-certificate", "-a", "-p",
            "/System/Library/Keychains/SystemRootCertificates.keychain"]
     cert_re = re.compile(b"^-----BEGIN CERTIFICATE-----$"
@@ -52,15 +51,13 @@ def get_certs(openssl):
 
 
 def write_certs(certs, dest):
-    """ write concatenated certs to dest """
-
+    """Write concatenated certs to dest."""
     with open(dest, "wb") as output:
         output.write(b"\n".join(certs))
 
 
 def main(openssl, dest):
-    """ main program """
-
+    """Main program."""
     print("I: make_cert_pem.py %s %s" % (openssl, dest))
     certs = get_certs(openssl)
     if certs is None:

--- a/tools/mac-osx/make_cert_pem.py
+++ b/tools/mac-osx/make_cert_pem.py
@@ -58,7 +58,6 @@ def write_certs(certs, dest):
 
 
 def main(openssl, dest):
-    """Main program."""
     print("I: make_cert_pem.py %s %s" % (openssl, dest))
     certs = get_certs(openssl)
     if certs is None:

--- a/tools/mac-osx/make_cert_pem.py
+++ b/tools/mac-osx/make_cert_pem.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-""" A script to initialize our bundled openssl CA trust store
-    based on your System's keychain
+"""A script to initialize our bundled openssl CA trust store.
 
-    Released under the same licence as gPodder (GPL3 or later)
-    Copyright (c) 2016 Eric Le Lay
+Based on your System's keychain.
+
+Released under the same licence as gPodder (GPL3 or later)
+Copyright (c) 2016 Eric Le Lay
 """
 
 import argparse

--- a/tools/test-auth-server.py
+++ b/tools/test-auth-server.py
@@ -36,7 +36,7 @@ SIZE = 500000                 # Size (in bytes) of the episode downloads)
 
 
 def mkpubdates(items):
-    """Generate fake pubDates (one each day, recently)"""
+    """Generate fake pubDates (one each day, recently)."""
     current = datetime.datetime.now() - datetime.timedelta(days=items + 3)
     for i in range(items):
         yield current.ctime()
@@ -44,7 +44,7 @@ def mkpubdates(items):
 
 
 def mkrss(items=EP_COUNT):
-    """Generate a dumm RSS feed with a given number of items"""
+    """Generate a dumm RSS feed with a given number of items."""
     ITEMS = '\n'.join("""
     <item>
         <title>Episode %(INDEX)s</title>
@@ -108,7 +108,7 @@ def mkrss(items=EP_COUNT):
 
 
 def mkdata(size=SIZE):
-    """Generate dummy data of a given size (in bytes)"""
+    """Generate dummy data of a given size (in bytes)."""
     return bytes([32 + (i % (127 - 32)) for i in range(size)])
 
 

--- a/tools/win_installer/misc/create-launcher.py
+++ b/tools/win_installer/misc/create-launcher.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-"""Creates simple Python .exe launchers for gui and cli apps
+"""Creates simple Python .exe launchers for gui and cli apps.
 
 ./create-launcher.py "3.8.0" <target-dir>
 """
@@ -22,7 +22,7 @@ import tempfile
 
 
 def build_resource(rc_path, out_path):
-    """Raises subprocess.CalledProcessError"""
+    """Can raise subprocess.CalledProcessError."""
 
     def is_64bit():
         return struct.calcsize("P") == 8

--- a/tools/win_installer/misc/depcheck.py
+++ b/tools/win_installer/misc/depcheck.py
@@ -7,8 +7,8 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-"""
-Deletes unneeded DLLs and checks DLL dependencies.
+"""Deletes unneeded DLLs and checks DLL dependencies.
+
 Execute with the build python, will figure out the rest.
 """
 


### PR DESCRIPTION
Chip away at trying to make gPodder code mostly flake8 clean. Fix the formatting of docstrings to pass pydocstyle checks from flake8.

Also ignore spellcheck checks (SC*) at least for now.

The remaining flake8 errors are mostly about non-specific `except:` statements. I'm not sure if these should be fixed, or just ignored.