### PR TITLE
Fix windows build, depcheck.py: Add try..except to try GIRepository 3.0 then 2.0

### DIFF
--- a/tools/win_installer/misc/depcheck.py
+++ b/tools/win_installer/misc/depcheck.py
@@ -32,25 +32,30 @@ except ValueError as e:
 from gi.repository import GIRepository  # isort:skip
 
 
-def _get_shared_libraries(q, namespace, version):
+def _get_shared_libraries(q, namespace, version, loglevel=logging.WARNING):
+    import multiprocessing
+    logger = multiprocessing.log_to_stderr(level=loglevel)
+
     repo = GIRepository.Repository()
     try:
         repo.require(namespace, version, 0)
         if girepository_version == 3:
             ret = repo.get_shared_libraries(namespace)
+            logger.debug("repo.get_share_libraries(%s) returned: %s", namespace, ret)
             if ret:
                 lib = ret[0]
             else:
                 lib = None
         elif girepository_version == 2:
             lib = repo.get_shared_library(namespace)
+            logger.debug("repo.get_share_library(%s) returned: %s", namespace, lib)
         else:
             lib = None
-            logging.error("GIRepository version is not 3 or 2")
+            logger.error("GIRepository version is not 3 or 2")
 
         q.put(lib)
     except Exception as e:
-        logging.exception(e)
+        logger.exception(e)
         q.put(None)
 
 
@@ -58,8 +63,9 @@ def _get_shared_libraries(q, namespace, version):
 def get_shared_libraries(namespace, version):
     # we have to start a new process because multiple versions can't be loaded
     # in the same process
+    loglevel = logging.getLogger().getEffectiveLevel()
     q = Queue()
-    p = Process(target=_get_shared_libraries, args=(q, namespace, version))
+    p = Process(target=_get_shared_libraries, args=(q, namespace, version, loglevel))
     p.start()
     result = q.get()
     p.join()


### PR DESCRIPTION
Hopefully this fixes the windows build ci.

Due to the differences in the API between the versions I have added an if..else to call the right method for the version '3.0' vs '2.0'.

Any input is appreciated.

See also: #1662
Closes #1742 