### PR TITLE
Add support for updating in youtube-dl extension preferences

### DIFF
--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -596,7 +596,7 @@ class gPodderExtension:
                 self.latest_version = match.group(1)
                 success = True
             else:
-                logger.Error("Could not find LATEST version in pip output")
+                logger.Error("Could not find LATEST version in pip output:\n%s", output)
                 self.latest_version = None
         except Exception as e:
             logger.Error("Error checking for latest version: %r", e)

--- a/share/gpodder/extensions/youtube-dl.py
+++ b/share/gpodder/extensions/youtube-dl.py
@@ -588,6 +588,7 @@ class gPodderExtension:
                     [sys.executable, '-m', 'pip', 'index', 'versions', program_name],
                     stderr=subprocess.STDOUT,
                     encoding='utf-8',
+                    close_fds=True,
                     timeout=60)
             logger.debug("pip index version %s: %s", program_name, output)
             match = re.search(r'LATEST:\s*(\S*)', output)
@@ -621,6 +622,7 @@ class gPodderExtension:
                     [sys.executable, '-m', 'pip', 'install', '--upgrade', program_name],
                     stderr=subprocess.STDOUT,
                     encoding='utf-8',
+                    close_fds=True,
                     timeout=120)
         except subprocess.CalledProcessError as e:
             logger.error("Error running %s: exit code %s, output: %s", e.cmd, e.returncode, e.output)


### PR DESCRIPTION
This pull request adds two buttons to the youtube-dl extension preferences:

![yt-dlp](https://github.com/user-attachments/assets/c2e4976b-2be9-4dde-b559-ceb765daad10)

The "Check for update" button runs `pip index versions yt-dlp` and attempts to parse its output for the line `LATEST: ...` and updates the label to show it.
<details><summary><code>pip index versions yt-dlp</code> output</summary>

```
$ pip index versions yt-dlp
WARNING: pip index is currently an experimental command. It may be removed/changed in a futur
e release without prior warning.
yt-dlp (2025.2.19)
Available versions: 2025.2.19, 2025.1.26, 2025.1.15, 2025.1.12, 2024.12.23, 2024.12.13, 2024.
12.6, 2024.12.3, 2024.11.18, 2024.11.4, 2024.10.22, 2024.10.7, 2024.9.27, 2024.8.6, 2024.8.1,
 2024.7.25, 2024.7.16, 2024.7.9, 2024.7.8, 2024.7.7, 2024.7.2, 2024.7.1, 2024.5.27, 2024.5.26
, 2024.4.9, 2024.3.10, 2023.12.30, 2023.11.16, 2023.11.14, 2023.10.13, 2023.10.7, 2023.9.24,
2023.7.6, 2023.6.22, 2023.6.21, 2023.3.4, 2023.3.3, 2023.2.17, 2023.1.6, 2023.1.2, 2022.11.11
, 2022.10.4, 2022.9.1, 2022.8.19, 2022.8.14, 2022.8.8, 2022.7.18, 2022.7.17, 2022.6.29, 2022.
6.22.1, 2022.6.22, 2022.5.18, 2022.4.8, 2022.3.8.2, 2022.3.8.1, 2022.3.8, 2022.2.4, 2022.2.3,
 2022.1.21, 2021.12.27, 2021.12.25, 2021.12.1, 2021.11.10.1, 2021.11.10, 2021.10.22, 2021.10.
10, 2021.10.9, 2021.9.25, 2021.9.2, 2021.9.1, 2021.8.10, 2021.8.2, 2021.7.24, 2021.7.21, 2021
.7.7, 2021.6.23, 2021.6.9, 2021.6.1, 2021.5.20, 2021.5.11, 2021.4.22, 2021.4.11, 2021.4.3, 20
21.3.24.1, 2021.3.21, 2021.3.15, 2021.3.7, 2021.3.3.2, 2021.3.1, 2021.2.24, 2021.2.19, 2021.2
.15, 2021.2.9, 2021.2.4, 2021.1.29, 2021.1.24.post1, 2021.1.24, 2021.1.20, 2021.1.16
  INSTALLED: 2025.2.19
  LATEST:    2025.2.19

``` 

</details> 

The "Update" button runs `pip install --upgrade yt-dlp`.

I'm asking for your thoughts about this approach. Is this layout ok?

Possible improvements:
- Should this be shown in all gpodder installs? Or should it be limited to the windows and mac versions? This won't work for gpodder installed from linux repositories that manage `yt-dlp` themselves.
- Is it possible to re-import the updated `yt-dlp`  module? Currently you need to restart gpodder to use the updated module.
- Currently the UI freezes when running the pip commands

See initial discussion: https://github.com/gpodder/gpodder/issues/1688#issuecomment-2667378738

Let me know if anything needs to change.