### PR TITLE
Rename download directory after overriding title from OPML file.

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -2699,7 +2699,7 @@ class gPodder(BuilderWidget, dbus.service.Object):
 
                     if title is not None:
                         # Prefer title from subscription source (bug 1711)
-                        channel.title = title
+                        channel.rename(title)
                     if section is not None:
                         channel.section = section
 


### PR DESCRIPTION
Channel title from OPML file overrides title provided by feed. However, the download directory is set prior to that and must be renamed.

This is the same way gpo handles it.