### PR TITLE
Fix sync 'destination field' bug.

### DIFF
--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -197,6 +197,9 @@ class Device(services.ObservableService):
         signals = ['progress', 'sub-progress', 'status', 'done', 'post-done']
         services.ObservableService.__init__(self, signals)
 
+    def get_device_description(self):
+        return 'unknown device'
+
     def open(self):
         pass
 
@@ -298,6 +301,9 @@ class iPodDevice(Device):
             # Can't get free disk space
             return -1
         return result - RESERVED_FOR_ITDB
+
+    def get_device_description(self):
+        return 'iPod mountpoint %s' % self.mountpoint
 
     def open(self):
         Device.open(self)
@@ -438,6 +444,9 @@ class MP3PlayerDevice(Device):
     def get_free_space(self):
         info = self.destination.query_filesystem_info(Gio.FILE_ATTRIBUTE_FILESYSTEM_FREE, None)
         return info.get_attribute_uint64(Gio.FILE_ATTRIBUTE_FILESYSTEM_FREE)
+
+    def get_device_description(self):
+        return 'MP3 player destination %s' % self.destination.get_uri()
 
     def open(self):
         Device.open(self)

--- a/src/gpodder/syncui.py
+++ b/src/gpodder/syncui.py
@@ -114,8 +114,7 @@ class gPodderSyncUI(object):
                 # Only set if device is configured and opened successfully
                 self.device = device
         except Exception as err:
-            logger.error('opening destination %s failed with %s',
-                device.destination.get_uri(), err.message)
+            logger.error('opening %s failed with %s', device.get_device_description(), err.message)
             self._show_message_cannot_open()
             if done_callback:
                 done_callback()


### PR DESCRIPTION
PR #1401 queried the destination field only available in MP3PlayerDevice, causing iPod devices to throw an exception. This adds a description method to all devices that returns a string for use in sync errors.

Partially fixes #1753.

@elelay Both devices technically use the `device_folder` config value, which is called mountpoint for ipod and destination for mp3 player. Should I just use "folder" for both of them in `get_device_description()` so they make more sense for users reading logs?

We could also use this method in the MP3PlayerDevice destination errors to make them more readable.