### PR TITLE
Added an extension that runs a command upon sync completion

### DIFF
--- a/bin/gpo
+++ b/bin/gpo
@@ -1016,6 +1016,7 @@ class gPodderCli(object):
         done_lock.acquire()
         sync_ui.on_synchronize_episodes(self._model.get_podcasts(), episodes=None, force_played=True, done_callback=done_lock.release)
         done_lock.acquire()  # block until done
+        gpodder.user_extensions.on_all_episodes_synced()
 
     def _extensions_list(self):
         def by_category(ext):

--- a/share/gpodder/extensions/command_on_sync.py
+++ b/share/gpodder/extensions/command_on_sync.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 _ = gpodder.gettext
 
 __title__ = _('Run a Command on Sync')
-__description__ = _('Run a predefined external command upon sync completion.')
+__description__ = _('Run a custom external command upon sync completion.')
 __authors__ = 'Eric Le Lay <elelay@macports.org>, Azer Abdullaev <azer.abdullaev.berlin+git@gmail.com>'
 __doc__ = 'https://gpodder.github.io/docs/extensions/commandonsync.html'
 __category__ = 'post-sync'

--- a/share/gpodder/extensions/command_on_sync.py
+++ b/share/gpodder/extensions/command_on_sync.py
@@ -41,6 +41,6 @@ class gPodderExtension:
         proc = util.Popen(command, shell=True, env=env, close_fds=True)
         proc.wait()
         if proc.returncode == 0:
-            logger.info("%s succeeded", command)
+            logger.info("Post-sync command %r succeeded", command)
         else:
-            logger.warning("%s run with exit code %i", command, proc.returncode)
+            logger.warning("Post-sync command %r exited with status=%i", command, proc.returncode)

--- a/share/gpodder/extensions/command_on_sync.py
+++ b/share/gpodder/extensions/command_on_sync.py
@@ -19,7 +19,7 @@ __description__ = _('Run a custom external command upon sync completion.')
 __authors__ = 'Eric Le Lay <elelay@macports.org>, Azer Abdullaev <azer.abdullaev.berlin+git@gmail.com>'
 __doc__ = 'https://gpodder.github.io/docs/extensions/commandonsync.html'
 __category__ = 'post-sync'
-__only_for__ = 'gtk'
+__only_for__ = 'gtk, cli'
 
 
 DefaultConfig = {

--- a/share/gpodder/extensions/command_on_sync.py
+++ b/share/gpodder/extensions/command_on_sync.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# gPodder extension for running a command on successful synchronization of all episodes
+#
+
+import datetime
+import logging
+import os
+
+import gpodder
+from gpodder import util
+
+logger = logging.getLogger(__name__)
+
+_ = gpodder.gettext
+
+__title__ = _('Run a Command on Sync')
+__description__ = _('Run a predefined external command upon sync completion.')
+__authors__ = 'Eric Le Lay <elelay@macports.org>, Azer Abdullaev <azer.abdullaev.berlin+git@gmail.com>'
+__doc__ = 'https://gpodder.github.io/docs/extensions/commandonsync.html'
+__category__ = 'post-sync'
+__only_for__ = 'gtk'
+
+
+DefaultConfig = {
+    'command': "zenity --info --width=600 --text=\"Sync completed!\""
+}
+
+
+class gPodderExtension:
+    def __init__(self, container):
+        self.container = container
+
+    def on_all_episodes_synced(self):
+        cmd_template = self.container.config.command
+        self.run_command(cmd_template)
+
+    def run_command(self, command):
+        env = os.environ.copy()
+
+        proc = util.Popen(command, shell=True, env=env, close_fds=True)
+        proc.wait()
+        if proc.returncode == 0:
+            logger.info("%s succeeded", command)
+        else:
+            logger.warning("%s run with exit code %i", command, proc.returncode)

--- a/share/gpodder/extensions/command_on_sync.py
+++ b/share/gpodder/extensions/command_on_sync.py
@@ -23,7 +23,7 @@ __only_for__ = 'gtk'
 
 
 DefaultConfig = {
-    'command': "zenity --info --width=600 --text=\"Sync completed!\""
+    'command': 'zenity --info --width=600 --text="Sync completed!"',
 }
 
 

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -504,6 +504,11 @@ class ExtensionManager(object):
         """
 
     @call_extensions
+    def on_all_episodes_synced(self):
+        """Called when all episodes have been synchronized
+        """
+
+    @call_extensions
     def on_create_menu(self):
         """Called when the Extras menu is created
 

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1708,10 +1708,10 @@ class gPodder(BuilderWidget, dbus.service.Object):
             message += self.format_episode_list(
                 [str(task) for task in failed_syncs], 5)
             self.show_message(message, _('Device synchronization finished'), True)
+            gpodder.user_extensions.on_all_episodes_synced()
         elif finished_syncs:
             message = self.format_episode_list([str(task) for task in finished_syncs])
             self.show_message(message, _('Device synchronization finished'))
-            gpodder.user_extensions.on_all_episodes_synced()
         elif failed_syncs:
             message = self.format_episode_list([str(task) for task in failed_syncs])
             self.show_message(message, _('Device synchronization failed'), True)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1712,6 +1712,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         elif finished_syncs:
             message = self.format_episode_list([str(task) for task in finished_syncs])
             self.show_message(message, _('Device synchronization finished'))
+            gpodder.user_extensions.on_all_episodes_synced()
         elif failed_syncs:
             message = self.format_episode_list([str(task) for task in failed_syncs])
             self.show_message(message, _('Device synchronization failed'), True)

--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1711,6 +1711,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
         elif finished_syncs:
             message = self.format_episode_list([str(task) for task in finished_syncs])
             self.show_message(message, _('Device synchronization finished'))
+            gpodder.user_extensions.on_all_episodes_synced()
         elif failed_syncs:
             message = self.format_episode_list([str(task) for task in failed_syncs])
             self.show_message(message, _('Device synchronization failed'), True)


### PR DESCRIPTION
First of all, thanks for such a Swiss army knife of an application! I use it daily in conjunction with my other self-hosted systems and open-source software, and it brings me nothing but joy.

However, there's one missing feature I am currently depending on. I use a rockbox-alike device for podcasts and music listening, and I need to run an arbitrary command to complete my routines, like scrobbling the Rockbox playback log to Last.fm, rsyncing music, and also audiobooks.

This plugin is essentially a copy of Command on Download, just that it executes once when device sync is complete. All related function calls and definitions added.

Documentation to be supplied to gpodder.github.io repo