### PR TITLE
Change progress dialog to be non-modal.

### DIFF
--- a/src/gpodder/gtkui/interface/progress.py
+++ b/src/gpodder/gtkui/interface/progress.py
@@ -71,7 +71,6 @@ class ProgressIndicator(object):
     def _create_progress(self):
         self.dialog = Gtk.MessageDialog(self.parent,
                 0, 0, Gtk.ButtonsType.CANCEL, self.subtitle or self.title)
-        self.dialog.set_modal(True)
         self.dialog.connect('delete-event', self._on_delete_event)
         if self.cancellable:
             def cancel_callback(dialog, response):


### PR DESCRIPTION
The main window is unresponsive during long running actions on the main loop. The progress dialog appeared to notify the user of the action's progress.

However, if the action failed and opened another dialog, it would cause the progress dialog to appear due to exceeding the timeout. This caused a deadlock between two modal dialogs, where the error dialog couldn't be clicked and the progress dialog had no cancel button, or was maybe also not clickable.

Making the progress dialog non-modal should prevent this from happening. The user will be able to click the non-responsive UI behind the dialog, but that is better than gpodder locking up.

@elelay Do you see any reason not to do this? It should fix the startup problems on Windows.