### PR TITLE
get_new_episodes(): Deduplicate existing vs new branches

### DIFF
--- a/src/gpodder/model.py
+++ b/src/gpodder/model.py
@@ -169,22 +169,18 @@ class PodcastParserFeed(Feed):
             # Detect (and update) existing episode based on GUIDs
             existing_episode = existing_guids.get(episode.guid, None)
             if existing_episode:
-                if existing_episode.total_time == 0 and 'youtube' in episode.url:
-                    # query duration for existing youtube episodes that haven't been downloaded or queried
-                    # such as live streams after they have ended
-                    existing_episode.total_time = youtube.get_total_time(episode)
-
                 existing_episode.update_from(episode)
-                existing_episode.cache_text_description()
-                existing_episode.save()
-                continue
-            elif episode.total_time == 0 and 'youtube' in episode.url:
-                # query duration for new youtube episodes
+                episode = existing_episode
+            else:
+                new_episodes.append(episode)
+
+            if episode.total_time == 0 and 'youtube' in episode.url:
+                # query duration for new and existing youtube episodes that haven't been
+                # downloaded or queried such as live streams after they have ended
                 episode.total_time = youtube.get_total_time(episode)
 
             episode.cache_text_description()
             episode.save()
-            new_episodes.append(episode)
         return new_episodes, seen_guids
 
     def get_next_page(self, channel, max_episodes):


### PR DESCRIPTION
Random drive-by change.

Instead of duplicating:

* The conditional call to `youtube.get_total_time()`
* Calls to `.cache_text_description()` and `.save()`

We do these only once after having determined if it's an existing episode (and we call `.update_from()`, then the existing episode becomes `episode`) or a new episode (and we append it to `new_episodes`).

There's one logical difference to the old code (but probably unintended):

* Previously, `youtube.get_total_time(episode)` and `'youtube' in episode.url` were called on the "new" episode, whereas now it would be called on the existing object, having been updated from the "new" episode with `.update_from()`, so practically it hopefully is the same