### PR TITLE
device: add note about two-way-sync limitation

### DIFF
--- a/share/gpodder/ui/gtk/gpodderpreferences.ui
+++ b/share/gpodder/ui/gtk/gpodderpreferences.ui
@@ -1298,7 +1298,7 @@
                               <object class="GtkLabel" id="label_delete_using_playlists_note">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Note: To detect episodes as deleted on the device, "Create playlists on device" must be enabled.</property>
+                                <property name="label" translatable="yes">Note: To detect episodes as deleted on the device, "Create playlists on device" must be enabled and "Use absolute paths in playlists" must be disabled.</property>
                                 <property name="wrap">True</property>
                                 <property name="xalign">0</property>
                               </object>


### PR DESCRIPTION
This can be reverted if PR #1829 is merged. Adds a note that two-way-sync does not work if absolute paths are used for playlists.