### PR TITLE
10_youtube-dl.py: change sys.executable to pythonw for calling pip commands

### DIFF
--- a/share/gpodder/extensions/10_youtube-dl.py
+++ b/share/gpodder/extensions/10_youtube-dl.py
@@ -592,7 +592,7 @@ class gPodderExtension:
         success = False
         try:
             output = subprocess.check_output(
-                    [sys.executable, '-m', 'pip', 'index', 'versions', program_name],
+                    ['pythonw', '-m', 'pip', 'index', 'versions', program_name],
                     stderr=subprocess.STDOUT,
                     encoding='utf-8',
                     close_fds=True,
@@ -626,7 +626,7 @@ class gPodderExtension:
     def do_update(self, widget):
         try:
             subprocess.check_output(
-                    [sys.executable, '-m', 'pip', 'install', '--upgrade', program_name],
+                    ['pythonw', '-m', 'pip', 'install', '--upgrade', program_name],
                     stderr=subprocess.STDOUT,
                     encoding='utf-8',
                     close_fds=True,


### PR DESCRIPTION
It was meant to call the parent python executable, which worked when running gpodder from source tree with python.
But in windows builds it actually calls the pre-built gpodder.exe and cause an error:

    [10_youtube-dl] ERROR: Error checking for latest version: CalledProcessError(2, ['C:\\Users\\newuser\\Desktop\\gpodder-3.11.5-portable\\data\\bin\\gpodder.exe', '-m', 'pip', 'index', 'versions', 'yt-dlp'])

I chose `pythonw` instead of just `python` so that there wont be a black cmd window opened and then closed quickly when running the pip commands.
Again, sorry for not testing this process thoroughly enough. I missed it by only running gpodder from the source tree with python. I won't happen again.