### PR TITLE
Fix setuptools deprecation warnings.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,8 @@ authors = [
     {name = "Thomas Perl", email = "thp@gpodder.org"},
 ]
 readme = "README.md"
-license = {file = "COPYING"}
-classifiers = [
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-]
+license = "GPL-3.0-or-later"
+license-files = ["COPYING"]
 requires-python = ">=3.8"
 dependencies = [
     "dbus-python;platform_system=='Linux'",


### PR DESCRIPTION
> `project.license` as a TOML table is deprecated

> License classifiers are deprecated.

@elelay We can't merge this until the Mac build is updated from setuptools 65.5.0 to 77.0.3+.