### PR TITLE
windows nsis build: use `$GPO_VERSION` for VIProductVersion

### DIFF
--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -481,7 +481,7 @@ function build_installer {
     (cd $(dirname "$BUILDPY") && build_compileall -d "" -q -f -l .)
 
     cp "${MISC}"/gpodder.ico "${BUILD_ROOT}"
-    (cd "$BUILD_ROOT" && makensis -V3 -NOCD -DVERSION="$GPO_VERSION_DESC" -DBUILD_VERSION="$BUILD_VERSION" "${MISC}"/win_installer.nsi)
+    (cd "$BUILD_ROOT" && makensis -V3 -NOCD -DVERSION="$GPO_VERSION" -DVERSION_DESC="$GPO_VERSION_DESC" -DBUILD_VERSION="$BUILD_VERSION" "${MISC}"/win_installer.nsi)
 
     mv "$BUILD_ROOT/gpodder-LATEST.exe" "$DIR/gpodder-$GPO_VERSION_DESC-installer.exe"
 }

--- a/tools/win_installer/misc/win_installer.nsi
+++ b/tools/win_installer/misc/win_installer.nsi
@@ -108,8 +108,8 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "${GPO_NAME}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "${GPO_WEBSITE}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright gPodder Project GPL-3.0"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "${GPO_DESC}"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${VERSION}"
-VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${VERSION}"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${VERSION_DESC}"
+VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${VERSION_DESC}"
 # Need to be four numbers separated by dots
 VIProductVersion "${VERSION}.${BUILD_VERSION}"
 


### PR DESCRIPTION
Trying to build the master branch on windows I found `$GPO_VERSION_DESC` can be like `3.11.5-rev253-93b29332` and it would be passed to the nsis script as the version.

But `VIProductVersion` demands version to be four numbers separated by dots. And this would result in an error that aborts the build.

We can use the more descriptive `$GPO_VERSION_DESC` for other settings that accept a version.