### PR TITLE
Remove the redundant application uniqueness test

### DIFF
--- a/bin/gpodder
+++ b/bin/gpodder
@@ -37,15 +37,6 @@ from optparse import OptionGroup, OptionParser
 
 logger = logging.getLogger(__name__)
 
-try:
-    import dbus
-    have_dbus = True
-except ImportError:
-    print("""
-    Warning: python-dbus not found. Disabling D-Bus support.
-    """, file=sys.stderr)
-    have_dbus = False
-
 
 def main():
     # Paths to important files
@@ -144,30 +135,6 @@ def main():
             and os.environ.get('WAYLAND_DISPLAY', '') == ''):
         logger.error('Cannot start gPodder: $DISPLAY or $WAYLAND_DISPLAY is not set.')
         sys.exit(1)
-
-    if have_dbus:
-        # Try to find an already-running instance of gPodder
-        session_bus = dbus.SessionBus()
-
-        # Obtain a reference to an existing instance; don't call get_object if
-        # such an instance doesn't exist as it *will* create a new instance
-        if session_bus.name_has_owner(gpodder.dbus_bus_name):
-            try:
-                remote_object = session_bus.get_object(
-                    gpodder.dbus_bus_name,
-                    gpodder.dbus_gui_object_path)
-
-                # An instance of GUI is already running
-                logger.info('Activating existing instance via D-Bus.')
-                remote_object.show_gui_window(
-                    dbus_interface=gpodder.dbus_interface)
-
-                if options.subscribe:
-                    remote_object.subscribe_to_url(options.subscribe)
-
-                return
-            except dbus.exceptions.DBusException as dbus_exception:
-                logger.info('Cannot connect to remote object.', exc_info=True)
 
     if gpodder.ui.gtk:
         from gpodder.gtkui import app

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -38,7 +38,7 @@ from .model import Model
 
 import gi  # isort:skip
 gi.require_version('Gtk', '3.0')  # isort:skip
-from gi.repository import GdkPixbuf, Gio, GObject, Gtk  # isort:skip
+from gi.repository import GdkPixbuf, Gio, GLib, Gtk  # isort:skip
 
 
 logger = logging.getLogger(__name__)
@@ -354,7 +354,7 @@ class gPodderApplication(Gtk.Application):
 
 
 def main(options=None):
-    GObject.set_application_name('gPodder')
+    GLib.set_application_name('gPodder')
 
     gp = gPodderApplication(options)
     gp.run()

--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -115,6 +115,10 @@ class gPodderApplication(Gtk.Application):
         action.connect('activate', self.on_menu)
         self.add_action(action)
 
+        action = Gio.SimpleAction.new('subscribe_to_url', GLib.VariantType.new('s'))
+        action.connect('activate', self.on_subscribe_to_url_activate)
+        self.add_action(action)
+
     def do_startup(self):
         Gtk.Application.do_startup(self)
 
@@ -335,6 +339,9 @@ class gPodderApplication(Gtk.Application):
             self.window.check_for_distro_updates()
         else:
             self.window.check_for_updates(silent=False)
+
+    def on_subscribe_to_url_activate(self, action, param):
+        self.window.subscribe_to_url(param.get_string())
 
     def on_extension_enabled(self, extension):
         self.window.on_extension_enabled(extension)


### PR DESCRIPTION
Gtk.Application (which gPodder uses already) ensures uniqueness without extra code.

Add a signal handler to 'notify::is-registered' which checks if the current instance is remote (i.e. gPodder is already running) and logs the same message about Dbus activation as before.