### PR TITLE
Reverse order of feeds being updated by id in the sql query

### DIFF
--- a/src/gpodder/dbsqlite.py
+++ b/src/gpodder/dbsqlite.py
@@ -150,7 +150,8 @@ class Database(object):
     def load_podcasts(self, factory):
         logger.info('Loading podcasts')
 
-        sql = 'SELECT * FROM %s' % self.TABLE_PODCAST
+        # See https://github.com/gpodder/gpodder/issues/1768 for why descending order
+        sql = 'SELECT * FROM %s order by id desc' % self.TABLE_PODCAST
 
         with self.lock:
             cur = self.cursor()


### PR DESCRIPTION
This is a small change to the sqlite sql query. Intended to update the latest feeds first.
See the issue below for discussion and reasons for this change.
Solves #1768 