### PR TITLE
Add Traditional Chinese (Taiwan) translation (zh-TW)

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,0 +1,3230 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Kerry LU <KerryYK.Lu@gmail.com>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-04 03:44+0800\n"
+"PO-Revision-Date: 2025-06-04 02:01+0800\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.6\n"
+
+#: src/gpodder/config.py:53
+#, python-format
+msgid "gPodder on %s"
+msgstr "%s 上的 gPodder"
+
+#: src/gpodder/deviceplaylist.py:133
+#, python-format
+msgid "Folder %s could not be created."
+msgstr "資料夾 %s 無法建立。"
+
+#: src/gpodder/deviceplaylist.py:133
+msgid "Error writing playlist"
+msgstr "寫入播放清單錯誤"
+
+#: src/gpodder/directory.py:111
+msgid "gpodder.net search"
+msgstr "搜尋 gpodder.net"
+
+#: src/gpodder/directory.py:121
+msgid "OPML from web"
+msgstr "來自網路的 OPML 檔案"
+
+#: src/gpodder/directory.py:131
+msgid "OPML file"
+msgstr "OPML 檔案"
+
+#: src/gpodder/directory.py:141 share/gpodder/ui/gtk/gpodderwelcome.ui.h:1
+msgid "Getting started"
+msgstr "開始"
+
+#: src/gpodder/directory.py:151
+msgid "gpodder.net Top 50"
+msgstr "gpodder.net Top 50"
+
+#: src/gpodder/directory.py:161
+msgid "gpodder.net Tags"
+msgstr "gpodder.net 標籤"
+
+#: src/gpodder/directory.py:180
+msgid "Soundcloud search"
+msgstr "搜尋 Soundcloud"
+
+#: src/gpodder/directory.py:195
+msgid "Sorry, soundcloud search doesn't work anymore."
+msgstr "抱歉，Soundcloud 搜尋功能已無法使用。"
+
+#: src/gpodder/directory.py:198
+#, python-format
+msgid "Error querying soundcloud: %(code)s %(msg)s"
+msgstr "查詢 Soundcloud 時發生錯誤：%(code)s %(msg)s"
+
+#: src/gpodder/directory.py:199
+#, python-format
+msgid "Unexpected response from soundcloud: %r"
+msgstr "收到 Soundcloud 的非預期回應：%r"
+
+#: src/gpodder/directory.py:204
+msgid "Imported OPML file"
+msgstr "已匯入 OPML 檔案"
+
+#: src/gpodder/download.py:595 src/gpodder/sync.py:657
+msgid "Queued"
+msgstr "已排入佇列"
+
+#: src/gpodder/download.py:595 src/gpodder/gtkui/model.py:390
+msgid "Downloading"
+msgstr "下載中"
+
+#: src/gpodder/download.py:596 src/gpodder/model.py:905 src/gpodder/sync.py:658
+msgid "Finished"
+msgstr "已完成"
+
+#: src/gpodder/download.py:596 src/gpodder/sync.py:658
+msgid "Failed"
+msgstr "失敗"
+
+#: src/gpodder/download.py:596 src/gpodder/sync.py:658
+msgid "Cancelling"
+msgstr "正在取消"
+
+#: src/gpodder/download.py:596 src/gpodder/sync.py:658
+msgid "Cancelled"
+msgstr "已取消"
+
+#: src/gpodder/download.py:596 src/gpodder/sync.py:658
+msgid "Pausing"
+msgstr "暫停中"
+
+#: src/gpodder/download.py:596 src/gpodder/sync.py:658
+#: src/gpodder/gtkui/model.py:386
+msgid "Paused"
+msgstr "已暫停"
+
+#: src/gpodder/download.py:988
+msgid "Episode has no URL to download"
+msgstr "單集沒有可供下載的 URL"
+
+#: src/gpodder/download.py:991
+msgid "Missing content from server"
+msgstr "伺服器端缺少內容"
+
+#: src/gpodder/download.py:997
+#, python-format
+msgid "Couldn't connect to server %(host)s:%(port)s"
+msgstr "無法連線到伺服器 %(host)s:%(port)s"
+
+#: src/gpodder/download.py:1006
+#, python-format
+msgid "Request Error: %(error)s"
+msgstr "請求錯誤：%(error)s"
+
+#: src/gpodder/download.py:1012
+#, python-format
+msgid "I/O Error: %(error)s: %(filename)s"
+msgstr "I/O 錯誤：%(error)s: %(filename)s"
+
+#: src/gpodder/download.py:1018
+#, python-format
+msgid "HTTP Error %(code)s: %(message)s"
+msgstr "HTTP 錯誤 %(code)s: %(message)s"
+
+#: src/gpodder/download.py:1022 src/gpodder/sync.py:858
+#, python-format
+msgid "Error: %s"
+msgstr "錯誤：%s"
+
+#: src/gpodder/extensions.py:48
+msgid "Desktop Integration"
+msgstr "桌面整合"
+
+#: src/gpodder/extensions.py:49
+msgid "Interface"
+msgstr "使用者介面"
+
+#: src/gpodder/extensions.py:50
+msgid "Post download"
+msgstr "下載後處理"
+
+#: src/gpodder/extensions.py:52 src/gpodder/model.py:970
+#: src/gpodder/model.py:1393
+msgid "Other"
+msgstr "其他"
+
+#: src/gpodder/extensions.py:93
+msgid "No description for this extension."
+msgstr "此擴充功能沒有描述。"
+
+#: src/gpodder/extensions.py:218
+#, python-format
+msgid "Command not found: %(command)s"
+msgstr "找不到指令：%(command)s"
+
+#: src/gpodder/extensions.py:234
+#, python-format
+msgid "Need at least one of the following commands: %(list_of_commands)s"
+msgstr "至少需要以下其一指令：%(list_of_commands)s"
+
+#: src/gpodder/extensions.py:272
+#, python-format
+msgid "Python module not found: %(module)s"
+msgstr "找不到 Python 模組：%(module)s"
+
+#: src/gpodder/model.py:605 src/gpodder/model.py:612 src/gpodder/youtube.py:591
+msgid "No description available"
+msgstr "無可用描述"
+
+#: src/gpodder/model.py:841
+msgid "unknown"
+msgstr "未知"
+
+#: src/gpodder/model.py:935
+msgid "Default"
+msgstr "預設"
+
+#: src/gpodder/model.py:936
+msgid "Only keep latest"
+msgstr "僅保留最新"
+
+#: src/gpodder/model.py:1376 src/gpodder/model.py:1391
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:56
+msgid "Video"
+msgstr "影片"
+
+#: src/gpodder/model.py:1389
+msgid "Audio"
+msgstr "音訊"
+
+#: src/gpodder/model.py:1569
+#, python-format
+msgid ""
+"Warning: path to gPodder home (%(root)s) is very long and can result in "
+"failure to download files.\n"
+msgstr "警告：gPodder 家目錄的路徑 (%(root)s) 過長，可能導致下載檔案失敗。\n"
+
+#: src/gpodder/model.py:1571
+msgid "You're advised to set it to a shorter path."
+msgstr "建議您將其設定為較短的路徑。"
+
+#: src/gpodder/my.py:180
+#, python-format
+msgid "Add %s"
+msgstr "新增 %s"
+
+#: src/gpodder/my.py:182
+#, python-format
+msgid "Remove %s"
+msgstr "移除 %s"
+
+#: src/gpodder/sync.py:205
+msgid "Cancelled by user"
+msgstr "使用者已取消"
+
+#: src/gpodder/sync.py:208
+msgid "Writing data to disk"
+msgstr "正在將資料寫入磁碟"
+
+#: src/gpodder/sync.py:310
+msgid "Opening iPod database"
+msgstr "正在開啟 iPod 資料庫"
+
+#: src/gpodder/sync.py:316
+msgid "iPod opened"
+msgstr "已開啟 iPod"
+
+#: src/gpodder/sync.py:325
+msgid "Saving iPod database"
+msgstr "正在儲存 iPod 資料庫"
+
+#: src/gpodder/sync.py:358 src/gpodder/sync.py:633
+#, python-format
+msgid "Removing %s"
+msgstr "正在移除 %s"
+
+#: src/gpodder/sync.py:369 src/gpodder/sync.py:504
+#, python-format
+msgid "Adding %s"
+msgstr "正在新增 %s"
+
+#: src/gpodder/sync.py:386
+#, python-format
+msgid "Error copying %(episode)s: Not enough free space on %(mountpoint)s"
+msgstr "複製 %(episode)s 時發生錯誤：%(mountpoint)s 上沒有足夠的可用空間"
+
+#: src/gpodder/sync.py:444
+msgid "Opening MP3 player"
+msgstr "正在開啟 MP3 播放器"
+
+#: src/gpodder/sync.py:469
+msgid "MP3 player opened"
+msgstr "已開啟 MP3 播放器"
+
+#: src/gpodder/sync.py:523
+#, python-format
+msgid ""
+"Not enough space in %(path)s: %(free)s available, but need at least %(need)s"
+msgstr "%(path)s 中的空間不足：可用空間 %(free)s，但至少需要 %(need)s"
+
+#: src/gpodder/sync.py:560
+#, python-format
+msgid "Error copying %(from_file)s to %(to_file)s: %(message)s"
+msgstr "將 %(from_file)s 複製到 %(to_file)s 時發生錯誤：%(message)s"
+
+#: src/gpodder/sync.py:657
+msgid "Syncing"
+msgstr "同步中"
+
+#: src/gpodder/syncui.py:88
+msgid "No device configured"
+msgstr "沒有已設定的裝置"
+
+#: src/gpodder/syncui.py:89
+msgid "Please set up your device in the preferences dialog."
+msgstr "請在偏好設定對話方塊中設定您的裝置。"
+
+#: src/gpodder/syncui.py:94
+msgid "Cannot open device"
+msgstr "無法開啟裝置"
+
+#: src/gpodder/syncui.py:95
+msgid "Please check logs and the settings in the preferences dialog."
+msgstr "請檢查日誌以及偏好設定對話方塊中的設定。"
+
+#: src/gpodder/syncui.py:156
+msgid "Not enough space left on device"
+msgstr "裝置剩餘空間不足"
+
+#: src/gpodder/syncui.py:157
+#, python-format
+msgid ""
+"Additional free space required: %(required_space)s\n"
+"Do you want to continue?"
+msgstr ""
+"需要額外的 %(required_space)s 空間\n"
+"您要繼續嗎？"
+
+#: src/gpodder/syncui.py:221
+msgid "Update successful"
+msgstr "更新成功"
+
+#: src/gpodder/syncui.py:222
+msgid "The playlist on your MP3 player has been updated."
+msgstr "您 MP3 播放器上的播放清單已更新。"
+
+#: src/gpodder/syncui.py:294 src/gpodder/gtkui/main.py:982
+#: src/gpodder/gtkui/main.py:1185 src/gpodder/gtkui/main.py:3104
+#: src/gpodder/gtkui/main.py:3378
+#: src/gpodder/gtkui/desktop/episodeselector.py:130
+msgid "Episode"
+msgstr "單集"
+
+#: src/gpodder/syncui.py:299
+msgid "Episodes have been deleted on device"
+msgstr "裝置上的單集已被刪除"
+
+#: src/gpodder/syncui.py:311
+msgid "Error writing playlist files"
+msgstr "寫入播放清單檔案時發生錯誤"
+
+#: src/gpodder/util.py:466
+#, python-format
+msgid "%(count)d day ago"
+msgid_plural "%(count)d days ago"
+msgstr[0] "%(count)d 天前"
+
+#: src/gpodder/util.py:560
+msgid "Today"
+msgstr "今天"
+
+#: src/gpodder/util.py:562
+msgid "Yesterday"
+msgstr "昨天"
+
+#: src/gpodder/util.py:577
+msgid "kB"
+msgstr "kB"
+
+#: src/gpodder/util.py:578
+msgid "MB"
+msgstr "MB"
+
+#: src/gpodder/util.py:579
+msgid "GB"
+msgstr "GB"
+
+#: src/gpodder/util.py:583
+msgid "KiB"
+msgstr "KiB"
+
+#: src/gpodder/util.py:584
+msgid "MiB"
+msgstr "MiB"
+
+#: src/gpodder/util.py:585
+msgid "GiB"
+msgstr "GiB"
+
+#: src/gpodder/util.py:591 src/gpodder/util.py:594
+msgid "(unknown)"
+msgstr "(未知)"
+
+#: src/gpodder/util.py:601
+msgid "B"
+msgstr "B"
+
+#: src/gpodder/util.py:1484 src/gpodder/util.py:1506
+#, python-format
+msgid "%(count)d second"
+msgid_plural "%(count)d seconds"
+msgstr[0] "%(count)d 秒"
+
+#: src/gpodder/util.py:1498
+#, python-format
+msgid "%(count)d hour"
+msgid_plural "%(count)d hours"
+msgstr[0] "%(count)d 小時"
+
+#: src/gpodder/util.py:1502
+#, python-format
+msgid "%(count)d minute"
+msgid_plural "%(count)d minutes"
+msgstr[0] "%(count)d 分鐘"
+
+#: src/gpodder/util.py:1510
+msgid "and"
+msgstr "和"
+
+#: src/gpodder/util.py:1546
+#, python-format
+msgid "System default program '%(opener)s' not found"
+msgstr "找不到系統預設程式 '%(opener)s'"
+
+#: src/gpodder/util.py:1555
+#, python-format
+msgid "Cannot open file/folder '%(filename)s' using default program"
+msgstr "無法使用預設程式開啟檔案/資料夾 '%(filename)s'"
+
+#: src/gpodder/util.py:1557
+#, python-format
+msgid "Cannot open '%(filename)s' using '%(opener)s'"
+msgstr "無法使用 '%(opener)s' 開啟 '%(filename)s'"
+
+#: src/gpodder/util.py:1559
+msgid "Cannot open file/folder"
+msgstr "無法開啟檔案/資料夾"
+
+#: src/gpodder/gtkui/app.py:192
+msgid "Cannot start gPodder"
+msgstr "無法啟動 gPodder"
+
+#: src/gpodder/gtkui/app.py:193
+#, python-format
+msgid "D-Bus error: %s"
+msgstr "D-Bus 錯誤：%s"
+
+#: src/gpodder/gtkui/app.py:286
+msgid "About gPodder"
+msgstr "關於 gPodder"
+
+#: src/gpodder/gtkui/app.py:288
+#: src/gpodder/gtkui/desktop/episodeselector.py:330
+#: share/gpodder/extensions/subscription_stats.py:177
+#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:2
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:3
+msgid "_Close"
+msgstr "關閉(C)"
+
+#: src/gpodder/gtkui/app.py:310
+msgid "Website"
+msgstr "網站"
+
+#: src/gpodder/gtkui/app.py:311
+msgid "Bug Tracker"
+msgstr "錯誤追蹤器"
+
+#: src/gpodder/gtkui/app.py:372
+msgid "Path to gPodder home is too long"
+msgstr "gPodder 家目錄路徑過長"
+
+#: src/gpodder/gtkui/config.py:54
+msgid "Integer"
+msgstr "整數"
+
+#: src/gpodder/gtkui/config.py:56
+msgid "Float"
+msgstr "浮點數"
+
+#: src/gpodder/gtkui/config.py:58
+msgid "Boolean"
+msgstr "布林值"
+
+#: src/gpodder/gtkui/config.py:60
+msgid "String"
+msgstr "字串"
+
+#: src/gpodder/gtkui/desktopfile.py:74
+#, python-format
+msgid "Command: %s"
+msgstr "指令：%s"
+
+#: src/gpodder/gtkui/desktopfile.py:161
+msgid "Default application"
+msgstr "預設應用程式"
+
+#: src/gpodder/gtkui/download.py:98
+#, python-format
+msgid "%(status)s (%(progress).0f%%, %(rate)s/s, %(remaining)s)"
+msgstr "%(status)s (%(progress).0f%%, %(rate)s/秒, %(remaining)s)"
+
+#: src/gpodder/gtkui/main.py:178 share/applications/gpodder.desktop.in.h:1
+msgid "gPodder"
+msgstr "gPodder"
+
+#: src/gpodder/gtkui/main.py:218 src/gpodder/gtkui/main.py:808
+#: src/gpodder/gtkui/main.py:950
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:65
+msgid "Extensions"
+msgstr "擴充功能"
+
+#: src/gpodder/gtkui/main.py:454
+msgid "Loading incomplete downloads"
+msgstr "正在載入未完成的下載"
+
+#: src/gpodder/gtkui/main.py:455
+msgid "Some episodes have not finished downloading in a previous session."
+msgstr "部分單集在前一次連線中未完成下載。"
+
+#: src/gpodder/gtkui/main.py:458 bin/gpo:629
+#, python-format
+msgid "%(count)d partial file"
+msgid_plural "%(count)d partial files"
+msgstr[0] "%(count)d 個不完整的檔案"
+
+#: src/gpodder/gtkui/main.py:469
+msgid "Cleaning up..."
+msgstr "正在清理..."
+
+#: src/gpodder/gtkui/main.py:584
+msgid "Action"
+msgstr "操作"
+
+#: src/gpodder/gtkui/main.py:632
+msgid "Confirm changes from gpodder.net"
+msgstr "確認來自 gpodder.net 的變更"
+
+#: src/gpodder/gtkui/main.py:633
+msgid "Select the actions you want to carry out."
+msgstr "選取您想要執行的動作。"
+
+#: src/gpodder/gtkui/main.py:637
+msgid "A_pply"
+msgstr "套用(p)"
+
+#: src/gpodder/gtkui/main.py:673
+msgid "Uploading subscriptions"
+msgstr "正在上傳訂閱項目"
+
+#: src/gpodder/gtkui/main.py:674
+msgid "Your subscriptions are being uploaded to the server."
+msgstr "您的訂閱項目正在上傳到伺服器。"
+
+#: src/gpodder/gtkui/main.py:679
+msgid "List uploaded successfully."
+msgstr "清單上傳成功。"
+
+#: src/gpodder/gtkui/main.py:687
+msgid ""
+"Could not find your device.\n"
+"\n"
+"Check login is a username (not an email)\n"
+"and that the device name matches one in your account."
+msgstr ""
+"找不到您的裝置。\n"
+"\n"
+"請檢查登入的是使用者名稱 (而非電子郵件地址)\n"
+"且裝置名稱與您帳戶中的裝置名稱相符。"
+
+#: src/gpodder/gtkui/main.py:693
+msgid "Error while uploading"
+msgstr "上傳時發生錯誤"
+
+#: src/gpodder/gtkui/main.py:1001
+msgid "Size"
+msgstr "大小"
+
+#: src/gpodder/gtkui/main.py:1006
+msgid "Duration"
+msgstr "時長"
+
+#: src/gpodder/gtkui/main.py:1011
+msgid "Released"
+msgstr "發佈時間"
+
+#: src/gpodder/gtkui/main.py:1019
+msgid "Size+"
+msgstr "大小+"
+
+#: src/gpodder/gtkui/main.py:1027
+msgid "Duration+"
+msgstr "時長+"
+
+#: src/gpodder/gtkui/main.py:1205 src/gpodder/gtkui/main.py:1398
+#: share/gpodder/ui/gtk/gpodder.ui.h:16
+msgid "Progress"
+msgstr "進度"
+
+#: src/gpodder/gtkui/main.py:1259
+msgid "No episodes in current view"
+msgstr "目前檢視中沒有單集"
+
+#: src/gpodder/gtkui/main.py:1261
+msgid "No episodes available"
+msgstr "沒有可用的單集"
+
+#: src/gpodder/gtkui/main.py:1267
+msgid "No podcasts in this view"
+msgstr "此檢視中沒有 Podcast"
+
+#: src/gpodder/gtkui/main.py:1269
+msgid "No subscriptions"
+msgstr "沒有訂閱項目"
+
+#: src/gpodder/gtkui/main.py:1271
+msgid "No active tasks"
+msgstr "沒有進行中的任務"
+
+#: src/gpodder/gtkui/main.py:1402 src/gpodder/gtkui/main.py:1404
+#, python-format
+msgid "%(count)d active"
+msgid_plural "%(count)d active"
+msgstr[0] "%(count)d 個進行中"
+
+#: src/gpodder/gtkui/main.py:1406
+#, python-format
+msgid "%(count)d pausing"
+msgid_plural "%(count)d pausing"
+msgstr[0] "%(count)d 個暫停中"
+
+#: src/gpodder/gtkui/main.py:1408
+#, python-format
+msgid "%(count)d cancelling"
+msgid_plural "%(count)d cancelling"
+msgstr[0] "%(count)d 個取消中"
+
+#: src/gpodder/gtkui/main.py:1410
+#, python-format
+msgid "%(count)d queued"
+msgid_plural "%(count)d queued"
+msgstr[0] "%(count)d 個已排入佇列"
+
+#: src/gpodder/gtkui/main.py:1412
+#, python-format
+msgid "%(count)d paused"
+msgid_plural "%(count)d paused"
+msgstr[0] "%(count)d 個已暫停"
+
+#: src/gpodder/gtkui/main.py:1414
+#, python-format
+msgid "%(count)d failed"
+msgid_plural "%(count)d failed"
+msgstr[0] "%(count)d 個失敗"
+
+#: src/gpodder/gtkui/main.py:1427
+#, python-format
+msgid "downloading %(count)d file"
+msgid_plural "downloading %(count)d files"
+msgstr[0] "正在下載 %(count)d 個檔案"
+
+#: src/gpodder/gtkui/main.py:1439
+#, python-format
+msgid "synchronizing %(count)d file"
+msgid_plural "synchronizing %(count)d files"
+msgstr[0] "正在同步 %(count)d 個檔案"
+
+#: src/gpodder/gtkui/main.py:1443
+#, python-format
+msgid "%(queued)d task queued"
+msgid_plural "%(queued)d tasks queued"
+msgstr[0] "%(queued)d 個任務已排入佇列"
+
+#: src/gpodder/gtkui/main.py:1470
+msgid "Please report this problem and restart gPodder:"
+msgstr "請回報此問題並重新啟動 gPodder："
+
+#: src/gpodder/gtkui/main.py:1471
+msgid "Unhandled exception"
+msgstr "未處理的例外情況"
+
+#: src/gpodder/gtkui/main.py:1564
+#, python-format
+msgid "Feedparser error: %s"
+msgstr "Feedparser 錯誤：%s"
+
+#: src/gpodder/gtkui/main.py:1580 src/gpodder/gtkui/model.py:444
+#: src/gpodder/gtkui/model.py:787 src/gpodder/gtkui/desktop/channel.py:97
+#, python-format
+msgid "ERROR: %s"
+msgstr "錯誤：%s"
+
+#: src/gpodder/gtkui/main.py:1694
+msgid "Could not download some episodes:"
+msgstr "無法下載部分單集："
+
+#: src/gpodder/gtkui/main.py:1696 src/gpodder/gtkui/main.py:1699
+msgid "Downloads finished"
+msgstr "下載完成"
+
+#: src/gpodder/gtkui/main.py:1702
+msgid "Downloads failed"
+msgstr "下載失敗"
+
+#: src/gpodder/gtkui/main.py:1707
+msgid "Could not sync some episodes:"
+msgstr "無法同步部分單集："
+
+#: src/gpodder/gtkui/main.py:1710 src/gpodder/gtkui/main.py:1714
+msgid "Device synchronization finished"
+msgstr "裝置同步完成"
+
+#: src/gpodder/gtkui/main.py:1718
+msgid "Device synchronization failed"
+msgstr "裝置同步失敗"
+
+#: src/gpodder/gtkui/main.py:1760
+#, python-format
+msgid "%(count)d more episode"
+msgid_plural "%(count)d more episodes"
+msgstr[0] "另外 %(count)d 個單集"
+
+#: src/gpodder/gtkui/main.py:1777 src/gpodder/gtkui/main.py:3252
+msgid "Queueing"
+msgstr "正在排入佇列"
+
+#: src/gpodder/gtkui/main.py:1778
+msgid "Removing"
+msgstr "正在移除"
+
+#: src/gpodder/gtkui/main.py:1845 src/gpodder/gtkui/main.py:3281
+#: src/gpodder/gtkui/main.py:3362
+msgid "Updating..."
+msgstr "更新中..."
+
+#: src/gpodder/gtkui/main.py:1879 share/gpodder/ui/gtk/gpodder.ui.h:2
+#: share/gpodder/ui/gtk/menus.ui.h:63
+msgid "Start download now"
+msgstr "立即開始下載"
+
+#: src/gpodder/gtkui/main.py:1881 src/gpodder/gtkui/main.py:2106
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:207
+#: share/gpodder/ui/gtk/gpodder.ui.h:3 share/gpodder/ui/gtk/menus.ui.h:24
+msgid "Download"
+msgstr "下載"
+
+#: src/gpodder/gtkui/main.py:1978
+msgid "File already exists"
+msgstr "檔案已存在"
+
+#: src/gpodder/gtkui/main.py:1980
+#, python-format
+msgid ""
+"A file named \"%(filename)s\" already exists. Do you want to replace it?"
+msgstr ""
+"名為「%(filename)s」的檔案已存在。\n"
+"您要取代它嗎？"
+
+#: src/gpodder/gtkui/main.py:2025
+#, python-format
+msgid ""
+"Error saving to local folder: %(error)r.\n"
+"Would you like to continue?"
+msgstr ""
+"儲存到本機資料夾時發生錯誤：%(error)r。\n"
+"您想繼續嗎？"
+
+#: src/gpodder/gtkui/main.py:2027 src/gpodder/gtkui/main.py:2032
+msgid "Error saving to local folder"
+msgstr "儲存到本機資料夾時發生錯誤"
+
+#: src/gpodder/gtkui/main.py:2031
+#, python-format
+msgid "Error saving to local folder: %(error)r"
+msgstr "儲存到本機資料夾時發生錯誤：%(error)r"
+
+#: src/gpodder/gtkui/main.py:2056
+msgid "Error converting file."
+msgstr "轉換檔案時發生錯誤。"
+
+#: src/gpodder/gtkui/main.py:2056
+msgid "Bluetooth file transfer"
+msgstr "藍牙檔案傳輸"
+
+#: src/gpodder/gtkui/main.py:2091 src/gpodder/gtkui/main.py:2150
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:210
+#: share/gpodder/ui/gtk/menus.ui.h:23
+msgid "Open"
+msgstr "開啟"
+
+#: src/gpodder/gtkui/main.py:2094 src/gpodder/gtkui/main.py:2158
+#: share/gpodder/ui/gtk/gpodder.ui.h:1 share/gpodder/ui/gtk/menus.ui.h:22
+msgid "Play"
+msgstr "播放"
+
+#: src/gpodder/gtkui/main.py:2096 src/gpodder/gtkui/main.py:2160
+msgid "Preview"
+msgstr "預覽"
+
+#: src/gpodder/gtkui/main.py:2098 src/gpodder/gtkui/main.py:2162
+msgid "Stream"
+msgstr "串流"
+
+#: src/gpodder/gtkui/main.py:2104 share/gpodder/ui/gtk/gpodder.ui.h:4
+#: share/gpodder/ui/gtk/menus.ui.h:25
+msgid "Pause"
+msgstr "暫停"
+
+#: src/gpodder/gtkui/main.py:2115 src/gpodder/gtkui/desktop/channel.py:206
+#: share/gpodder/ui/gtk/gpodder.ui.h:5 share/gpodder/ui/gtk/menus.ui.h:26
+msgid "Cancel"
+msgstr "取消"
+
+#: src/gpodder/gtkui/main.py:2127
+msgid "Send to"
+msgstr "傳送到"
+
+#: src/gpodder/gtkui/main.py:2321
+msgid "Please check your media player settings in the preferences dialog."
+msgstr "請在偏好設定對話方塊中檢查您的媒體播放器設定。"
+
+#: src/gpodder/gtkui/main.py:2322
+msgid "Error opening player"
+msgstr "開啟播放器時發生錯誤"
+
+#: src/gpodder/gtkui/main.py:2592
+msgid "Adding podcasts"
+msgstr "正在新增 Podcast"
+
+#: src/gpodder/gtkui/main.py:2593
+msgid "Please wait while episode information is downloaded."
+msgstr "請稍候，正在下載單集資訊。"
+
+#: src/gpodder/gtkui/main.py:2601
+msgid "Existing subscriptions skipped"
+msgstr "已略過現有的訂閱項目"
+
+#: src/gpodder/gtkui/main.py:2602
+msgid "You are already subscribed to these podcasts:"
+msgstr "您已訂閱這些 Podcast ："
+
+#: src/gpodder/gtkui/main.py:2610 bin/gpo:350
+msgid "Podcast requires authentication"
+msgstr "Podcast 需要驗證"
+
+#: src/gpodder/gtkui/main.py:2611 bin/gpo:351
+#, python-format
+msgid "Please login to %s:"
+msgstr "請登入 %s："
+
+#: src/gpodder/gtkui/main.py:2619 src/gpodder/gtkui/main.py:2717
+msgid "Authentication failed"
+msgstr "驗證失敗"
+
+#: src/gpodder/gtkui/main.py:2625
+msgid "Website redirection detected"
+msgstr "偵測到網站重新導向"
+
+#: src/gpodder/gtkui/main.py:2626
+#, python-format
+msgid "The URL %(url)s redirects to %(target)s."
+msgstr "URL %(url)s 將重新導向至 %(target)s。"
+
+#: src/gpodder/gtkui/main.py:2627
+msgid "Do you want to visit the website now?"
+msgstr "您現在要造訪此網站嗎？"
+
+#: src/gpodder/gtkui/main.py:2636
+msgid "Could not add some podcasts"
+msgstr "無法新增部分 Podcast"
+
+#: src/gpodder/gtkui/main.py:2637
+msgid "Some podcasts could not be added to your list:"
+msgstr "部分 Podcast 無法新增至您的清單："
+
+#: src/gpodder/gtkui/main.py:2639
+msgid "Unknown"
+msgstr "未知"
+
+#: src/gpodder/gtkui/main.py:2726
+msgid "Redirection detected"
+msgstr "偵測到重新導向"
+
+#: src/gpodder/gtkui/main.py:2760
+msgid "Merging episode actions"
+msgstr "正在合併單集操作"
+
+#: src/gpodder/gtkui/main.py:2761
+msgid "Episode actions from gpodder.net are merged."
+msgstr "已合併來自 gpodder.net 的單集操作。"
+
+#: src/gpodder/gtkui/main.py:2787
+msgid "Cancelling..."
+msgstr "正在取消…"
+
+#: src/gpodder/gtkui/main.py:2796
+msgid "Please connect to a network, then try again."
+msgstr "請連線至網路後再試一次。"
+
+#: src/gpodder/gtkui/main.py:2797
+msgid "No network connection"
+msgstr "沒有網路連線"
+
+#: src/gpodder/gtkui/main.py:2818
+#, python-format
+msgid "Updating %(count)d feed..."
+msgid_plural "Updating %(count)d feeds..."
+msgstr[0] "正在更新 %(count)d 個 Feed…"
+
+#: src/gpodder/gtkui/main.py:2835
+#, python-format
+msgid "Updating %(podcast)s (%(position)d/%(total)d)"
+msgstr "正在更新 %(podcast)s (%(position)d/%(total)d)"
+
+#: src/gpodder/gtkui/main.py:2881
+#, python-format
+msgid "%(count)d channel failed to update"
+msgid_plural "%(count)d channels failed to update"
+msgstr[0] "%(count)d 個頻道更新失敗"
+
+#: src/gpodder/gtkui/main.py:2884
+msgid "Error while updating feeds"
+msgstr "更新 Feed 時發生錯誤"
+
+#: src/gpodder/gtkui/main.py:2916
+msgid "No new episodes with downloadable content"
+msgstr "沒有包含可下載內容的新單集"
+
+#: src/gpodder/gtkui/main.py:2916
+msgid "No new episodes"
+msgstr "沒有新單集"
+
+#: src/gpodder/gtkui/main.py:2931
+#, python-format
+msgid "Downloading %(count)d new episode."
+msgid_plural "Downloading %(count)d new episodes."
+msgstr[0] "正在下載 %(count)d 個新單集。"
+
+#: src/gpodder/gtkui/main.py:2934 src/gpodder/gtkui/main.py:2941
+#: src/gpodder/gtkui/main.py:3401
+msgid "New episodes available"
+msgstr "有可用的新單集"
+
+#: src/gpodder/gtkui/main.py:2938
+#, python-format
+msgid "%(count)d new episode added to download list."
+msgid_plural "%(count)d new episodes added to download list."
+msgstr[0] "%(count)d 個新單集已新增至下載清單。"
+
+#: src/gpodder/gtkui/main.py:2947
+#, python-format
+msgid "%(count)d new episode available"
+msgid_plural "%(count)d new episodes available"
+msgstr[0] "%(count)d 個新單集可用"
+
+#: src/gpodder/gtkui/main.py:2975 src/gpodder/gtkui/main.py:3671
+#: src/gpodder/gtkui/main.py:3698 src/gpodder/gtkui/interface/common.py:133
+#: src/gpodder/gtkui/interface/common.py:269
+#: src/gpodder/gtkui/desktop/channel.py:145
+#: src/gpodder/gtkui/desktop/episodeselector.py:328
+#: src/gpodder/gtkui/desktop/preferences.py:850
+#: src/gpodder/gtkui/desktop/preferences.py:868
+#: share/gpodder/extensions/concatenate_videos.py:40
+#: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:2
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:2
+#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:3
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:3
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:2
+msgid "_Cancel"
+msgstr "取消(C)"
+
+#: src/gpodder/gtkui/main.py:2976
+msgid "_Quit"
+msgstr "結束(Q)"
+
+#: src/gpodder/gtkui/main.py:2978
+msgid "Quit gPodder"
+msgstr "結束 gPodder"
+
+#: src/gpodder/gtkui/main.py:2979
+msgid ""
+"You are downloading episodes. You can resume downloads the next time you "
+"start gPodder. Do you want to quit now?"
+msgstr "您正在下載單集。下次啟動 gPodder 時可以繼續下載。您要立即結束嗎？"
+
+#: src/gpodder/gtkui/main.py:3033 bin/gpo:870
+msgid "Episodes are locked"
+msgstr "單集已鎖定"
+
+#: src/gpodder/gtkui/main.py:3035 bin/gpo:872
+msgid ""
+"The selected episodes are locked. Please unlock the episodes that you want "
+"to delete before trying to delete them."
+msgstr ""
+"選取的單集已被鎖定。\n"
+"請先將您想刪除的單集解除鎖定，然後再嘗試刪除。"
+
+#: src/gpodder/gtkui/main.py:3042 bin/gpo:879
+#, python-format
+msgid "Delete %(count)d episode?"
+msgid_plural "Delete %(count)d episodes?"
+msgstr[0] "要刪除 %(count)d 個單集嗎？"
+
+#: src/gpodder/gtkui/main.py:3044 bin/gpo:881
+msgid "Deleting episodes removes downloaded files."
+msgstr "刪除單集將會移除已下載的檔案。"
+
+#: src/gpodder/gtkui/main.py:3053
+msgid "Deleting episodes"
+msgstr "正在刪除單集"
+
+#: src/gpodder/gtkui/main.py:3054 bin/gpo:886
+msgid "Please wait while episodes are deleted"
+msgstr "請稍候，正在刪除單集"
+
+#: src/gpodder/gtkui/main.py:3107
+#, python-format
+msgid "Select older than %(count)d day"
+msgid_plural "Select older than %(count)d days"
+msgstr[0] "選取 %(count)d 天前的單集"
+
+#: src/gpodder/gtkui/main.py:3109
+msgid "Select played"
+msgstr "選取已播放"
+
+#: src/gpodder/gtkui/main.py:3110
+msgid "Select finished"
+msgstr "選取已完成"
+
+#: src/gpodder/gtkui/main.py:3115
+msgid "Select the episodes you want to delete:"
+msgstr "選取您想要刪除的單集："
+
+#: src/gpodder/gtkui/main.py:3132 share/gpodder/ui/gtk/menus.ui.h:11
+msgid "Delete episodes"
+msgstr "刪除單集"
+
+#: src/gpodder/gtkui/main.py:3135 src/gpodder/gtkui/main.py:3569
+msgid "_Delete"
+msgstr "刪除(D)"
+
+#: src/gpodder/gtkui/main.py:3202 src/gpodder/gtkui/main.py:3543
+#: src/gpodder/gtkui/main.py:3652
+msgid "No podcast selected"
+msgstr "未選取 Podcast"
+
+#: src/gpodder/gtkui/main.py:3203
+msgid "Please select a podcast in the podcasts list to update."
+msgstr "請在 Podcast 清單中選取一個 Podcast 以進行更新。"
+
+#: src/gpodder/gtkui/main.py:3335
+#, python-format
+msgid "Download error while downloading %(episode)s: %(message)s"
+msgstr "下載 %(episode)s 時發生錯誤：%(message)s"
+
+#: src/gpodder/gtkui/main.py:3336
+msgid "Download error"
+msgstr "下載錯誤"
+
+#: src/gpodder/gtkui/main.py:3381
+msgid "Select the episodes you want to download:"
+msgstr "選取您想要下載的單集："
+
+#: src/gpodder/gtkui/main.py:3409
+msgid "_Mark as old"
+msgstr "標記為已看過(M)"
+
+#: src/gpodder/gtkui/main.py:3416
+msgid "Please check for new episodes later."
+msgstr "請稍後再檢查是否有新單集。"
+
+#: src/gpodder/gtkui/main.py:3417
+msgid "No new episodes available"
+msgstr "沒有可用的新單集"
+
+#: src/gpodder/gtkui/main.py:3506
+#, python-format
+msgid "Subscriptions on %(server)s"
+msgstr "%(server)s 上的訂閱項目"
+
+#: src/gpodder/gtkui/main.py:3517
+msgid "Login to gpodder.net"
+msgstr "登入 gpodder.net"
+
+#: src/gpodder/gtkui/main.py:3518
+msgid "Please login to download your subscriptions."
+msgstr "請登入以下載您的訂閱項目。"
+
+#: src/gpodder/gtkui/main.py:3544
+msgid "Please select a podcast in the podcasts list to edit."
+msgstr "請在 Podcast 清單中選取一個 Podcast 以進行編輯。"
+
+#: src/gpodder/gtkui/main.py:3558
+#: share/gpodder/extensions/subscription_stats.py:68
+msgid "Podcast"
+msgstr "Podcast"
+
+#: src/gpodder/gtkui/main.py:3564 share/gpodder/ui/gtk/menus.ui.h:16
+msgid "Delete podcasts"
+msgstr "刪除 Podcast"
+
+#: src/gpodder/gtkui/main.py:3565
+msgid "Select the podcast you want to delete."
+msgstr "選取您想要刪除的 Podcast 。"
+
+#: src/gpodder/gtkui/main.py:3578
+msgid "Deleting podcast"
+msgstr "正在刪除 Podcast"
+
+#: src/gpodder/gtkui/main.py:3579
+msgid "Please wait while the podcast is deleted"
+msgstr "請稍候，正在刪除 Podcast"
+
+#: src/gpodder/gtkui/main.py:3580
+msgid ""
+"This podcast and all its episodes will be PERMANENTLY DELETED.\n"
+"Are you sure you want to continue?"
+msgstr ""
+"此 Podcast 及其所有單集將被永久刪除。\n"
+"您確定要繼續嗎？"
+
+#: src/gpodder/gtkui/main.py:3582
+msgid "Deleting podcasts"
+msgstr "正在刪除 Podcast"
+
+#: src/gpodder/gtkui/main.py:3583
+msgid "Please wait while the podcasts are deleted"
+msgstr "請稍候，正在刪除 Podcast"
+
+#: src/gpodder/gtkui/main.py:3584
+msgid ""
+"These podcasts and all their episodes will be PERMANENTLY DELETED.\n"
+"Are you sure you want to continue?"
+msgstr ""
+"這些 Podcast 及其所有單集將被永久刪除。\n"
+"您確定要繼續嗎？"
+
+#: src/gpodder/gtkui/main.py:3653
+msgid "Please select a podcast in the podcasts list to remove."
+msgstr "請在 Podcast 清單中選取要移除的 Podcast 。"
+
+#: src/gpodder/gtkui/main.py:3663
+msgid "OPML files"
+msgstr "OPML 檔案"
+
+#: src/gpodder/gtkui/main.py:3668
+msgid "Import from OPML"
+msgstr "從 OPML 匯入"
+
+#: src/gpodder/gtkui/main.py:3672 src/gpodder/gtkui/desktop/channel.py:146
+#: src/gpodder/gtkui/desktop/preferences.py:851
+#: src/gpodder/gtkui/desktop/preferences.py:869
+msgid "_Open"
+msgstr "開啟(O)"
+
+#: src/gpodder/gtkui/main.py:3682
+msgid "Import podcasts from OPML file"
+msgstr "從 OPML 檔案匯入 Podcast"
+
+#: src/gpodder/gtkui/main.py:3688
+msgid "Nothing to export"
+msgstr "沒有可匯出的項目"
+
+#: src/gpodder/gtkui/main.py:3689
+msgid ""
+"Your list of podcast subscriptions is empty. Please subscribe to some "
+"podcasts first before trying to export your subscription list."
+msgstr ""
+"您的 Podcast 訂閱清單是空的。\n"
+"請先訂閱一些 Podcast ，然後再嘗試匯出您的訂閱清單。"
+
+#: src/gpodder/gtkui/main.py:3695
+msgid "Export to OPML"
+msgstr "匯出至 OPML 檔案"
+
+#: src/gpodder/gtkui/main.py:3699 src/gpodder/gtkui/interface/common.py:270
+#: src/gpodder/gtkui/desktop/channel.py:195
+#: src/gpodder/gtkui/desktop/channel.py:203
+#: share/gpodder/extensions/concatenate_videos.py:41
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:4
+msgid "_Save"
+msgstr "儲存(S)"
+
+#: src/gpodder/gtkui/main.py:3708
+#, python-format
+msgid "%(count)d subscription exported"
+msgid_plural "%(count)d subscriptions exported"
+msgstr[0] "%(count)d 個訂閱項目已匯出"
+
+#: src/gpodder/gtkui/main.py:3711
+msgid "Your podcast list has been successfully exported."
+msgstr "您的 Podcast 清單已成功匯出。"
+
+#: src/gpodder/gtkui/main.py:3715
+msgid "Could not export OPML to file. Please check your permissions."
+msgstr ""
+"無法將 OPML 匯出至檔案。\n"
+"請檢查您的權限。"
+
+#: src/gpodder/gtkui/main.py:3717
+msgid "OPML export failed"
+msgstr "OPML 匯出失敗"
+
+#: src/gpodder/gtkui/main.py:3730
+msgid "Managed by distribution"
+msgstr "由發行版管理"
+
+#: src/gpodder/gtkui/main.py:3731
+msgid "Please check your distribution for gPodder updates."
+msgstr "請檢查您發行版的相關頁面以獲取 gPodder 更新。"
+
+#: src/gpodder/gtkui/main.py:3746
+msgid "Could not check for updates"
+msgstr "無法檢查更新"
+
+#: src/gpodder/gtkui/main.py:3747
+msgid "Please try again later."
+msgstr "請稍後再試。"
+
+#: src/gpodder/gtkui/main.py:3752
+msgid "No updates available"
+msgstr "沒有可用的更新"
+
+#: src/gpodder/gtkui/main.py:3753
+msgid "You have the latest version of gPodder."
+msgstr "您的 gPodder 已是最新版本。"
+
+#: src/gpodder/gtkui/main.py:3757
+msgid "New version available"
+msgstr "有可用的新版本"
+
+#: src/gpodder/gtkui/main.py:3759
+#, python-format
+msgid "Installed version: %s"
+msgstr "已安裝版本：%s"
+
+#: src/gpodder/gtkui/main.py:3760
+#, python-format
+msgid "Newest version: %s"
+msgstr "最新版本：%s"
+
+#: src/gpodder/gtkui/main.py:3761
+#, python-format
+msgid "Release date: %s"
+msgstr "發佈日期：%s"
+
+#: src/gpodder/gtkui/main.py:3763
+msgid "Download the latest version from gpodder.org?"
+msgstr "要從 gpodder.org 下載最新版本嗎？"
+
+#: src/gpodder/gtkui/model.py:58
+#, python-format
+msgid "released %s"
+msgstr "發佈於 %s"
+
+#: src/gpodder/gtkui/model.py:59 src/gpodder/gtkui/model.py:77
+#: src/gpodder/gtkui/model.py:303 src/gpodder/gtkui/shownotes.py:212
+#: src/gpodder/gtkui/shownotes.py:355
+#, python-format
+msgid "from %s"
+msgstr "來自 %s"
+
+#: src/gpodder/gtkui/model.py:70 src/gpodder/gtkui/model.py:432
+msgid "played"
+msgstr "已播放"
+
+#: src/gpodder/gtkui/model.py:72
+msgid "unplayed"
+msgstr "未播放"
+
+#: src/gpodder/gtkui/model.py:75
+msgid "today"
+msgstr "今天"
+
+#: src/gpodder/gtkui/model.py:76
+#, python-format
+msgid "downloaded %s"
+msgstr "已下載 %s"
+
+#: src/gpodder/gtkui/model.py:399
+msgid "Deleted"
+msgstr "已刪除"
+
+#: src/gpodder/gtkui/model.py:408
+msgid "Downloaded episode"
+msgstr "已下載的單集"
+
+#: src/gpodder/gtkui/model.py:411
+msgid "Downloaded video episode"
+msgstr "已下載的影片單集"
+
+#: src/gpodder/gtkui/model.py:414
+msgid "Downloaded image"
+msgstr "已下載的圖片"
+
+#: src/gpodder/gtkui/model.py:417
+msgid "Downloaded file"
+msgstr "已下載的檔案"
+
+#: src/gpodder/gtkui/model.py:421
+msgid "missing file"
+msgstr "遺失的檔案"
+
+#: src/gpodder/gtkui/model.py:425
+msgid "never played"
+msgstr "從未播放"
+
+#: src/gpodder/gtkui/model.py:427
+msgid "never displayed"
+msgstr "從未顯示"
+
+#: src/gpodder/gtkui/model.py:429
+msgid "never opened"
+msgstr "從未開啟"
+
+#: src/gpodder/gtkui/model.py:434
+msgid "displayed"
+msgstr "已顯示"
+
+#: src/gpodder/gtkui/model.py:436
+msgid "opened"
+msgstr "已開啟"
+
+#: src/gpodder/gtkui/model.py:438
+msgid "deletion prevented"
+msgstr "已防止刪除"
+
+#: src/gpodder/gtkui/model.py:450
+msgid "No downloadable content"
+msgstr "沒有可下載的內容"
+
+#: src/gpodder/gtkui/model.py:456
+msgid "New episode"
+msgstr "新單集"
+
+#: src/gpodder/gtkui/model.py:506 share/gpodder/ui/gtk/menus.ui.h:42
+msgid "All episodes"
+msgstr "所有單集"
+
+#: src/gpodder/gtkui/model.py:507
+msgid "from all podcasts"
+msgstr "來自所有 Podcast"
+
+#: src/gpodder/gtkui/model.py:792
+msgid "Subscription paused"
+msgstr "訂閱已暫停"
+
+#: src/gpodder/gtkui/shownotes.py:69
+#, python-format
+msgid "%(date)s | %(size)s | %(duration)s"
+msgstr "%(date)s | %(size)s | %(duration)s"
+
+#: src/gpodder/gtkui/shownotes.py:156
+msgid "Please select an episode"
+msgstr "請選取一個單集"
+
+#: src/gpodder/gtkui/shownotes.py:262
+msgid "Open Episode Title Link"
+msgstr "開啟單集標題連結"
+
+#: src/gpodder/gtkui/shownotes.py:267
+msgid "Copy Episode Title Link Address"
+msgstr "複製單集標題連結網址"
+
+#: src/gpodder/gtkui/shownotes.py:362
+#, python-format
+msgid ""
+"<div id=\"gpodder-title\">\n"
+"%(heading)s\n"
+"<p>%(subheading)s</p>\n"
+"<p>%(details)s</p></div>\n"
+msgstr ""
+"<div id=\"gpodder-title\">\n"
+"%(heading)s\n"
+"<p>%(subheading)s</p>\n"
+"<p>%(details)s</p></div>\n"
+
+#: src/gpodder/gtkui/shownotes.py:402
+msgid "Open shownotes in web browser"
+msgstr "在網頁瀏覽器中開啟 Shownotes"
+
+#: src/gpodder/gtkui/shownotes.py:408
+msgid "Open link in web browser"
+msgstr "在網頁瀏覽器中開啟連結"
+
+#: src/gpodder/gtkui/interface/addpodcast.py:82
+msgid "Nothing to paste."
+msgstr "沒有可以貼上的內容。"
+
+#: src/gpodder/gtkui/interface/addpodcast.py:82
+msgid "Clipboard is empty"
+msgstr "剪貼簿是空的"
+
+#: src/gpodder/gtkui/interface/common.py:129
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:3
+#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:4
+msgid "_OK"
+msgstr "確定(O)"
+
+#: src/gpodder/gtkui/interface/common.py:176
+msgid "Username"
+msgstr "使用者名稱"
+
+#: src/gpodder/gtkui/interface/common.py:179
+msgid "New user"
+msgstr "新使用者"
+
+#: src/gpodder/gtkui/interface/common.py:186
+msgid "Login"
+msgstr "登入"
+
+#: src/gpodder/gtkui/interface/common.py:188
+msgid "Authentication required"
+msgstr "需要驗證"
+
+#: src/gpodder/gtkui/interface/common.py:197
+msgid "hostname or root URL (e.g. https://gpodder.net)"
+msgstr "主機名稱或根 URL (例如：https://gpodder.net)"
+
+#: src/gpodder/gtkui/interface/common.py:218
+msgid "Server"
+msgstr "伺服器"
+
+#: src/gpodder/gtkui/interface/common.py:224
+msgid "Password"
+msgstr "密碼"
+
+#: src/gpodder/gtkui/interface/common.py:227
+msgid "Show Password"
+msgstr "顯示密碼"
+
+#: src/gpodder/gtkui/interface/common.py:264
+#: share/gpodder/ui/gtk/gpodderexporttolocalfolder.ui.h:1
+msgid "Select destination"
+msgstr "選取目的地"
+
+#: src/gpodder/gtkui/interface/configeditor.py:34
+msgid "Setting"
+msgstr "設定"
+
+#: src/gpodder/gtkui/interface/configeditor.py:42
+msgid "Set to"
+msgstr "設為"
+
+#: src/gpodder/gtkui/interface/configeditor.py:87
+#, python-format
+msgid "Cannot set %(field)s to %(value)s. Needed data type: %(datatype)s"
+msgstr ""
+"無法將「%(field)s」欄位值設為「%(value)s」。\n"
+"所需的資料類型：%(datatype)s"
+
+#: src/gpodder/gtkui/interface/configeditor.py:91
+msgid "Error setting option"
+msgstr "設定選項時發生錯誤"
+
+#: src/gpodder/gtkui/desktop/channel.py:128
+msgid "Add section"
+msgstr "新增分類"
+
+#: src/gpodder/gtkui/desktop/channel.py:128
+msgid "New section:"
+msgstr "新分類："
+
+#: src/gpodder/gtkui/desktop/channel.py:129
+#: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:3
+msgid "_Add"
+msgstr "新增(A)"
+
+#: src/gpodder/gtkui/desktop/channel.py:142
+msgid "Select new podcast cover artwork"
+msgstr "選取新的 Podcast 封面圖片"
+
+#: src/gpodder/gtkui/desktop/channel.py:174
+msgid "You can only drop a single image or URL here."
+msgstr "您只能拖放單一圖片或 URL 到此處。"
+
+#: src/gpodder/gtkui/desktop/channel.py:175
+#: src/gpodder/gtkui/desktop/channel.py:187
+msgid "Drag and drop"
+msgstr "拖放"
+
+#: src/gpodder/gtkui/desktop/channel.py:186
+msgid "You can only drop local files and http:// URLs here."
+msgstr "您只能拖放本機檔案或 http:// 網址到此處。"
+
+#: src/gpodder/gtkui/desktop/episodeselector.py:103
+msgid "Remove"
+msgstr "移除"
+
+#: src/gpodder/gtkui/desktop/episodeselector.py:139
+msgid "_Download"
+msgstr "下載(D)"
+
+#: src/gpodder/gtkui/desktop/episodeselector.py:283
+#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:5
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:1
+msgid "Select _all"
+msgstr "全選(a)"
+
+#: src/gpodder/gtkui/desktop/episodeselector.py:287
+#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:6
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:2
+msgid "Select _none"
+msgstr "全部不選(n)"
+
+#: src/gpodder/gtkui/desktop/episodeselector.py:319
+msgid "Nothing selected"
+msgstr "未選取任何項目"
+
+#: src/gpodder/gtkui/desktop/episodeselector.py:320
+#, python-format
+msgid "%(count)d episode"
+msgid_plural "%(count)d episodes"
+msgstr[0] "%(count)d 個單集"
+
+#: src/gpodder/gtkui/desktop/episodeselector.py:323
+#, python-format
+msgid "size: %s"
+msgstr "大小：%s"
+
+#: src/gpodder/gtkui/desktop/exportlocal.py:51
+#, python-format
+msgid "Export remaining %(count)d episode to this folder with its default name"
+msgid_plural ""
+"Export remaining %(count)d episodes to this folder with their default name"
+msgstr[0] "將剩餘的 %(count)d 個單集以其預設名稱匯出到此資料夾"
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:203
+msgid "Search:"
+msgstr "搜尋："
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:204
+msgid "Search"
+msgstr "搜尋"
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:206
+#: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:4
+msgid "URL:"
+msgstr "網址："
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:209
+msgid "Filename:"
+msgstr "檔案名稱："
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:230
+msgid "Please wait while the podcast list is downloaded"
+msgstr "請稍候，正在下載 Podcast 清單"
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:263
+msgid "Error"
+msgstr "錯誤：%s"
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:267
+#, python-format
+msgid ""
+"Error: %s\n"
+"\n"
+"%s"
+msgstr ""
+"錯誤：%s\n"
+"\n"
+"%s"
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:270
+msgid "No results"
+msgstr "沒有結果"
+
+#: src/gpodder/gtkui/desktop/podcastdirectory.py:271
+msgid "Sorry, no podcasts were found"
+msgstr "抱歉，找不到任何 Podcast"
+
+#: src/gpodder/gtkui/desktop/preferences.py:47
+#: src/gpodder/gtkui/desktop/preferences.py:90
+msgid "Do nothing"
+msgstr "不執行任何動作"
+
+#: src/gpodder/gtkui/desktop/preferences.py:48
+msgid "Show episode list"
+msgstr "顯示單集清單"
+
+#: src/gpodder/gtkui/desktop/preferences.py:49
+msgid "Add to download list"
+msgstr "新增至下載清單"
+
+#: src/gpodder/gtkui/desktop/preferences.py:50
+msgid "Download immediately"
+msgstr "立即下載"
+
+#: src/gpodder/gtkui/desktop/preferences.py:69
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:63
+msgid "None"
+msgstr "無"
+
+#: src/gpodder/gtkui/desktop/preferences.py:70
+msgid "iPod"
+msgstr "iPod"
+
+#: src/gpodder/gtkui/desktop/preferences.py:71
+msgid "Filesystem-based"
+msgstr "基於檔案系統"
+
+#: src/gpodder/gtkui/desktop/preferences.py:91
+msgid "Mark as played"
+msgstr "標記為已播放"
+
+#: src/gpodder/gtkui/desktop/preferences.py:92
+msgid "Delete from gPodder"
+msgstr "從 gPodder 刪除"
+
+#: src/gpodder/gtkui/desktop/preferences.py:116
+msgid "Same filename as local"
+msgstr "使用與本機相同的檔案名稱"
+
+#: src/gpodder/gtkui/desktop/preferences.py:117
+msgid "Use episode title as filename"
+msgstr "移除單集標題前綴"
+
+#: src/gpodder/gtkui/desktop/preferences.py:118
+msgid "Use custom filename format"
+msgstr "使用自訂檔案名稱格式"
+
+#: src/gpodder/gtkui/desktop/preferences.py:141
+#: src/gpodder/gtkui/desktop/preferences.py:167
+#, python-format
+msgid "Custom (%(format_ids)s)"
+msgstr "自訂 (%(format_ids)s)"
+
+#: src/gpodder/gtkui/desktop/preferences.py:213
+msgid "SOCKS5h (Remote DNS)"
+msgstr "SOCKS5h (遠端 DNS)"
+
+#: src/gpodder/gtkui/desktop/preferences.py:214
+msgid "SOCKS5"
+msgstr "SOCKS5"
+
+#: src/gpodder/gtkui/desktop/preferences.py:215
+msgid "HTTP"
+msgstr "HTTP"
+
+#: src/gpodder/gtkui/desktop/preferences.py:499
+msgid "Name"
+msgstr "名稱"
+
+#: src/gpodder/gtkui/desktop/preferences.py:551
+msgid "Documentation"
+msgstr "說明文件"
+
+#: src/gpodder/gtkui/desktop/preferences.py:556
+msgid "Extension info"
+msgstr "擴充功能資訊"
+
+#: src/gpodder/gtkui/desktop/preferences.py:561
+msgid "Support the author"
+msgstr "支持作者"
+
+#: src/gpodder/gtkui/desktop/preferences.py:604 bin/gpo:1084
+msgid "Extension cannot be activated"
+msgstr "無法啟用擴充功能"
+
+#: src/gpodder/gtkui/desktop/preferences.py:656
+msgid "Configure audio player"
+msgstr "設定音訊播放器"
+
+#: src/gpodder/gtkui/desktop/preferences.py:657
+#: src/gpodder/gtkui/desktop/preferences.py:667
+msgid "Command:"
+msgstr "指令："
+
+#: src/gpodder/gtkui/desktop/preferences.py:666
+msgid "Configure video player"
+msgstr "設定影片播放器"
+
+#: src/gpodder/gtkui/desktop/preferences.py:679
+#: src/gpodder/gtkui/desktop/preferences.py:703
+msgid "manually"
+msgstr "手動"
+
+#: src/gpodder/gtkui/desktop/preferences.py:705
+#, python-format
+msgid "after %(count)d day"
+msgid_plural "after %(count)d days"
+msgstr[0] "%(count)d 天後"
+
+#: src/gpodder/gtkui/desktop/preferences.py:739
+msgid "Replace subscription list on server"
+msgstr "取代伺服器上的訂閱清單"
+
+#: src/gpodder/gtkui/desktop/preferences.py:740
+msgid ""
+"Remote podcasts that have not been added locally will be removed on the "
+"server. Continue?"
+msgstr "尚未新增至本機的遠端 Podcast 將在伺服器上被移除。要繼續嗎？"
+
+#: src/gpodder/gtkui/desktop/preferences.py:847
+msgid "Select folder for mount point"
+msgstr "選取掛載點的資料夾"
+
+#: src/gpodder/gtkui/desktop/preferences.py:865
+msgid "Select folder for playlists"
+msgstr "選取播放清單的資料夾"
+
+#: src/gpodder/gtkui/desktop/preferences.py:879
+msgid "The playlists folder must be on the device"
+msgstr "播放清單資料夾必須位於裝置上"
+
+#: src/gpodder/plugins/soundcloud.py:166
+msgid "Unknown track"
+msgstr "未知曲目"
+
+#: src/gpodder/plugins/soundcloud.py:201
+#, python-format
+msgid "%s on Soundcloud"
+msgstr "Soundcloud 上的 %s"
+
+#: src/gpodder/plugins/soundcloud.py:210
+#, python-format
+msgid "Tracks published by %s on Soundcloud."
+msgstr "由 Soundcloud 上的 %s 發佈的曲目。"
+
+#: src/gpodder/plugins/soundcloud.py:244
+#, python-format
+msgid "%s's favorites on Soundcloud"
+msgstr "%s 在 Soundcloud 上的最愛"
+
+#: src/gpodder/plugins/soundcloud.py:250
+#, python-format
+msgid "Tracks favorited by %s on Soundcloud."
+msgstr "%s 在 Soundcloud 上加入最愛的曲目。"
+
+#: share/gpodder/extensions/10_youtube-dl.py:38
+msgid ""
+"Manage YouTube subscriptions using youtube-dl (pip install youtube_dl) or yt-"
+"dlp (pip install yt-dlp)"
+msgstr ""
+"使用 youtube-dl (pip install youtube_dl) 或 yt-dlp (pip install yt-dlp) 管理 "
+"YouTube 訂閱項目"
+
+#: share/gpodder/extensions/10_youtube-dl.py:43
+#, python-format
+msgid ""
+"Your version of youtube-dl/yt-dlp %(have_version)s has known issues, please "
+"upgrade to %(want_version)s or newer."
+msgstr ""
+"您的 youtube-dl/yt-dlp 版本 %(have_version)s 有已知問題，請升級至 "
+"%(want_version)s 或更新的版本。"
+
+#: share/gpodder/extensions/10_youtube-dl.py:521
+msgid "Not checked"
+msgstr "未檢查"
+
+#: share/gpodder/extensions/10_youtube-dl.py:554
+msgid "Old youtube-dl"
+msgstr "舊版 youtube-dl"
+
+#: share/gpodder/extensions/10_youtube-dl.py:558
+msgid "Download with youtube-dl"
+msgstr "使用 youtube-dl 下載"
+
+#: share/gpodder/extensions/10_youtube-dl.py:611
+#, python-format
+msgid "Available version: %(version)s"
+msgstr "可用版本：%(version)s"
+
+#: share/gpodder/extensions/10_youtube-dl.py:614
+msgid "No update available"
+msgstr "沒有可用的更新"
+
+#: share/gpodder/extensions/10_youtube-dl.py:617
+msgid "Error checking for update"
+msgstr "檢查更新時發生錯誤"
+
+#: share/gpodder/extensions/10_youtube-dl.py:641
+msgid ""
+"Parse YouTube channel feeds with youtube-dl to access more than 15 episodes"
+msgstr "使用 youtube-dl 解析 YouTube 頻道 Feed 以存取超過 15 個單集"
+
+#: share/gpodder/extensions/10_youtube-dl.py:648
+msgid "Download all supported episodes with youtube-dl"
+msgstr "使用 youtube-dl 下載所有支援的單集"
+
+#: share/gpodder/extensions/10_youtube-dl.py:653
+msgid ""
+"youtube-dl provides access to additional YouTube formats and DRM content.  "
+"Episodes from non-YouTube channels, that have youtube-dl support, will "
+"<b>fail</b> to download unless you manually <a href=\"https://gpodder.github."
+"io/docs/youtube.html#formats\">add custom formats</a> for each site.  "
+"<b>Download with youtube-dl</b> appears in the episode menu when this option "
+"is disabled, and can be used to manually download from supported sites."
+msgstr ""
+"youtube-dl 提供對額外 YouTube 格式和 DRM 內容的存取。下載來自 youtube-dl 支援"
+"的非 YouTube 網站的單集將會<b>失敗</b>，除非您手動為每個網站<a "
+"href=\"https://gpodder.github.io/docs/youtube.html#formats\">新增自訂格式</"
+"a>。停用此選項時，「<b>使用 youtube-dl 下載</b>」會出現在單集選單中，並可用於"
+"從支援的網站手動下載。"
+
+#: share/gpodder/extensions/10_youtube-dl.py:664
+msgid "Embed all available subtitles in downloaded video"
+msgstr "在下載的影片中嵌入所有可用的字幕"
+
+#: share/gpodder/extensions/10_youtube-dl.py:671
+msgid ""
+"The \"ffmpeg\" command was not found. FFmpeg is required for embedding "
+"subtitles."
+msgstr "找不到 \"ffmpeg\" 指令。嵌入字幕需要 FFmpeg。"
+
+#: share/gpodder/extensions/10_youtube-dl.py:679
+#, python-format
+msgid "Note: You need to restart gpodder after updating %s"
+msgstr "注意：更新 %s 後您需要重新啟動 gPodder"
+
+#: share/gpodder/extensions/10_youtube-dl.py:682
+msgid "Check for update"
+msgstr "檢查更新"
+
+#: share/gpodder/extensions/10_youtube-dl.py:684
+msgid "Available version:"
+msgstr "可用版本："
+
+#: share/gpodder/extensions/10_youtube-dl.py:685
+msgid "Update"
+msgstr "更新"
+
+#: share/gpodder/extensions/10_youtube-dl.py:699
+msgid "youtube-dl"
+msgstr "youtube-dl"
+
+#: share/gpodder/extensions/20_audio_converter.py:20
+msgid "Convert audio files"
+msgstr "轉換音訊檔案錯誤"
+
+#: share/gpodder/extensions/20_audio_converter.py:21
+msgid "Transcode audio files to mp3/ogg"
+msgstr "將音訊檔案轉碼為 mp3/ogg 格式"
+
+#: share/gpodder/extensions/20_audio_converter.py:93
+#: share/gpodder/extensions/20_video_converter.py:84
+#, python-format
+msgid "Convert to %(format)s"
+msgstr "轉換為 %(format)s"
+
+#: share/gpodder/extensions/20_audio_converter.py:134
+#: share/gpodder/extensions/20_video_converter.py:115
+#: share/gpodder/extensions/30_rockbox_convert2mp4.py:65
+msgid "File converted"
+msgstr "檔案已轉換"
+
+#: share/gpodder/extensions/20_audio_converter.py:137
+#: share/gpodder/extensions/20_video_converter.py:118
+msgid "Conversion failed"
+msgstr "轉換失敗"
+
+#: share/gpodder/extensions/20_video_converter.py:20
+msgid "Convert video files"
+msgstr "轉換影片檔案"
+
+#: share/gpodder/extensions/20_video_converter.py:21
+msgid "Transcode video files to avi/mp4/m4v"
+msgstr "將影片檔案轉碼為 avi/mp4/m4v 格式"
+
+#: share/gpodder/extensions/30_normalize_audio.py:21
+msgid "Normalize audio with re-encoding"
+msgstr "重新編碼使音量平衡"
+
+#: share/gpodder/extensions/30_normalize_audio.py:22
+msgid "Normalize the volume of audio files with normalize-audio"
+msgstr "使用 normalize-audio 使音訊檔案的音量大小一致"
+
+#: share/gpodder/extensions/30_normalize_audio.py:106
+msgid "File normalized"
+msgstr "已平衡檔案音量"
+
+#: share/gpodder/extensions/30_rockbox_convert2mp4.py:26
+msgid "Convert video files to MP4 for Rockbox"
+msgstr "將影片檔案轉換為適用於 Rockbox 的 MP4 格式"
+
+#: share/gpodder/extensions/30_rockbox_convert2mp4.py:27
+msgid "Converts all videos to a Rockbox-compatible format"
+msgstr "轉換所有影片為 Rockbox 相容格式"
+
+#: share/gpodder/extensions/40_rm_ogg_cover.py:37
+msgid "Remove cover art from OGG files"
+msgstr "從 OGG 檔案中移除封面圖片"
+
+#: share/gpodder/extensions/40_rm_ogg_cover.py:38
+msgid "removes coverart from all downloaded ogg files"
+msgstr "從所有已下載的 OGG 檔案中移除封面圖片"
+
+#: share/gpodder/extensions/40_rm_ogg_cover.py:67
+msgid "Remove cover art"
+msgstr "移除封面圖片"
+
+#: share/gpodder/extensions/50_tagging.py:56
+msgid "Tag downloaded files using Mutagen"
+msgstr "使用 Mutagen 為已下載檔案加上標籤"
+
+#: share/gpodder/extensions/50_tagging.py:57
+msgid "Add episode and podcast titles to MP3/OGG tags"
+msgstr "將單集與 Podcast 標題新增至 MP3/OGG 標籤"
+
+#: share/gpodder/extensions/50_tagging.py:541
+msgid "<b><big>Tagging Extension</big></b>"
+msgstr "<b><big>標籤擴充功能</big></b>"
+
+#: share/gpodder/extensions/50_tagging.py:546
+msgid "This extension writes tags on MP3/MP4/OGG episodes after download."
+msgstr "此擴充功能會在下載 MP3/MP4/OGG 單集後寫入標籤。"
+
+#: share/gpodder/extensions/50_tagging.py:553
+msgid "Only Remove Existing Tags"
+msgstr "僅移除現有標籤"
+
+#: share/gpodder/extensions/50_tagging.py:558
+msgid "Modify tags"
+msgstr "修改標籤"
+
+#: share/gpodder/extensions/50_tagging.py:563
+msgid "Remove existing tags before writing"
+msgstr "寫入前移除現有標籤"
+
+#: share/gpodder/extensions/50_tagging.py:570
+msgid "Write Title tag"
+msgstr "寫入標題標籤"
+
+#: share/gpodder/extensions/50_tagging.py:575
+msgid "Write Album tag"
+msgstr "寫入 Album 標籤"
+
+#: share/gpodder/extensions/50_tagging.py:580
+msgid "Write Artist tag (to same as Album)"
+msgstr "寫入演出者標籤 (與 Album 相同)"
+
+#: share/gpodder/extensions/50_tagging.py:585
+msgid "Write Subtitle tag"
+msgstr "寫入副標題標籤"
+
+#: share/gpodder/extensions/50_tagging.py:590
+msgid "Write Comments tag (to same as Subtitle)"
+msgstr "寫入註解標籤 (與副標題相同)"
+
+#: share/gpodder/extensions/50_tagging.py:595
+msgid "Note: Subtitle is often very long. Can cause parsing issues."
+msgstr "請注意：副標題通常很長，可能會導致解析問題。"
+
+#: share/gpodder/extensions/50_tagging.py:599
+msgid "Write Genre tag"
+msgstr "寫入類型標籤"
+
+#: share/gpodder/extensions/50_tagging.py:604
+msgid "Write Publish Date tag"
+msgstr "寫入發佈日期標籤"
+
+#: share/gpodder/extensions/50_tagging.py:611
+msgid "Remove Album from Title (if present)"
+msgstr "從標題中移除 Album (如果存在)"
+
+#: share/gpodder/extensions/50_tagging.py:621
+msgid "Genre tag:"
+msgstr "類型標籤："
+
+#: share/gpodder/extensions/50_tagging.py:631
+msgid "Embed Coverart"
+msgstr "嵌入封面圖片"
+
+#: share/gpodder/extensions/50_tagging.py:636
+msgid "Prefer channel coverart"
+msgstr "偏好使用頻道封面圖片"
+
+#: share/gpodder/extensions/50_tagging.py:641
+#: share/gpodder/extensions/rockbox_coverart.py:188
+msgid "Process art: convert, resize, and make baseline"
+msgstr "處理圖片：轉換、調整大小並製作基準JPEG"
+
+#: share/gpodder/extensions/50_tagging.py:647
+msgid ""
+"Enable conversion and resizing of art.\n"
+"\n"
+" If enabled, convert art to desired format (default JPEG) and size (default "
+"500px),\n"
+" and if format is JPEG, write as Baseline (rather than Progressive) format.\n"
+" If disabled, embed art as-is."
+msgstr ""
+"啟用圖片轉換與大小調整。\n"
+"\n"
+" 若啟用，將圖片轉換為所需格式 (預設 JPEG) 與大小 (預設 500px)，\n"
+"且若格式為 JPEG，則寫為 Baseline (而非 Progressive) 格式。\n"
+"若停用，則直接嵌入原始圖片。"
+
+#: share/gpodder/extensions/50_tagging.py:664
+#: share/gpodder/extensions/rockbox_coverart.py:217
+msgid "Image size (px):"
+msgstr "圖片大小 (像素)："
+
+#: share/gpodder/extensions/50_tagging.py:677
+msgid "Image type:"
+msgstr "圖片類型："
+
+#: share/gpodder/extensions/50_tagging.py:691
+msgid "Tagging"
+msgstr "標籤"
+
+#: share/gpodder/extensions/80_rename_download.py:18
+msgid "Rename episodes after download"
+msgstr "下載單集後重新命名"
+
+#: share/gpodder/extensions/80_rename_download.py:19
+msgid "Rename episodes to \"<Episode Title>.<ext>\" on download"
+msgstr "下載時依照「<單集標題>.<副檔名>」格式重新命名單集"
+
+#: share/gpodder/extensions/80_rename_download.py:54
+#: share/gpodder/extensions/80_rename_download.py:61
+#: share/gpodder/extensions/80_rename_download.py:83
+msgid "Rename all downloaded episodes"
+msgstr "重新命名所有已下載的單集"
+
+#: share/gpodder/extensions/80_rename_download.py:60
+msgid "No downloaded episodes to rename"
+msgstr "沒有已下載的單集可供重新命名"
+
+#: share/gpodder/extensions/80_rename_download.py:66
+msgid "Renaming all downloaded episodes"
+msgstr "正在重新命名所有已下載的單集"
+
+#: share/gpodder/extensions/80_rename_download.py:80
+#, python-format
+msgid "Renamed %(count)d downloaded episode"
+msgid_plural "Renamed %(count)d downloaded episodes"
+msgstr[0] "已重新命名 %(count)d 個已下載的單集"
+
+#: share/gpodder/extensions/90_command_on_download.py:17
+msgid "Run a Command on Download"
+msgstr "下載時執行指令"
+
+#: share/gpodder/extensions/90_command_on_download.py:18
+msgid "Run a predefined external command upon download completion."
+msgstr "下載完成時執行預先定義的外部指令。"
+
+#: share/gpodder/extensions/91_enqueue_in_mediaplayer.py:21
+msgid "Enqueue/Resume in media players"
+msgstr "在媒體播放器中加入佇列/繼續播放"
+
+#: share/gpodder/extensions/91_enqueue_in_mediaplayer.py:22
+msgid ""
+"Add a context menu item for enqueueing/resuming playback of episodes in "
+"installed media players"
+msgstr "新增右鍵選單項目，用於在已安裝的媒體播放器中將單集加入佇列或繼續播放"
+
+#: share/gpodder/extensions/91_enqueue_in_mediaplayer.py:40
+msgid "Enqueue in"
+msgstr "加入佇列於"
+
+#: share/gpodder/extensions/91_enqueue_in_mediaplayer.py:100
+msgid "Resume in"
+msgstr "繼續播放於"
+
+#: share/gpodder/extensions/command_on_sync.py:17
+msgid "Run a Command on Sync"
+msgstr "同步時執行指令"
+
+#: share/gpodder/extensions/command_on_sync.py:18
+msgid "Run a custom external command upon sync completion."
+msgstr "下載完成時執行預先定義的外部指令。"
+
+#: share/gpodder/extensions/concatenate_videos.py:19
+#: share/gpodder/extensions/concatenate_videos.py:103
+msgid "Concatenate videos"
+msgstr "合併影片"
+
+#: share/gpodder/extensions/concatenate_videos.py:20
+msgid "Add a context menu item for concatenating multiple videos"
+msgstr "新增用於合併多個影片的右鍵選單項目"
+
+#: share/gpodder/extensions/concatenate_videos.py:37
+msgid "Save video"
+msgstr "儲存影片"
+
+#: share/gpodder/extensions/concatenate_videos.py:66
+msgid "Concatenating video files"
+msgstr "正在合併影片檔案"
+
+#: share/gpodder/extensions/concatenate_videos.py:67
+#, python-format
+msgid "Writing %(filename)s"
+msgstr "正在寫入檔案 %(filename)s"
+
+#: share/gpodder/extensions/concatenate_videos.py:81
+msgid "Videos successfully converted"
+msgstr "影片轉換成功"
+
+#: share/gpodder/extensions/concatenate_videos.py:82
+msgid "Error converting videos"
+msgstr "轉換影片時發生錯誤"
+
+#: share/gpodder/extensions/concatenate_videos.py:83
+msgid "Concatenation result"
+msgstr "合併結果"
+
+#: share/gpodder/extensions/episode_website_context_menu.py:15
+msgid "\"Open website\" episode and podcast context menu"
+msgstr "「開啟網站」單集與 Podcast 右鍵選單"
+
+#: share/gpodder/extensions/episode_website_context_menu.py:16
+msgid ""
+"Add a context menu item for opening the website of an episode or podcast"
+msgstr "新增用於開啟 Podcast 或單集網站的右鍵選單項目"
+
+#: share/gpodder/extensions/episode_website_context_menu.py:40
+#: share/gpodder/extensions/episode_website_context_menu.py:43
+msgid "Open website"
+msgstr "開啟網站"
+
+#: share/gpodder/extensions/filter.py:15
+msgid "Filter Episodes"
+msgstr "篩選單集"
+
+#: share/gpodder/extensions/filter.py:16
+msgid "Disable automatic downloads based on episode title."
+msgstr "停用基於單集標題的自動下載。"
+
+#: share/gpodder/extensions/filter.py:55
+msgid "Regular Expression"
+msgstr "正規表示式"
+
+#: share/gpodder/extensions/filter.py:58
+msgid "Ignore Case"
+msgstr "忽略大小寫"
+
+#: share/gpodder/extensions/filter.py:128
+msgid "Filter"
+msgstr "篩選"
+
+#: share/gpodder/extensions/filter.py:142
+msgid ""
+"<b>Note:</b> The Cancel button does <b>not</b> return the filter settings to "
+"the values they had before. The changes are saved immediately after they are "
+"made."
+msgstr ""
+"<b>請注意：</b>「取消」按鈕<b>不會</b>讓篩選器設定回到先前的值。變更內容將在"
+"修改後立即儲存。"
+
+#: share/gpodder/extensions/filter.py:152
+msgid "Block"
+msgstr "封鎖"
+
+#: share/gpodder/extensions/filter.py:161
+msgid "Except"
+msgstr "例外"
+
+#: share/gpodder/extensions/filter.py:168
+msgid ""
+"Clicking the block checkbox and leaving it empty will disable auto-download "
+"for all episodes in this channel.  The patterns match partial text in "
+"episode title, and an empty pattern matches any title.  The except pattern "
+"unblocks blocked episodes (to block all then unblock some)."
+msgstr ""
+"點選「封鎖」核取方塊並將其留空，將會停用此頻道中所有單集的自動下載。規則樣式"
+"會比對單集標題中的部分文字，而空白的規則樣式則會比對任何標題。例外規則樣式可"
+"將被封鎖的單集解除封鎖 (例如先全部封鎖再解除一部分)。"
+
+#: share/gpodder/extensions/filter.py:177
+msgid "Filter episodes now"
+msgstr "立即篩選單集"
+
+#: share/gpodder/extensions/filter.py:181
+msgid "Undoes any episodes you marked as old."
+msgstr "復原將任何單集標記為舊單集的操作。"
+
+#: share/gpodder/extensions/gtk_statusicon.py:19
+msgid "Gtk Status Icon"
+msgstr "Gtk 狀態圖示"
+
+#: share/gpodder/extensions/gtk_statusicon.py:20
+msgid "Show a status icon for Gtk-based Desktops."
+msgstr "在 GTK 桌面上顯示狀態圖示。"
+
+#: share/gpodder/extensions/minimize_on_start.py:11
+msgid "Minimize on start"
+msgstr "啟動時最小化"
+
+#: share/gpodder/extensions/minimize_on_start.py:12
+msgid "Minimizes the gPodder window on startup."
+msgstr "啟動時最小化 gPodder 視窗。"
+
+#: share/gpodder/extensions/mpris-listener.py:36
+msgid "MPRIS Listener"
+msgstr "MPRIS 監聽器"
+
+#: share/gpodder/extensions/mpris-listener.py:37
+msgid "Convert MPRIS notifications to gPodder Media Player D-Bus API"
+msgstr "將 MPRIS 通知轉換為 gPodder 媒體播放器 D-Bus API"
+
+#: share/gpodder/extensions/notification-win32.py:50
+msgid "Notification Bubbles for Windows"
+msgstr "Windows 通知泡泡"
+
+#: share/gpodder/extensions/notification-win32.py:51
+msgid "Display notification bubbles for different events."
+msgstr "為不同事件顯示不同的通知泡泡。"
+
+#: share/gpodder/extensions/podverse.py:23
+msgid "Search Podverse"
+msgstr "搜尋 Podverse"
+
+#: share/gpodder/extensions/podverse.py:24
+msgid "Search podverse podcast index"
+msgstr "搜尋 Podverse Podcast 索引"
+
+#: share/gpodder/extensions/podverse.py:31
+msgid "Podverse search"
+msgstr "搜尋 Podverse"
+
+#: share/gpodder/extensions/podverse.py:37
+msgid "Please provide at least 3 characters"
+msgstr "請至少提供 3 個字元"
+
+#: share/gpodder/extensions/podverse.py:43
+#, python-format
+msgid "Error searching: %s"
+msgstr "搜尋錯誤：%s"
+
+#: share/gpodder/extensions/rockbox_coverart.py:25
+msgid "Rockbox Cover Art Sync"
+msgstr "Rockbox 封面圖片同步"
+
+#: share/gpodder/extensions/rockbox_coverart.py:26
+msgid "Copy Cover Art To Rockboxed Media Player"
+msgstr "複製封面圖片到已安裝 Rockbox 的媒體播放器"
+
+#: share/gpodder/extensions/rockbox_coverart.py:173
+msgid "<b><big>Rockbox Coverart Extension</big></b>"
+msgstr "<b><big>Rockbox 封面圖片擴充功能</big></b>"
+
+#: share/gpodder/extensions/rockbox_coverart.py:178
+msgid ""
+"This extension writes podcast cover art to a media player. This extension "
+"assumes that each podcast has its own folder on device. Only folder-wide "
+"coverart is written - this extension does not do anything about embedded "
+"cover art."
+msgstr ""
+"此擴充功能會將 Podcast 封面圖片寫入媒體播放器。此擴充功能假設每個 Podcast 在"
+"裝置上都有自己的資料夾。僅寫入整個資料夾共用的封面圖片 - 此擴充功能不處理嵌入"
+"式封面圖片。"
+
+#: share/gpodder/extensions/rockbox_coverart.py:194
+msgid ""
+"Enable conversion and resizing of art.\n"
+"\n"
+" If enabled, convert art to desired format (default JPEG) and size (default "
+"500px),\n"
+" and if format is JPEG, write as Baseline (rather than Progressive) format.\n"
+" If disabled, fall back to simple behavior."
+msgstr ""
+"啟用圖片轉換與大小調整。\n"
+"\n"
+"若啟用，將圖片轉換為所需格式 (預設 JPEG) 與大小 (預設 500px)，\n"
+"且若格式為 JPEG，則寫為 Baseline (而非 Progressive) 格式。\n"
+"若停用，則退回簡易處理方式。"
+
+#: share/gpodder/extensions/rockbox_coverart.py:201
+msgid "Allow upscaling of art"
+msgstr "允許放大圖片"
+
+#: share/gpodder/extensions/rockbox_coverart.py:228
+msgid "Art name on device:"
+msgstr "裝置上的圖片名稱："
+
+#: share/gpodder/extensions/rockbox_coverart.py:235
+msgid ""
+"Only JPEG and PNG formats are allowed. Note that Rockbox only supports JPEG "
+"format images, so PNG is not recommended if using a Rockbox player. "
+"Typically, devices look for art named either \"cover.jpg\" or \"folder.jpg\"."
+msgstr "Rockbox 封面圖片。"
+
+#: share/gpodder/extensions/rockbox_coverart.py:247
+msgid "Rockbox Coverart"
+msgstr "Rockbox 封面圖片"
+
+#: share/gpodder/extensions/sonos.py:19 share/gpodder/extensions/sonos.py:79
+msgid "Stream to Sonos"
+msgstr "串流至 Sonos"
+
+#: share/gpodder/extensions/sonos.py:20
+msgid "Stream podcasts to Sonos speakers"
+msgstr "將 Podcast 串流至 Sonos 喇叭"
+
+#: share/gpodder/extensions/subscription_stats.py:18
+#: share/gpodder/extensions/subscription_stats.py:36
+#: share/gpodder/extensions/subscription_stats.py:146
+msgid "Subscription Statistics"
+msgstr "訂閱發佈統計"
+
+#: share/gpodder/extensions/subscription_stats.py:19
+msgid "Show publishing statistics for subscriptions."
+msgstr "顯示訂閱項目的發佈間隔的統計資料。"
+
+#: share/gpodder/extensions/subscription_stats.py:53
+msgid "Updated"
+msgstr "最新更新"
+
+#: share/gpodder/extensions/subscription_stats.py:61
+msgid "Days"
+msgstr "天數"
+
+#: share/gpodder/extensions/subscription_stats.py:154
+#, python-format
+msgid "%d subscriptions (%d paused)"
+msgstr "%d 個訂閱 (其中 %d 個已暫停)"
+
+#: share/gpodder/extensions/subscription_stats.py:163
+msgid "daily"
+msgstr "日更"
+
+#: share/gpodder/extensions/subscription_stats.py:164
+msgid "weekly"
+msgstr "週更"
+
+#: share/gpodder/extensions/subscription_stats.py:165
+msgid "monthly"
+msgstr "月更"
+
+#: share/gpodder/extensions/subscription_stats.py:166
+msgid "yearly"
+msgstr "年更"
+
+#: share/gpodder/extensions/subscription_stats.py:170
+#, python-format
+msgid "Average days between the last %d episodes."
+msgstr "最近 %d 個單集的平均發佈間隔天數。"
+
+#: share/gpodder/extensions/taskbar_progress.py:42
+msgid "Show download progress on the taskbar"
+msgstr "在工作列上顯示下載進度"
+
+#: share/gpodder/extensions/taskbar_progress.py:43
+msgid "Displays the progress on the Windows taskbar."
+msgstr "在 Windows 工作列上顯示進度。"
+
+#: share/gpodder/extensions/ted_subtitles.py:17
+msgid "Subtitle Downloader for TED Talks"
+msgstr "TED Talks 字幕下載器"
+
+#: share/gpodder/extensions/ted_subtitles.py:18
+msgid "Downloads .srt subtitles for TED Talks Videos"
+msgstr "為 TED Talks 影片下載 .srt 字幕"
+
+#: share/gpodder/extensions/ubuntu_appindicator.py:15
+msgid "Ubuntu App Indicator"
+msgstr "Ubuntu 應用程式指示器"
+
+#: share/gpodder/extensions/ubuntu_appindicator.py:16
+msgid "Show a status indicator in the top bar."
+msgstr "在頂端列顯示狀態指示器。"
+
+#: share/gpodder/extensions/ubuntu_appindicator.py:47
+msgid "Show main window"
+msgstr "顯示主視窗"
+
+#: share/gpodder/extensions/ubuntu_appindicator.py:58
+#: share/gpodder/ui/gtk/gpodder.ui.h:7 share/gpodder/ui/gtk/menus.ui.h:7
+msgid "Quit"
+msgstr "結束"
+
+#: share/gpodder/extensions/ubuntu_unity.py:18
+msgid "Ubuntu Unity Integration"
+msgstr "Ubuntu Unity 整合"
+
+#: share/gpodder/extensions/ubuntu_unity.py:19
+msgid "Show download progress in the Unity Launcher icon."
+msgstr "在 Unity 啟動器圖示中顯示下載進度。"
+
+#: share/gpodder/extensions/update_feeds_on_startup.py:15
+msgid "Search for new episodes on startup"
+msgstr "啟動時搜尋新單集"
+
+#: share/gpodder/extensions/update_feeds_on_startup.py:16
+msgid "Starts the search for new episodes on startup"
+msgstr "啟動時開始搜尋新單集"
+
+#: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:1
+msgid "Add a new podcast"
+msgstr "新增 Podcast"
+
+#: share/gpodder/ui/gtk/gpodderaddpodcast.ui.h:5
+msgid "_Paste"
+msgstr "貼上(P)"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:1
+msgid "Channel Editor"
+msgstr "頻道編輯器"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:5
+msgid "<b>Feed URL</b>"
+msgstr "<b>Feed URL</b>"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:6
+msgid "<b>Download location</b>"
+msgstr "<b>下載位置</b>"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:7
+msgid "Info"
+msgstr "資訊"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:8
+msgid "Pause subscription"
+msgstr "暫停訂閱"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:9
+msgid "Sync to player devices"
+msgstr "同步到播放裝置"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:10
+msgid "Section:"
+msgstr "分類："
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:11
+msgid "Strategy:"
+msgstr "處理方式："
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:12
+msgid "<b>HTTP/FTP Authentication</b>"
+msgstr "<b>HTTP/FTP 驗證</b>"
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:13
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:21
+msgid "Username:"
+msgstr "使用者名稱："
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:14
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:22 bin/gpo:354
+msgid "Password:"
+msgstr "密碼："
+
+#: share/gpodder/ui/gtk/gpodderchannel.ui.h:15
+msgid "Settings"
+msgstr "設定"
+
+#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:1
+msgid "gPodder Configuration Editor"
+msgstr "gPodder 設定編輯器"
+
+#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:3
+msgid "Search for:"
+msgstr "搜尋："
+
+#: share/gpodder/ui/gtk/gpodderconfigeditor.ui.h:4
+msgid "_Show All"
+msgstr "全部顯示(S)"
+
+#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:1
+msgid "Select episodes"
+msgstr "選取單集"
+
+#: share/gpodder/ui/gtk/gpodderepisodeselector.ui.h:2
+msgid "_Remove"
+msgstr "移除(R)"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:4
+msgid "Add"
+msgstr "新增"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:5
+msgid "<big>Choose</big>"
+msgstr "<big>選擇</big>"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:6
+msgid "Select a source for new podcasts"
+msgstr "選取新 Podcast 的來源"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:7
+msgid "Podcast Providers"
+msgstr "Podcast 供應商"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:8
+msgid "label"
+msgstr "標籤"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:9
+msgid "..."
+msgstr "…"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:10
+msgid "Download in progress..."
+msgstr "下載中…"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:11
+msgid "Podcast Retrieve Progress"
+msgstr "Podcast 擷取進度"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:12
+msgid "Podcast Results"
+msgstr "Podcast 結果"
+
+#: share/gpodder/ui/gtk/gpodderpodcastdirectory.ui.h:13
+msgid "Podcast Selection"
+msgstr "Podcast 選取"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:1
+#: share/gpodder/ui/gtk/gpodder.ui.h:6 share/gpodder/ui/gtk/menus.ui.h:1
+msgid "Preferences"
+msgstr "偏好設定"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:2
+msgid "_Edit config"
+msgstr "編輯設定(E)"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:4
+msgid "Video player:"
+msgstr "影片播放器："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:5
+msgid "Audio player:"
+msgstr "音訊播放器："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:6
+msgid "Find as you type"
+msgstr "輸入時同步尋找"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:7
+msgid "Color scheme:"
+msgstr "色彩配置："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:8
+msgid "System"
+msgstr "系統"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:9
+msgid "Light"
+msgstr "淺色"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:10
+msgid "Dark"
+msgstr "深色"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:11
+msgid "General"
+msgstr "一般"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:12
+#: share/gpodder/ui/gtk/menus.ui.h:39
+msgid "Hide podcasts without episodes"
+msgstr "隱藏沒有單集的 Podcast"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:13
+#: share/gpodder/ui/gtk/menus.ui.h:40
+msgid "\"All episodes\" in podcast list"
+msgstr "Podcast 清單中顯示「所有單集」"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:14
+#: share/gpodder/ui/gtk/menus.ui.h:41
+msgid "Use sections for podcast list"
+msgstr "Podcast 清單使用分類"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:15
+#: share/gpodder/ui/gtk/menus.ui.h:46
+msgid "Always show New Episodes"
+msgstr "一律顯示新單集"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:16
+#: share/gpodder/ui/gtk/menus.ui.h:47
+msgid "Trim episode title prefix"
+msgstr "移除單集標題前綴"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:17
+#: share/gpodder/ui/gtk/menus.ui.h:48
+msgid "Episode descriptions"
+msgstr "顯示單集描述"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:18
+msgid "View"
+msgstr "檢視"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:19
+msgid "Synchronize subscriptions and episode actions"
+msgstr "同步訂閱項目與單集操作"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:20
+msgid "Server:"
+msgstr "伺服器："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:23
+msgid "Device name:"
+msgstr "裝置名稱："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:24
+msgid "Replace subscription list on server with local subscriptions:"
+msgstr "使用本機訂閱項目取代伺服器上的訂閱清單："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:25
+msgid "Upload local subscriptions"
+msgstr "上傳本機訂閱項目"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:26
+msgid "gpodder.net"
+msgstr "gpodder.net"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:27
+msgid "Update interval:"
+msgstr "更新間隔："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:28
+msgid "Maximum number of episodes per podcast:"
+msgstr "每個 Podcast 的最大單集數量："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:29
+msgid "Consider only episodes added in the update as new"
+msgstr "僅將更新時新增的單集視為新單集"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:30
+msgid "When new episodes are found:"
+msgstr "找到新單集時："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:31
+msgid "Check connection before updating (if supported)"
+msgstr "更新前檢查連線 (若支援)"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:32
+msgid "Updating"
+msgstr "更新"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:33
+msgid "Delete played episodes:"
+msgstr "刪除已播放的單集："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:34
+msgid "Remove played episodes even if unfinished"
+msgstr "即使未播放完畢也移除已播放的單集"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:35
+msgid "Also remove unplayed episodes"
+msgstr "同時移除未播放的單集"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:36
+msgid "Clean-up"
+msgstr "清理"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:37
+msgid "Device type:"
+msgstr "裝置類型："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:38
+msgid "Mountpoint:"
+msgstr "裝置路徑："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:39
+msgid "Create separate folders for each podcast"
+msgstr "為每個 Podcast 建立獨立資料夾"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:40
+msgid "Create playlists on device"
+msgstr "在裝置上建立播放清單"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:41
+msgid "Use absolute paths in playlists"
+msgstr "在播放清單中使用絕對路徑"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:42
+msgid "Playlists Folder:"
+msgstr "播放清單資料夾："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:43
+msgid "Episode filename method:"
+msgstr "單集檔案名稱方法："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:44
+msgid "Custom filename format:"
+msgstr "自訂檔案名稱格式："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:45
+msgid "Maximum filename length:"
+msgstr "檔案名稱最大長度："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:46
+msgid "Only sync unplayed episodes"
+msgstr "僅同步未播放的單集"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:47
+msgid ""
+"Sync existing episodes on device when file size differs from gPodder "
+"(disable if device modifies files)"
+msgstr ""
+"當裝置上現有單集的檔案大小與 gPodder 中的不同時進行同步 (若裝置會修改檔案則停"
+"用此功能)"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:48
+msgid "Delete episodes from gPodder when deleted on Device"
+msgstr "當裝置上的單集被刪除時，同時從 gPodder 中刪除"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:49
+msgid ""
+"Note: To detect episodes as deleted on the device, \"Create playlists on "
+"device\" must be enabled."
+msgstr ""
+"請注意：若要在裝置上偵測已刪除的單集，必須啟用「在裝置上建立播放清單」功能。"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:50
+msgid "Delete episodes from Device when deleted in gPodder"
+msgstr "當 gPodder 中的單集被刪除時，同時從裝置上刪除"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:51
+msgid "After syncing an episode:"
+msgstr "同步單集後："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:52
+msgid "Devices"
+msgstr "播放裝置"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:53
+msgid "Preferred YouTube format:"
+msgstr "偏好的 YouTube 格式："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:54
+msgid "Preferred YouTube HLS format:"
+msgstr "偏好的 YouTube HLS 格式："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:55
+msgid "Preferred Vimeo format:"
+msgstr "偏好的 Vimeo 格式："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:57
+msgid "Use proxy (Overrides environment variables)"
+msgstr "使用代理伺服器 (將覆寫環境變數)"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:58
+msgid "Proxy type:"
+msgstr "代理伺服器類型："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:59
+msgid "Hostname:"
+msgstr "主機名稱："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:60
+msgid "Port:"
+msgstr "連接埠："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:61
+msgid "Use username and password"
+msgstr "使用使用者名稱和密碼"
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:62
+msgid ""
+"Proxies given in environment variables (will be used only if proxy above is "
+"disabled):"
+msgstr "環境變數中設定的代理伺服器 (僅在上方代理伺服器設定停用時才會使用)："
+
+#: share/gpodder/ui/gtk/gpodderpreferences.ui.h:64
+msgid "Network"
+msgstr "網路"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:8 share/gpodder/ui/gtk/menus.ui.h:9
+msgid "Check for new episodes"
+msgstr "檢查新單集"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:9
+msgid "Filter:"
+msgstr "篩選器："
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:10
+msgid "Podcasts"
+msgstr "Podcast"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:11
+msgid "Resume all"
+msgstr "全部續傳"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:12
+msgid "Incomplete downloads from a previous session were found."
+msgstr "發現先前連線階段未完成的下載。"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:13
+msgid "Limit rate to"
+msgstr "下載速率限制為"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:14
+msgid "KiB/s"
+msgstr "KiB/秒"
+
+#: share/gpodder/ui/gtk/gpodder.ui.h:15
+msgid "Limit downloads to"
+msgstr "同時下載數量限制為"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:3
+msgid "<big>Welcome to gPodder</big>"
+msgstr "<big>歡迎使用 gPodder</big>"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:4
+msgid "Your podcast list is empty."
+msgstr "您的 Podcast 清單是空的。"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:5
+msgid "Choose from a list of example podcasts"
+msgstr "從範例 Podcast 清單中選擇"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:6
+msgid "Add a podcast by entering its URL"
+msgstr "透過輸入 URL 新增 Podcast"
+
+#: share/gpodder/ui/gtk/gpodderwelcome.ui.h:7
+msgid "Restore my subscriptions from gpodder.net"
+msgstr "從 gpodder.net 還原我的訂閱項目"
+
+#: share/gpodder/ui/gtk/menus.ui.h:2
+msgid "Go to gpodder.net"
+msgstr "前往 gpodder.net"
+
+#: share/gpodder/ui/gtk/menus.ui.h:3
+msgid "Software updates"
+msgstr "軟體更新"
+
+#: share/gpodder/ui/gtk/menus.ui.h:4
+msgid "Open Logs"
+msgstr "開啟日誌"
+
+#: share/gpodder/ui/gtk/menus.ui.h:5
+msgid "Help"
+msgstr "說明"
+
+#: share/gpodder/ui/gtk/menus.ui.h:6
+msgid "About"
+msgstr "關於"
+
+#: share/gpodder/ui/gtk/menus.ui.h:8
+msgid "_Podcasts"
+msgstr "Podcast(P)"
+
+#: share/gpodder/ui/gtk/menus.ui.h:10
+msgid "Download new episodes"
+msgstr "下載新單集"
+
+#: share/gpodder/ui/gtk/menus.ui.h:12
+msgid "Find Podcast"
+msgstr "尋找 Podcast"
+
+#: share/gpodder/ui/gtk/menus.ui.h:13
+msgid "_Subscriptions"
+msgstr "訂閱(S)"
+
+#: share/gpodder/ui/gtk/menus.ui.h:14
+msgid "Discover new podcasts"
+msgstr "探索新 Podcast"
+
+#: share/gpodder/ui/gtk/menus.ui.h:15
+msgid "Add podcast via URL"
+msgstr "透過 URL 新增 Podcast"
+
+#: share/gpodder/ui/gtk/menus.ui.h:17
+msgid "Update podcast"
+msgstr "更新 Podcast"
+
+#: share/gpodder/ui/gtk/menus.ui.h:18
+msgid "Podcast settings"
+msgstr "Podcast 設定"
+
+#: share/gpodder/ui/gtk/menus.ui.h:19
+msgid "Import from OPML file"
+msgstr "從 OPML 檔案匯入"
+
+#: share/gpodder/ui/gtk/menus.ui.h:20
+msgid "Export to OPML file"
+msgstr "匯出為 OPML 檔案"
+
+#: share/gpodder/ui/gtk/menus.ui.h:21
+msgid "_Episodes"
+msgstr "單集(E)"
+
+#: share/gpodder/ui/gtk/menus.ui.h:27
+msgid "Delete"
+msgstr "刪除"
+
+#: share/gpodder/ui/gtk/menus.ui.h:28
+msgid "Toggle new status"
+msgstr "切換新單集狀態"
+
+#: share/gpodder/ui/gtk/menus.ui.h:29
+msgid "Change delete lock"
+msgstr "變更刪除鎖定"
+
+#: share/gpodder/ui/gtk/menus.ui.h:30
+msgid "Open download folder"
+msgstr "開啟下載資料夾"
+
+#: share/gpodder/ui/gtk/menus.ui.h:31
+msgid "Select channel"
+msgstr "選取頻道"
+
+#: share/gpodder/ui/gtk/menus.ui.h:32
+msgid "Find Episode"
+msgstr "尋找單集"
+
+#: share/gpodder/ui/gtk/menus.ui.h:33
+msgid "Episode details"
+msgstr "單集詳細資料"
+
+#: share/gpodder/ui/gtk/menus.ui.h:34
+msgid "E_xtras"
+msgstr "額外功能(x)"
+
+#: share/gpodder/ui/gtk/menus.ui.h:35
+msgid "Sync to device"
+msgstr "同步到裝置"
+
+#: share/gpodder/ui/gtk/menus.ui.h:36
+msgid "_View"
+msgstr "檢視(V)"
+
+#: share/gpodder/ui/gtk/menus.ui.h:37
+msgid "Toolbar"
+msgstr "工具列"
+
+#: share/gpodder/ui/gtk/menus.ui.h:38
+msgid "Always show Find entries"
+msgstr "一律顯示尋找欄位"
+
+#: share/gpodder/ui/gtk/menus.ui.h:43
+msgid "Hide deleted episodes"
+msgstr "隱藏已刪除的單集"
+
+#: share/gpodder/ui/gtk/menus.ui.h:44
+msgid "Downloaded episodes"
+msgstr "已下載的單集"
+
+#: share/gpodder/ui/gtk/menus.ui.h:45
+msgid "Unplayed episodes"
+msgstr "未播放的單集"
+
+#: share/gpodder/ui/gtk/menus.ui.h:49
+msgid "Show episode released time"
+msgstr "顯示單集發佈時間"
+
+#: share/gpodder/ui/gtk/menus.ui.h:50
+msgid "Right align episode released column"
+msgstr "向右對齊單集發佈時間欄"
+
+#: share/gpodder/ui/gtk/menus.ui.h:51
+msgid "Require control click to sort episodes"
+msgstr "排序單集順序需按住 Ctrl 鍵並點擊"
+
+#: share/gpodder/ui/gtk/menus.ui.h:52
+msgid "Visible columns"
+msgstr "可見欄位"
+
+#: share/gpodder/ui/gtk/menus.ui.h:53
+msgid "Update channel"
+msgstr "更新頻道"
+
+#: share/gpodder/ui/gtk/menus.ui.h:54
+msgid "Channel settings"
+msgstr "頻道設定"
+
+#: share/gpodder/ui/gtk/menus.ui.h:55
+msgid "Delete channel"
+msgstr "刪除頻道"
+
+#: share/gpodder/ui/gtk/menus.ui.h:56
+msgid "Mark episodes as old"
+msgstr "將單集標記為已看過"
+
+#: share/gpodder/ui/gtk/menus.ui.h:57
+msgid "Archive all episodes"
+msgstr "封存所有單集"
+
+#: share/gpodder/ui/gtk/menus.ui.h:58
+msgid "Refresh image"
+msgstr "重新整理圖片"
+
+#: share/gpodder/ui/gtk/menus.ui.h:59
+msgid "New"
+msgstr "標記為未看過"
+
+#: share/gpodder/ui/gtk/menus.ui.h:60
+msgid "Archive"
+msgstr "封存"
+
+#: share/gpodder/ui/gtk/menus.ui.h:61
+msgid "Local folder"
+msgstr "本機資料夾"
+
+#: share/gpodder/ui/gtk/menus.ui.h:62
+msgid "Bluetooth device"
+msgstr "藍牙裝置"
+
+#: share/gpodder/ui/gtk/menus.ui.h:64
+msgid "Move up"
+msgstr "上移"
+
+#: share/gpodder/ui/gtk/menus.ui.h:65
+msgid "Move down"
+msgstr "下移"
+
+#: share/gpodder/ui/gtk/menus.ui.h:66
+msgid "Remove from list"
+msgstr "從清單中移除"
+
+#: bin/gpo:273
+msgid "Podcast update requested by extensions."
+msgstr "擴充功能已請求 Podcast 更新。"
+
+#: bin/gpo:277
+msgid "Episode download requested by extensions."
+msgstr "擴充功能已請求下載單集。"
+
+#: bin/gpo:330
+#, python-format
+msgid "Invalid url: %s"
+msgstr "無效的 URL：%s"
+
+#: bin/gpo:347
+msgid "Wrong username/password"
+msgstr "錯誤的使用者名稱/密碼"
+
+#: bin/gpo:352
+msgid "User name:"
+msgstr "使用者名稱："
+
+#: bin/gpo:369 bin/gpo:445 bin/gpo:493 bin/gpo:708 bin/gpo:730 bin/gpo:745
+#: bin/gpo:825
+#, python-format
+msgid "You are not subscribed to %s."
+msgstr "您尚未訂閱 %s。"
+
+#: bin/gpo:375
+#, python-format
+msgid "Already subscribed to %s."
+msgstr "已訂閱 %s。"
+
+#: bin/gpo:381
+#, python-format
+msgid "Cannot subscribe to %s."
+msgstr "無法訂閱 %s。"
+
+#: bin/gpo:397
+#, python-format
+msgid "Successfully added %s."
+msgstr "成功新增 %s。"
+
+#: bin/gpo:415
+msgid "This configuration option does not exist."
+msgstr "此設定選項不存在。"
+
+#: bin/gpo:419
+msgid "Can only set leaf configuration nodes."
+msgstr "只能設定末端設定節點。"
+
+#: bin/gpo:433
+#, python-format
+msgid "Renamed %(old_title)s to %(new_title)s."
+msgstr "已將 %(old_title)s 重新命名為 %(new_title)s。"
+
+#: bin/gpo:452
+#, python-format
+msgid "Unsubscribed from %s."
+msgstr "已取消訂閱 %s。"
+
+#: bin/gpo:530
+msgid "Invalid command."
+msgstr "指令無效。"
+
+#: bin/gpo:535
+#, python-format
+msgid "Invalid option: %s."
+msgstr "無效的選項：%s。"
+
+#: bin/gpo:560
+msgid "Updates disabled"
+msgstr "更新已停用"
+
+#: bin/gpo:571
+#, python-format
+msgid "%(count)d new episode"
+msgid_plural "%(count)d new episodes"
+msgstr[0] "%(count)d 個新單集"
+
+#: bin/gpo:577
+msgid "Checking for new episodes"
+msgstr "正在檢查新單集"
+
+#: bin/gpo:586
+#, python-format
+msgid "Skipping %(podcast)s"
+msgstr "正在略過 %(podcast)s"
+
+#: bin/gpo:715
+msgid "No episode with the specified GUID found."
+msgstr "找不到具有指定 GUID 的單集。"
+
+#: bin/gpo:719
+#, python-format
+msgid "Deleted episode \"%s\"."
+msgstr "已刪除單集「%s」。"
+
+#: bin/gpo:721
+msgid "Episode has already been deleted."
+msgstr "單集已被刪除。"
+
+#: bin/gpo:736
+#, python-format
+msgid "Disabling feed update from %s."
+msgstr "正在停用來自 %s 的 Feed 更新。"
+
+#: bin/gpo:751
+#, python-format
+msgid "Enabling feed update from %s."
+msgstr "正在啟用來自 %s 的 Feed 更新。"
+
+#: bin/gpo:780
+msgid "No podcasts found."
+msgstr "找不到任何 Podcast 。"
+
+#: bin/gpo:794
+msgid "Enter index to subscribe, ? for list"
+msgstr "輸入索引以訂閱，輸入 ? 查看清單"
+
+#: bin/gpo:808 bin/gpo:812 bin/gpo:953 bin/gpo:957
+msgid "Invalid value."
+msgstr "無效值。"
+
+#: bin/gpo:816
+#, python-format
+msgid "Adding %s..."
+msgstr "正在新增 %s…"
+
+#: bin/gpo:829
+#, python-format
+msgid "Invalid URL: %s"
+msgstr "無效的 URL：%s"
+
+#: bin/gpo:832
+#, python-format
+msgid "Changed URL from %(old_url)s to %(new_url)s."
+msgstr "已將 URL 從 %(old_url)s 變更為 %(new_url)s。"
+
+#: bin/gpo:857
+#, python-format
+msgid "%(title)s: %(msg)s ([yes]/no): "
+msgstr "%(title)s: %(msg)s ([是]/否)："
+
+#: bin/gpo:861 bin/gpo:1049
+msgid "yes"
+msgstr "是"
+
+#: bin/gpo:898
+#, python-format
+msgid "Deleting episode: %(episode)s"
+msgstr "正在刪除單集：%(episode)s"
+
+#: bin/gpo:931
+msgid ""
+"Enter episode index to toggle, ? for list, X to select all, space to select "
+"none, empty when ready"
+msgstr ""
+"輸入單集索引以切換選取狀態，? 查看清單，X 全選，空白鍵全部不選，準備就緒時直"
+"接按 Enter"
+
+#: bin/gpo:963
+#, python-format
+msgid "Will delete %(episode)s"
+msgstr "將刪除單集 %(episode)s"
+
+#: bin/gpo:965
+#, python-format
+msgid "Won't delete %(episode)s"
+msgstr "不會刪除單集 %(episode)s"
+
+#: bin/gpo:973
+#, python-format
+msgid "mounting volume for file %(file)s failed with: %(error)s"
+msgstr "檔案 %(file)s 掛載磁碟區失敗：%(error)s"
+
+#: bin/gpo:985
+#, python-format
+msgid "Syncing %s"
+msgstr "正在同步 %s"
+
+#: bin/gpo:1032
+msgid "(enabled)"
+msgstr "(已啟用)"
+
+#: bin/gpo:1043
+msgid "Title:"
+msgstr "標題："
+
+#: bin/gpo:1044
+msgid "Category:"
+msgstr "分類："
+
+#: bin/gpo:1045
+msgid "Description:"
+msgstr "描述："
+
+#: bin/gpo:1046
+msgid "Authors:"
+msgstr "作者："
+
+#: bin/gpo:1048
+msgid "Documentation:"
+msgstr "說明文件："
+
+#: bin/gpo:1049
+msgid "Enabled:"
+msgstr "已啟用："
+
+#: bin/gpo:1049
+msgid "no"
+msgstr "否"
+
+#: bin/gpo:1074
+msgid "enabled"
+msgstr "已啟用"
+
+#: bin/gpo:1074
+msgid "disabled"
+msgstr "已停用"
+
+#: bin/gpo:1077
+#, python-format
+msgid "Extension %(name)s (%(title)s) %(enabled)s"
+msgstr "擴充功能 %(name)s (%(title)s) %(enabled)s"
+
+#: bin/gpo:1157
+#, python-format
+msgid "Syntax error: %(error)s"
+msgstr "語法錯誤：%(error)s"
+
+#: bin/gpo:1275
+msgid "Ambiguous command. Did you mean.."
+msgstr "指令意義模糊。您的意思是不是..."
+
+#: bin/gpo:1279
+msgid "The requested function is not available."
+msgstr "請求的功能不可用。"
+
+#: share/applications/gpodder.desktop.in.h:2
+msgid "gPodder Podcast Client"
+msgstr "gPodder  Podcast 用戶端"
+
+#: share/applications/gpodder.desktop.in.h:3
+msgid "Podcast Client"
+msgstr "Podcast 用戶端"
+
+#: share/applications/gpodder.desktop.in.h:4
+msgid "Subscribe to audio and video content from the web"
+msgstr "訂閱來自網路的音訊與影片內容"
+
+#: share/applications/gpodder-url-handler.desktop.in.h:1
+msgid "gPodder (subscribe to feed)"
+msgstr "gPodder (訂閱 Feed)"

--- a/src/gpodder/utilwin32locale.py
+++ b/src/gpodder/utilwin32locale.py
@@ -103,7 +103,7 @@ def _localefromlcid(lcid):
                # we have only one zh_CN.po translation. Applying to all.
                2052: 'zh_CN',  # Chinese - People's Republic of China
                4100: 'zh_CN',  # Chinese - Singapore
-               1028: 'zh_CN',  # Chinese - Taiwan
+               1028: 'zh_TW',  # Chinese - Taiwan
                3076: 'zh_CN',  # Chinese - Hong Kong SAR
                5124: 'zh_CN',  # Chinese - Macao SAR
                1050: 'hr',  # Croatian


### PR DESCRIPTION
This pull request adds a new translation for Traditional Chinese (zh_TW) and updates utilwin32locale.py to enable zh_TW locale support on Windows.
While I’m not completely certain if this is the best or intended way to handle locale loading, the change works as expected in my environment.