### PR TITLE
Fix depcheck.py for windows build

### DIFF
--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -354,8 +354,7 @@ function cleanup_after {
     find "${MINGW_ROOT}"/bin -name "*.pyo" -exec rm -f {} \;
     find "${MINGW_ROOT}"/bin -name "*.pyc" -exec rm -f {} \;
 
-# TODO: Commented out until we can make depcheck.py working again.
-#    build_python "${MISC}/depcheck.py" --delete
+    build_python "${MISC}/depcheck.py" --delete
 
     find "${MINGW_ROOT}" -type d -empty -delete
 

--- a/tools/win_installer/misc/depcheck.py
+++ b/tools/win_installer/misc/depcheck.py
@@ -12,12 +12,12 @@ Deletes unneeded DLLs and checks DLL dependencies.
 Execute with the build python, will figure out the rest.
 """
 
+import logging
 import os
 import subprocess
 import sys
 from functools import cache
 from multiprocessing import Process, Queue
-import logging
 
 import gi  # isort:skip
 gi.require_version("GIRepository", "2.0")  # isort:skip

--- a/tools/win_installer/misc/depcheck.py
+++ b/tools/win_installer/misc/depcheck.py
@@ -140,7 +140,7 @@ def get_things_to_delete(root):
         if path:
             to_delete.append(path)
 
-    logging.debug(f"returning to_delete: {to_delete")
+    logging.debug(f"returning to_delete: {to_delete}")
     return to_delete
 
 

--- a/tools/win_installer/misc/depcheck.py
+++ b/tools/win_installer/misc/depcheck.py
@@ -73,7 +73,6 @@ def get_dependencies(filename):
         # can happen with wrong arch binaries
         return []
     data = data.decode("utf-8")
-    
     for line in data.splitlines():
         line = line.strip()
         if line.startswith("DLL Name:"):
@@ -157,7 +156,6 @@ def main(argv):
                 print("DELETE:", lib)
                 os.unlink(lib)
             libs = get_things_to_delete(sys.prefix)
-
 
 
 if __name__ == "__main__":

--- a/tools/win_installer/misc/depcheck.py
+++ b/tools/win_installer/misc/depcheck.py
@@ -140,7 +140,7 @@ def get_things_to_delete(root):
         if path:
             to_delete.append(path)
 
-    logging.debug(f"returing to_delete: {to_delete")
+    logging.debug(f"returning to_delete: {to_delete")
     return to_delete
 
 

--- a/tools/win_installer/misc/depcheck.py
+++ b/tools/win_installer/misc/depcheck.py
@@ -140,6 +140,8 @@ def main(argv):
                 print("DELETE:", lib)
                 os.unlink(lib)
             libs = get_things_to_delete(sys.prefix)
+    elif "--debug" in argv[1:]:
+        print(libs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fix adds a try...except around the problematic line for the `GIRepository-3.0.typelib` error. This results in `depcheck.py` deleting `libgirepository-2.0-0.dll`. And considering our GTK python binding doesn't use that dll (as mentioned in #1662) we should be fine.

In the end this reduces the windows install size by around 12MiB.

I tested the resulting exe files on windows and gpodder seems to run and work fine.

I have also added `--debug` option and lots of logging to `depcheck.py`. If that is not desired, I can remove them.
fixes #1662 
see also #1657

<details><summary>List of files depcheck.py deleted</summary>
<p>

```
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libharfbuzz-subset-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libturbojpeg.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libbrotlienc.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libasprintf-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/tcl86.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/tk86.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libgirepository-2.0-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libgif-7.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libpython3.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libwebpmux-3.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libtiffxx-6.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libpcre2-32-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libpcre2-16-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libmpdec++-4.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libatomic-1.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libncurses++w6.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libwebpdecoder-3.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libgthread-2.0-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libreadline8.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/edit.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libpcre2-posix-3.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libcairo-script-interpreter-2.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libgailutil-3-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libhistory8.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libcharset-1.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libwebpdemux-2.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libquadmath-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libgomp-1.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/liblzo2-2.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libpanelw6.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libformw6.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libtermcap-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libmenuw6.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libsystre-0.dll
DELETE: .../gpodder/tools/win_installer/_build_root/mingw32/bin/libtre-5.dll
```
</p>
</details> 
