### PR TITLE
Keep t32.exe and pip.exe in windows build

### DIFF
--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -245,8 +245,9 @@ function cleanup_after {
         fi
     done
 
-    find "${MINGW_ROOT}" -regextype "posix-extended" -name "*.exe" -a ! \
-        -iregex ".*/(gpodder|gpo|python)[^/]*\\.exe" \
+    find "${MINGW_ROOT}" -path "**/site-packages" -prune -o \
+        -regextype "posix-extended" -name "*.exe" -a ! \
+        -iregex ".*/(gpodder|gpo|python|pip)[^/]*\\.exe" \
         -exec rm -f {} \;
 
     rm -Rf "${MINGW_ROOT}"/libexec


### PR DESCRIPTION
The current windows build deletes all `.exe` files that are in python `site-packages/` directory. Using pip to update packages in-place needs some of those `.exe` files, Specifically in `distlib/`.

See this link for the discussion motivating this change: 
https://github.com/gpodder/gpodder/issues/1688#issuecomment-2667378738

Let me know if anything needs to change.

This change results in these files being added to the installed directory compared to `master`:

```
data/bin/pip.exe
data/bin/pip3.exe
data/lib/python3.12/site-packages/distlib/t32.exe
data/lib/python3.12/site-packages/distlib/w32.exe
data/lib/python3.12/site-packages/installer/_scripts/t32.exe
data/lib/python3.12/site-packages/installer/_scripts/w32.exe
data/lib/python3.12/site-packages/setuptools/cli.exe
data/lib/python3.12/site-packages/setuptools/cli-32.exe
data/lib/python3.12/site-packages/setuptools/gui.exe
data/lib/python3.12/site-packages/setuptools/gui-32.exe
```