### PR TITLE
Set published timestamp on downloaded files.

### DIFF
--- a/src/gpodder/download.py
+++ b/src/gpodder/download.py
@@ -381,6 +381,13 @@ class DefaultDownload(CustomDownload):
                             url)
                     continue
                 raise
+
+        # Podcastparser defaults published to zero if pubDate is not specified in feed,
+        # so only change the file timestamp if non-zero.
+        # This does mean that episodes released exactly on the epoch will get current time.
+        if self.__episode.published != 0 and self.__episode.published < time.time():
+            os.utime(tempname, (self.__episode.published, self.__episode.published))
+
         return (headers, real_url)
 
 


### PR DESCRIPTION
Downloaded episode files receive the current time on disk, this changes them to the published timestamp, if available. Episodes downloaded with yt-dlp already do this.

Fixes #1745.