### PR TITLE
Rework Device preferences tab

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -21,6 +21,13 @@
     <property name="step-increment">1</property>
     <property name="page-increment">1</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment_max_filename_length">
+    <property name="lower">30</property>
+    <property name="upper">150</property>
+    <property name="value">60</property>
+    <property name="step-increment">5</property>
+    <property name="page-increment">5</property>
+  </object>
   <object class="GtkDialog" id="gPodderPreferences">
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
@@ -993,6 +1000,21 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkCheckButton" id="checkbutton_one_folder_per_podcast">
+                                <property name="label" translatable="yes">Create separate folders for each podcast</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkSeparator">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -1000,7 +1022,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -1016,7 +1038,22 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_playlists_use_absolute_path">
+                                <property name="label" translatable="yes">Use absolute paths in playlists</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -1058,134 +1095,18 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="checkbutton_delete_using_playlists">
-                                <property name="label" translatable="yes">Remove episodes deleted on device from gPodder</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">8</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkSeparator">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">6</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkFlowBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="min-children-per-line">1</property>
-                                <property name="max-children-per-line">2</property>
-                                <property name="selection-mode">none</property>
-                                <child>
-                                  <object class="GtkFlowBoxChild">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel" id="label_on_sync">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label" translatable="yes">After syncing an episode:</property>
-                                        <property name="xalign">0</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkFlowBoxChild">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkComboBox" id="combobox_on_sync">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <signal name="changed" handler="on_combobox_on_sync_changed" swapped="no"/>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">7</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">8</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="checkbutton_skip_played_episodes">
-                                <property name="label" translatable="yes">Only sync unplayed episodes</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">4</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">9</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="checkbutton_delete_deleted_episodes">
-                                <property name="label" translatable="yes">Remove episodes deleted in gPodder from device</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">4</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">10</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="checkbutton_compare_episode_filesize">
-                                <property name="label" translatable="yes">Sync existing episodes on device when file size differs from gPodder (disable if device modifies files)</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">4</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">11</property>
                               </packing>
                             </child>
                             <child>
@@ -1227,7 +1148,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">12</property>
+                                <property name="position">8</property>
                               </packing>
                             </child>
                             <child>
@@ -1269,18 +1190,102 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">13</property>
+                                <property name="position">9</property>
                               </packing>
                             </child>
-
                             <child>
-                              <object class="GtkCheckButton" id="checkbutton_one_folder_per_podcast">
-                                <property name="label" translatable="yes">Create separate folders for each podcast</property>
+                              <object class="GtkFlowBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="min-children-per-line">1</property>
+                                <property name="max-children-per-line">2</property>
+                                <property name="selection-mode">none</property>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label_max_filename_length">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Maximum filename length:</property>
+                                        <property name="wrap">True</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spinbutton_max_filename_length">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="halign">end</property>
+                                        <property name="text">60</property>
+                                        <property name="adjustment">adjustment_max_filename_length</property>
+                                        <property name="value">60</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">10</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">11</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_skip_played_episodes">
+                                <property name="label" translatable="yes">Only sync unplayed episodes</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin-bottom">4</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">12</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_compare_episode_filesize">
+                                <property name="label" translatable="yes">Sync existing episodes on device when file size differs from gPodder (disable if device modifies files)</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">13</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_delete_using_playlists">
+                                <property name="label" translatable="yes">Delete episodes from gPodder when deleted on Device</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
                                 <property name="draw-indicator">True</property>
                               </object>
                               <packing>
@@ -1290,14 +1295,12 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="checkbutton_playlists_use_absolute_path">
-                                <property name="label" translatable="yes">Use absolute paths in playlists</property>
+                              <object class="GtkLabel" id="label_delete_using_playlists_note">
                                 <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">4</property>
-                                <property name="draw-indicator">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Note: To detect episodes as deleted on the device, "Create playlists on device" must be enabled.</property>
+                                <property name="wrap">True</property>
+                                <property name="xalign">0</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1305,7 +1308,62 @@
                                 <property name="position">15</property>
                               </packing>
                             </child>
-                            
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_delete_deleted_episodes">
+                                <property name="label" translatable="yes">Delete episodes from Device when deleted in gPodder</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">16</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFlowBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="min-children-per-line">1</property>
+                                <property name="max-children-per-line">2</property>
+                                <property name="selection-mode">none</property>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label_on_sync">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">After syncing an episode:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkComboBox" id="combobox_on_sync">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <signal name="changed" handler="on_combobox_on_sync_changed" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">17</property>
+                              </packing>
+                            </child>
                           </object>
                           <packing>
                             <property name="name">devices</property>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1189,19 +1189,87 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="checkbutton_use_title_as_filename">
-                                <property name="label" translatable="yes">Use Episode Title as Filename</property>
+                              <object class="GtkFlowBox">
                                 <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="halign">start</property>
-                                <property name="draw-indicator">True</property>
-                                <signal name="toggled" handler="on_checkbutton_use_title_as_filename_toggled" swapped="no"/>
+                                <property name="can-focus">False</property>
+                                <property name="min-children-per-line">1</property>
+                                <property name="max-children-per-line">2</property>
+                                <property name="selection-mode">none</property>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label_episode_filename">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Episode filename method:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkComboBox" id="combobox_episode_filename">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <signal name="changed" handler="on_combobox_episode_filename_changed" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">12</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFlowBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="min-children-per-line">1</property>
+                                <property name="max-children-per-line">2</property>
+                                <property name="selection-mode">none</property>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label_custom_sync_name">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Custom filename format:</property>
+                                        <property name="xalign">0</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkFlowBoxChild">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkEntry" id="entry_custom_sync_name">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="hexpand">True</property>
+                                        <signal name="changed" handler="on_custom_sync_name_changed" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">13</property>
                               </packing>
                             </child>
                           </object>

--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1272,6 +1272,40 @@
                                 <property name="position">13</property>
                               </packing>
                             </child>
+
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_one_folder_per_podcast">
+                                <property name="label" translatable="yes">Create separate folders for each podcast</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">4</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">14</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_playlists_use_absolute_path">
+                                <property name="label" translatable="yes">Use absolute paths in playlists</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">4</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">15</property>
+                              </packing>
+                            </child>
+                            
                           </object>
                           <packing>
                             <property name="name">devices</property>

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -387,7 +387,8 @@ class gPodderPreferences(BuilderWidget):
         self._config.connect_gtk_togglebutton('device_sync.playlists.use_absolute_path',
                                               self.checkbutton_playlists_use_absolute_path)
         
-
+        self._config.connect_gtk_spinbutton('device_sync.max_filename_length', self.spinbutton_max_filename_length)
+        
         self.entry_custom_sync_name.set_text(self._config.device_sync.custom_sync_name)
 
         # Have to do this before calling set_active on checkbutton_enable
@@ -759,11 +760,13 @@ class gPodderPreferences(BuilderWidget):
         if not widget.get_active():
             self._config.device_sync.playlists.create = False
             self.toggle_playlist_interface(False)
+            self.checkbutton_playlists_use_absolute_path.set_sensitive(False)
             # need to read value of checkbutton from interface,
             # rather than value of parameter
         else:
             self._config.device_sync.playlists.create = True
             self.toggle_playlist_interface(True)
+            self.checkbutton_playlists_use_absolute_path.set_sensitive(True)
 
     def toggle_playlist_interface(self, enabled):
         if enabled and self._config.device_sync.device_type == 'filesystem':
@@ -803,6 +806,7 @@ class gPodderPreferences(BuilderWidget):
             self.entry_custom_sync_name.set_sensitive(False)
             self.checkbutton_one_folder_per_podcast.set_sensitive(False)
             self.checkbutton_playlists_use_absolute_path.set_sensitive(False)
+            self.spinbutton_max_filename_length.set_sensitive(False)
         elif device_type == 'filesystem':
             self.btn_filesystemMountpoint.set_label(self._config.device_sync.device_folder or "")
             self.btn_filesystemMountpoint.set_sensitive(True)
@@ -816,6 +820,7 @@ class gPodderPreferences(BuilderWidget):
                 self._config.device_sync.custom_sync_name_enabled)
             self.checkbutton_one_folder_per_podcast.set_sensitive(True)
             self.checkbutton_playlists_use_absolute_path.set_sensitive(True)
+            self.spinbutton_max_filename_length.set_sensitive(True)
         elif device_type == 'ipod':
             self.btn_filesystemMountpoint.set_label(self._config.device_sync.device_folder)
             self.btn_filesystemMountpoint.set_sensitive(True)
@@ -829,6 +834,7 @@ class gPodderPreferences(BuilderWidget):
             self.entry_custom_sync_name.set_sensitive(False)
             self.checkbutton_one_folder_per_podcast.set_sensitive(False)
             self.checkbutton_playlists_use_absolute_path.set_sensitive(False)
+            self.spinbutton_max_filename_length.set_sensitive(False)
         self.checkbutton_compare_episode_filesize.set_sensitive(True)
 
         children = self.btn_filesystemMountpoint.get_children()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -107,6 +107,29 @@ class OnSyncActionList(Gtk.ListStore):
         self._config.device_sync.after_sync.mark_episodes_played = self[index][self.C_ON_SYNC_MARK_PLAYED]
 
 
+class OnEpisodeFilenameList(Gtk.ListStore):
+    C_CAPTION, C_USE_EPISODE_TITLE, C_USE_CUSTOM_FORMAT = list(range(3))
+
+    def __init__(self, config):
+        Gtk.ListStore.__init__(self, str, bool, bool)
+        self._config = config
+        self.append((_('Same filename as local'), False, False))
+        self.append((_('Use episode title as filename'), True, False))
+        self.append((_('Use custom filename format'), False, True))
+
+    def get_index(self):
+        for index, row in enumerate(self):
+            if (self._config.device_sync.custom_sync_name_enabled and row[self.C_USE_CUSTOM_FORMAT]):
+                return index
+            if (self._config.device_sync.use_title_as_filename and row[self.C_USE_EPISODE_TITLE]):
+                return index
+        return 0
+
+    def set_index(self, index):
+        self._config.device_sync.use_title_as_filename = self[index][self.C_USE_EPISODE_TITLE]
+        self._config.device_sync.custom_sync_name_enabled = self[index][self.C_USE_CUSTOM_FORMAT]
+
+
 class YouTubeVideoFormatListModel(Gtk.ListStore):
     C_CAPTION, C_ID = list(range(2))
 
@@ -342,6 +365,13 @@ class gPodderPreferences(BuilderWidget):
         self.combobox_on_sync.add_attribute(cellrenderer, 'text', OnSyncActionList.C_CAPTION)
         self.combobox_on_sync.set_active(self.on_sync_model.get_index())
 
+        self.episode_filename_model = OnEpisodeFilenameList(self._config)
+        self.combobox_episode_filename.set_model(self.episode_filename_model)
+        cellrenderer = Gtk.CellRendererText()
+        self.combobox_episode_filename.pack_start(cellrenderer, True)
+        self.combobox_episode_filename.add_attribute(cellrenderer, 'text', OnEpisodeFilenameList.C_CAPTION)
+        self.combobox_episode_filename.set_active(self.episode_filename_model.get_index())
+
         self._config.connect_gtk_togglebutton('device_sync.skip_played_episodes',
                                               self.checkbutton_skip_played_episodes)
         self._config.connect_gtk_togglebutton('device_sync.playlists.create',
@@ -352,8 +382,8 @@ class gPodderPreferences(BuilderWidget):
                                               self.checkbutton_delete_deleted_episodes)
         self._config.connect_gtk_togglebutton('device_sync.compare_episode_filesize',
                                               self.checkbutton_compare_episode_filesize)
-        self._config.connect_gtk_togglebutton('device_sync.use_title_as_filename',
-                                              self.checkbutton_use_title_as_filename)
+
+        self.entry_custom_sync_name.set_text(self._config.device_sync.custom_sync_name)
 
         # Have to do this before calling set_active on checkbutton_enable
         self._enable_mygpo = self._config.mygpo.enabled
@@ -713,6 +743,12 @@ class gPodderPreferences(BuilderWidget):
         index = self.combobox_on_sync.get_active()
         self.on_sync_model.set_index(index)
 
+    def on_combobox_episode_filename_changed(self, widget):
+        index = self.combobox_episode_filename.get_active()
+        self.episode_filename_model.set_index(index)
+        self.entry_custom_sync_name.set_sensitive(
+            self._config.device_sync.custom_sync_name_enabled)
+
     def on_checkbutton_create_playlists_toggled(
             self, widget, device_type_changed=False):
         if not widget.get_active():
@@ -741,10 +777,10 @@ class gPodderPreferences(BuilderWidget):
 
     def on_checkbutton_use_title_as_filename_toggled(
             self, widget):
-        if not widget.get_active():
-            self._config.device_sync.use_title_as_filename = False
-        else:
+        if widget.get_active():
             self._config.device_sync.use_title_as_filename = True
+        else:
+            self._config.device_sync.use_title_as_filename = False
 
     def on_combobox_device_type_changed(self, widget):
         index = self.combobox_device_type.get_active()
@@ -758,7 +794,8 @@ class gPodderPreferences(BuilderWidget):
             self.checkbutton_delete_using_playlists.set_sensitive(False)
             self.combobox_on_sync.set_sensitive(False)
             self.checkbutton_skip_played_episodes.set_sensitive(False)
-            self.checkbutton_use_title_as_filename.set_sensitive(False)
+            self.combobox_episode_filename.set_sensitive(False)
+            self.entry_custom_sync_name.set_sensitive(False)
         elif device_type == 'filesystem':
             self.btn_filesystemMountpoint.set_label(self._config.device_sync.device_folder or "")
             self.btn_filesystemMountpoint.set_sensitive(True)
@@ -767,7 +804,9 @@ class gPodderPreferences(BuilderWidget):
             self.combobox_on_sync.set_sensitive(True)
             self.checkbutton_skip_played_episodes.set_sensitive(True)
             self.checkbutton_delete_deleted_episodes.set_sensitive(True)
-            self.checkbutton_use_title_as_filename.set_sensitive(True)
+            self.combobox_episode_filename.set_sensitive(True)
+            self.entry_custom_sync_name.set_sensitive(
+                self._config.device_sync.custom_sync_name_enabled)
         elif device_type == 'ipod':
             self.btn_filesystemMountpoint.set_label(self._config.device_sync.device_folder)
             self.btn_filesystemMountpoint.set_sensitive(True)
@@ -777,7 +816,8 @@ class gPodderPreferences(BuilderWidget):
             self.combobox_on_sync.set_sensitive(False)
             self.checkbutton_skip_played_episodes.set_sensitive(True)
             self.checkbutton_delete_deleted_episodes.set_sensitive(True)
-            self.checkbutton_use_title_as_filename.set_sensitive(True)
+            self.combobox_episode_filename.set_sensitive(False)
+            self.entry_custom_sync_name.set_sensitive(False)
         self.checkbutton_compare_episode_filesize.set_sensitive(True)
 
         children = self.btn_filesystemMountpoint.get_children()
@@ -858,3 +898,6 @@ class gPodderPreferences(BuilderWidget):
 
     def on_proxy_password_changed(self, widget):
         self._config.network.proxy_password = widget.get_text()
+
+    def on_custom_sync_name_changed(self, widget):
+        self._config.device_sync.custom_sync_name = widget.get_text()

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -386,9 +386,9 @@ class gPodderPreferences(BuilderWidget):
                                               self.checkbutton_one_folder_per_podcast)
         self._config.connect_gtk_togglebutton('device_sync.playlists.use_absolute_path',
                                               self.checkbutton_playlists_use_absolute_path)
-        
+
         self._config.connect_gtk_spinbutton('device_sync.max_filename_length', self.spinbutton_max_filename_length)
-        
+
         self.entry_custom_sync_name.set_text(self._config.device_sync.custom_sync_name)
 
         # Have to do this before calling set_active on checkbutton_enable

--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -382,6 +382,11 @@ class gPodderPreferences(BuilderWidget):
                                               self.checkbutton_delete_deleted_episodes)
         self._config.connect_gtk_togglebutton('device_sync.compare_episode_filesize',
                                               self.checkbutton_compare_episode_filesize)
+        self._config.connect_gtk_togglebutton('device_sync.one_folder_per_podcast',
+                                              self.checkbutton_one_folder_per_podcast)
+        self._config.connect_gtk_togglebutton('device_sync.playlists.use_absolute_path',
+                                              self.checkbutton_playlists_use_absolute_path)
+        
 
         self.entry_custom_sync_name.set_text(self._config.device_sync.custom_sync_name)
 
@@ -796,6 +801,8 @@ class gPodderPreferences(BuilderWidget):
             self.checkbutton_skip_played_episodes.set_sensitive(False)
             self.combobox_episode_filename.set_sensitive(False)
             self.entry_custom_sync_name.set_sensitive(False)
+            self.checkbutton_one_folder_per_podcast.set_sensitive(False)
+            self.checkbutton_playlists_use_absolute_path.set_sensitive(False)
         elif device_type == 'filesystem':
             self.btn_filesystemMountpoint.set_label(self._config.device_sync.device_folder or "")
             self.btn_filesystemMountpoint.set_sensitive(True)
@@ -807,6 +814,8 @@ class gPodderPreferences(BuilderWidget):
             self.combobox_episode_filename.set_sensitive(True)
             self.entry_custom_sync_name.set_sensitive(
                 self._config.device_sync.custom_sync_name_enabled)
+            self.checkbutton_one_folder_per_podcast.set_sensitive(True)
+            self.checkbutton_playlists_use_absolute_path.set_sensitive(True)
         elif device_type == 'ipod':
             self.btn_filesystemMountpoint.set_label(self._config.device_sync.device_folder)
             self.btn_filesystemMountpoint.set_sensitive(True)
@@ -818,6 +827,8 @@ class gPodderPreferences(BuilderWidget):
             self.checkbutton_delete_deleted_episodes.set_sensitive(True)
             self.combobox_episode_filename.set_sensitive(False)
             self.entry_custom_sync_name.set_sensitive(False)
+            self.checkbutton_one_folder_per_podcast.set_sensitive(False)
+            self.checkbutton_playlists_use_absolute_path.set_sensitive(False)
         self.checkbutton_compare_episode_filesize.set_sensitive(True)
 
         children = self.btn_filesystemMountpoint.get_children()


### PR DESCRIPTION
Add a dropdown for device filename method (same as local, episode title, custom syncname). Make this grey out unless it's actually available (filesystem-based devices).

Add a custom syncname field to the device tab, which is only available when using custom syncname.

Added max_filename_length, one_folder_per_podcast, use_absolute_path. Decided to omit playlists.extension. Reordered things in that tab as well.