### PR TITLE
Remove html5lib from Mac and Windows builds.

### DIFF
--- a/tools/mac-osx/release_on_mac.sh
+++ b/tools/mac-osx/release_on_mac.sh
@@ -73,7 +73,7 @@ $run_pip debug -v
 $run_pip install -v brotli || exit 1
 $run_pip install -v pycryptodomex || exit 1
 # install extension dependencies; no explicit version for yt-dlp
-$run_pip install html5lib==1.1 mutagen==1.47.0 yt-dlp || exit 1
+$run_pip install mutagen==1.47.0 yt-dlp || exit 1
 $run_pip install pillow==11.0.0 filelock==3.16.1 || exit 1
 
 cd "$checkout"

--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -98,7 +98,6 @@ certifi==2024.12.14
 chardet==5.2.0
 comtypes==1.4.8
 git+https://github.com/jaraco/pywin32-ctypes.git@f27d6a0
-html5lib==1.1
 idna==3.10
 mutagen==1.47.0
 mygpoclient==1.10

--- a/tools/win_installer/bootstrap.sh
+++ b/tools/win_installer/bootstrap.sh
@@ -28,7 +28,7 @@ function main {
 
     pip3 install --user podcastparser mygpoclient \
                         pywin32-ctypes \
-                        html5lib webencodings six \
+                        webencodings six \
                         pillow filelock
 }
 


### PR DESCRIPTION
html5lib is unmaintained and does not support Python 3.14. It is only used to highlight URLs in text shownotes, and HTMLParser seems to work fine.

Fixes #1843.