### PR TITLE
makefile: Don't print all files on codespell invovation

### DIFF
--- a/makefile
+++ b/makefile
@@ -78,7 +78,7 @@ lint:
 	isort -q $(ISORTOPTS) || isort --df $(ISORTOPTS)
 
 	codespell --version
-	codespell --quiet-level 3 --skip "./.git,*.po,.mypy_cache,./share/applications/gpodder.desktop" --  $(shell git ls-files)
+	git ls-files | xargs codespell --quiet-level 3 --skip "./.git,*.po,.mypy_cache,./share/applications/gpodder.desktop" --
 
 release: distclean
 	$(PYTHON) -m build --sdist


### PR DESCRIPTION
The `codespell` invocation in `make lint` currently prints out all gPodder files known to git. Reduce the noise by rewriting the command in makefile.