### PR TITLE
pyproject.toml: Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ requires-python = ">=3.8"
 dependencies = [
     "dbus-python;platform_system=='Linux'",
     "mygpoclient==1.10",
-    "podcastparser==0.6.10",
+    "podcastparser==0.6.11",
     "PyGObject",
-    "requests[socks]==2.32.3",
-    "urllib3==2.2.2",
+    "requests[socks]>=2.32.3",
+    "urllib3>=2.2.2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
gPodder lags one minor release behind in podcastparser and requests. urllib3 has also seen several releases with the latest one containing some security fixes.

I'm not sure why requests and urllib3 are set to exact versions, this PR sets them to the latest versions above the current ones.