### PR TITLE
Issue #1763: Preferences: List extensions by priority within categories

### DIFF
--- a/src/gpodder/gtkui/desktop/preferences.py
+++ b/src/gpodder/gtkui/desktop/preferences.py
@@ -507,7 +507,7 @@ class gPodderPreferences(BuilderWidget):
 
         def key_func(pair):
             category, container = pair
-            return (category, container.metadata.title)
+            return (category, container.priority, container.metadata.title)
 
         def convert(extensions):
             for container in extensions:


### PR DESCRIPTION
As title states. Sorted by category, then priority, then metadata title.

Numerical priority is not displayed to the user - if they need to know it, they'll see the filenames anyway.