### PR TITLE
Fallback format by default

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -366,6 +366,7 @@ class gPodderYoutubeDL(download.CustomDownloader):
             return info, opts
 
     def fetch_video(self, info, opts):
+        self.add_format(self.gpodder_config, opts, fallback="bv*+ba/b")
         with youtube_dl.YoutubeDL(opts) as ydl:
             return ydl.process_video_result(info, download=True)
 


### PR DESCRIPTION
Lately I've been noticing that videos (from various sources) are not available except in video only or audio only formats, which isn't a big deal, since they can be easily merged. This is a fallback for the yt-dlp -f option to include, as last resorts, a combination of the best video and best audio, or the best available alone. This may often end up being a larger than expected file, but it is a fallback, and if a problem, an after-download command could be calling ffmpeg to scale the video, or the time until deletion could be reduced.