### PR TITLE
Import AppIndicator3 with a version to avoid warning

### DIFF
--- a/share/gpodder/extensions/ubuntu_appindicator.py
+++ b/share/gpodder/extensions/ubuntu_appindicator.py
@@ -5,6 +5,8 @@
 
 import logging
 
+import gi  # isort:skip
+gi.require_version('AppIndicator3', '0.1')
 from gi.repository import AppIndicator3 as appindicator
 from gi.repository import Gtk
 


### PR DESCRIPTION
Currently enabling the `ubuntu_appindicator` extension results in this warning:

```
PyGIWarning: AppIndicator3 was imported without specifying a version first. Use gi.require_version('AppIndicator3', '0.1') before import to ensure that the right version gets loaded.
```

This MR does as instructed.