### PR TITLE
Update gpodder.desktop.in

### DIFF
--- a/share/applications/gpodder.desktop.in
+++ b/share/applications/gpodder.desktop.in
@@ -7,5 +7,5 @@ Exec=__PREFIX__/bin/gpodder
 Icon=gpodder
 Terminal=false
 Type=Application
-Categories=AudioVideo;Audio;Network;FileTransfer;News;GTK;
+Categories=Network;Feed;GTK;
 StartupWMClass=gpodder


### PR DESCRIPTION
Desktop entry file has more than one 'Main Category'.

If multiple Main Categories are included in a single desktop entry file, the entry may appear more than once in the menu. I believe that gPodder belongs to 'Feed' category, so the more accurate classification of gPodder is a Network/Feed application.

References:
https://specifications.freedesktop.org/menu-spec/latest/category-registry.html https://specifications.freedesktop.org/menu-spec/latest/additional-category-registry.html