### PR TITLE
Break lines to under 80 characters on markdown docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,28 +3,38 @@
 ## Getting started <!-- omit in toc -->
 
 Before you begin:
-- Ensure you are using Python 3.7+
-- Check out the [existing issues](https://github.com/gpodder/gpodder/issues)
+ - Ensure you are using Python 3.7+
+ - Check out the [existing issues](https://github.com/gpodder/gpodder/issues)
 
-Contributions are made to this repo via Issues and Pull Requests (PRs). Make sure to search for existing Issues and PRs before creating your own.
+Contributions are made to this repo via Issues and Pull Requests (PRs). Make
+sure to search for existing Issues and PRs before creating your own.
 
 
 ## Getting the code and setting up the project
-1. Fork this project
-2. Clone the repository to your machine
-3. Create a separate branch to get started, e.g. for feature `feat/branch-name-here` or fix `fix/fix-name-goes-here`
-4. Make sure to create a new virtual environment and activate it:
-```shell
-python3 -m venv venv
-source activate venv/bin/activate
-```
-5. Install dependencies: [Run from Git](https://gpodder.github.io/docs/run-from-git.html)
-6. Start the program with debug mode: `./bin/gpodder -v`
-7. Make the changes, commit in a branch and push the branch to your fork and then submit a Pull Request.
+
+ 1. Fork this project
+ 2. Clone the repository to your machine
+ 3. Create a separate branch to get started, e.g. for feature
+    `feat/branch-name-here` or fix `fix/fix-name-goes-here`
+ 4. Make sure to create a new virtual environment and activate it:
+    ```shell
+    python3 -m venv venv source activate venv/bin/activate
+    ```
+ 5. Install dependencies: [Run from Git](
+    https://gpodder.github.io/docs/run-from-git.html)
+ 6. Start the program with debug mode: `./bin/gpodder -v`
+ 7. Make the changes, commit in a branch and push the branch to your fork and
+    then submit a Pull Request.
 
 ## Linting
-To ensure code quality, we recommend you to run the linter before pushing the changes to your repo. In order to do so ensure the necessary packages are installed by executing:
+
+To ensure code quality, we recommend you to run the linter before pushing the
+changes to your repo. In order to do so ensure the necessary packages are
+installed by executing:
+
 ```shell
 pip3 install pytest-cov minimock pycodestyle isort requests pytest pytest-httpserver
 ```
-Execute the linter in the root directory (Linux only): `make lint unittest`. On Windows execute: `pycodestyle share src/gpodder tools bin/* *.py`
+
+Execute the linter in the root directory (Linux only): `make lint unittest`. On
+Windows execute: `pycodestyle share src/gpodder tools bin/* *.py`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 As an alternative to python-dbus on Mac OS X and Windows, you can use
 the dummy (no-op) D-Bus module provided in "tools/fake-dbus-module/".
 
-For quick testing, see [Run from Git](https://gpodder.github.io/docs/run-from-git.html)
+For quick testing, see [Run from Git](
+https://gpodder.github.io/docs/run-from-git.html)
 to install dependencies.
 
 
@@ -55,12 +56,14 @@ to install dependencies.
 - Clickable links in GTK UI show notes: html5lib
 - HTML show notes: WebKit2 gobject bindings
     (webkit2gtk, webkitgtk4 or gir1.2-webkit2-4.0 packages).
-- Better Youtube support (> 15 entries in feeds, download audio-only): youtube_dl or yt-dlp
+- Better Youtube support (> 15 entries in feeds, download audio-only):
+    youtube_dl or yt-dlp
 
 
 ### Build Dependencies
 
-- [build](https://github.com/pypa/build/) only if using `make buildwheel` or `make install`
+- [build](https://github.com/pypa/build/) only if using `make buildwheel` or
+    `make install`
 - [installer](https://github.com/pypa/installer/) only if using `make install`
 - help2man
 - intltool
@@ -134,13 +137,14 @@ into an alternative root (default /) and prefix (default /usr):
 
     make install DESTDIR=tmp/ PREFIX=/usr/local/
 
-[*Debian*](https://wiki.debian.org/Python#Deviations_from_upstream) and *Ubuntu* use `dist-packages`
-instead of `site-packages` for third party installs, so you'll want something like:
+[*Debian*](https://wiki.debian.org/Python#Deviations_from_upstream) and *Ubuntu*
+use `dist-packages` instead of `site-packages` for third party installs, so
+you'll want something like:
 
     sudo python3 setup.py install --root / --prefix /usr/local --optimize=1 --install-lib=/usr/local/lib/python3.10/dist-packages
 
-In fact, first try running `python -c "import sys; print(sys.path)"` to check what is the exact path.
-It depends on your version of python.
+In fact, first try running `python -c "import sys; print(sys.path)"` to check
+what is the exact path.  It depends on your version of python.
 
 ## Portable Mode / Roaming Profiles
 
@@ -155,8 +159,10 @@ download directory directly on a MP3 player or USB disk:
 
 ## OS X Specific Notes
 
-- default GPODDER_HOME="$HOME/Library/Application Support/gPodder"
-- default GPODDER_DOWNLOAD_DIR="$HOME/Library/Application Support/gPodder/download"
+Default directories:
+
+ - GPODDER_HOME="$HOME/Library/Application Support/gPodder"
+ - GPODDER_DOWNLOAD_DIR="$HOME/Library/Application Support/gPodder/download"
 
 These settings may be modified by editing the following file of the .app :
 


### PR DESCRIPTION
The .editorconfig file has 80 chars as the line length for documentation files, so break lines on the markdown docs to that length.