### PR TITLE
normalize plugin doesn't work in Fedora

### DIFF
--- a/share/gpodder/extensions/30_normalize_audio.py
+++ b/share/gpodder/extensions/30_normalize_audio.py
@@ -46,7 +46,7 @@ class gPodderExtension:
         # Dependency check
         self.container.require_command('normalize-ogg')
         self.container.require_command('normalize-mp3')
-        self.container.require_command('normalize-audio')
+        self.command = self.container.require_any_command(['normalize', 'normalize-audio'])
 
     def on_load(self):
         logger.info('Extension "%s" is being loaded.' % __title__)
@@ -88,7 +88,7 @@ class gPodderExtension:
 
         basename, extension = os.path.splitext(filename)
 
-        cmd = [CONVERT_COMMANDS.get(extension, 'normalize-audio'), filename]
+        cmd = [CONVERT_COMMANDS.get(extension, self.command), filename]
 
         # Set cwd to prevent normalize from placing files in the directory gpodder was started from.
         if gpodder.ui.win32:


### PR DESCRIPTION
In Fedora (Redhat+Clones) the normalize-audio command doesn't exist, the command is only normalize as in the original author, this patch solves this