### PR TITLE
Use DBus ShowItems method in on_open_episode_download_folder()

### DIFF
--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -509,7 +509,7 @@ def get_free_disk_space(path):
     return s.f_bavail * s.f_bsize
 
 
-def format_date(timestamp):
+def format_date(timestamp, today=None):
     """Convert a UNIX timestamp to a date representation.
 
     This function returns "Today", "Yesterday", a weekday name or
@@ -521,14 +521,15 @@ def format_date(timestamp):
 
     For instance on windows we can't represent dates before epoch (timestamp<0)
 
+    The 'today' keyword argument is used for testing purposes only.
+
     >>> (os.name == 'nt') == (format_date(-39539) == None)
     True
     >>> format_date(time.time())
     'Today'
     >>> format_date(time.time() - 24*60*60)
     'Yesterday'
-    >>> weekday = datetime.datetime.now().weekday()
-    >>> 'Wednesday' if weekday == 2 else format_date(time.time() - ((weekday + 5)%7)*24*60*60)
+    >>> format_date(1742388710.0, today=datetime.date(2025, 3, 21))
     'Wednesday'
     >>> if os.name == 'posix':
     ...    old_tz = os.environ.get('TZ')
@@ -552,7 +553,8 @@ def format_date(timestamp):
         logger.warning('Cannot convert timestamp %r' % timestamp, exc_info=True)
         return None
 
-    today = datetime.date.today()
+    if today is None:
+        today = datetime.date.today()
 
     delta = today - timestamp_date
 

--- a/src/gpodder/util.py
+++ b/src/gpodder/util.py
@@ -1546,6 +1546,7 @@ def gui_open(filename, gui=None):
                 raise Exception((_("System default program '%(opener)s' not found"))
                     % {'opener': opener}
                 )
+            logger.debug('Opening file/folder "%s" using "%s"', filename, opener_fullpath)
             Popen([opener_fullpath, filename], close_fds=True)
         return True
     except:


### PR DESCRIPTION
Use the org.freedesktop.FileManager1.ShowItems method to open the selected episode in the default file manager. The file manager then opens with the given episode already selected.

If a Dbus connection cannot be obtained or the method call fails, fall back to opening the containing folder with util.gui_open(), as before.

Add debug logging to indicate which method is used.

---

I researched how to do this on #1741 and the implementation is straightforward.

This works for me on Linux with Nautilus which implements the `FileManager1` interface and with Nautilus uninstalled, the fallback to `gui_open()` is then used.

It would be nice to know if this breaks anything on Windows or MacOS, or on Linux systems without Dbus.