### PR TITLE
Tweak Extensions categories

### DIFF
--- a/share/gpodder/extensions/command_on_sync.py
+++ b/share/gpodder/extensions/command_on_sync.py
@@ -18,7 +18,7 @@ __title__ = _('Run a Command on Sync')
 __description__ = _('Run a custom external command upon sync completion.')
 __authors__ = 'Eric Le Lay <elelay@macports.org>, Azer Abdullaev <azer.abdullaev.berlin+git@gmail.com>'
 __doc__ = 'https://gpodder.github.io/docs/extensions/commandonsync.html'
-__category__ = 'post-sync'
+__category__ = 'device-sync'
 __only_for__ = 'gtk, cli'
 
 

--- a/share/gpodder/extensions/rockbox_coverart.py
+++ b/share/gpodder/extensions/rockbox_coverart.py
@@ -27,7 +27,7 @@ __description__ = _('Copy Cover Art To Rockboxed Media Player')
 __only_for__ = 'gtk, cli'
 __authors__ = 'Alex Mayer <magictrick4906@aim.com>, Dana Conrad <dconrad@fastmail.com>'
 __doc__ = 'https://gpodder.github.io/docs/extensions/rockbox_coverart.html'
-__category__ = 'post-download'
+__category__ = 'device-sync'
 
 DefaultConfig = {
     "art_name_on_device": "cover.jpg",

--- a/src/gpodder/extensions.py
+++ b/src/gpodder/extensions.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 CATEGORY_DICT = {
     'desktop-integration': _('Desktop Integration'),
+    'device-sync': _('Device Sync'),
     'interface': _('Interface'),
     'post-download': _('Post download'),
 }


### PR DESCRIPTION
I think the extensions categories list could use a little adjustment -

Currently, this PR adds "Device Sync", with:

- Rockbox Cover Art Sync
- Run A Command On Sync (Perhaps this could be renamed "Run A Command After Sync"?)

I also propose (but have not done yet in this PR) to add a "Download" counterpart to "Post Download", and put in it:

- Filter Episodes
- youtube-dl
- (maybe) Subtitle Downloader for TED Talks?

Thirdly (and finally), I wonder if "Run A Command On Download" should be renamed to "Run A Command After Download". This has not been done yet in this PR either.

Opinions?