### PR TITLE
main: Fix 'Open download folder' on non-downloaded episodes

### DIFF
--- a/src/gpodder/gtkui/main.py
+++ b/src/gpodder/gtkui/main.py
@@ -1912,7 +1912,12 @@ class gPodder(BuilderWidget, dbus.service.Object):
                 raise GLib.GError(Gio.IOErrorEnum.NOT_SUPPORTED,
                                   'No session bus available')
 
-            uri = pathlib.Path(episodes[0].local_filename(create=False)).as_uri()
+            filename = episodes[0].local_filename(create=False)
+            if filename is None:
+                raise GLib.GError(Gio.IOErrorEnum.NOT_FOUND,
+                                  'Episode file not found')
+
+            uri = pathlib.Path(filename).as_uri()
             bus.call_sync('org.freedesktop.FileManager1',
                           '/org/freedesktop/FileManager1',
                           'org.freedesktop.FileManager1',


### PR DESCRIPTION
When the selected episode was not downloaded, None was submitted as arg to pathlib.Path, resulting in an unhandled exception in on_open_episode_download_folder().

Raise GError when episode file does not exist, the folder is then opened with util.gui_open() in the exception handler.