### PR TITLE
Add yt-dlp-ejs to Mac and Windows builds.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ rockbox_coverart = ["filelock", "pillow"]
 sonos = ["soco>=0.7"]
 tagging = ["mutagen==1.47.0", "pillow"]
 video_converter = ["ffmpeg"]
-youtube_dl = ["yt-dlp", "ffmpeg"]
+youtube_dl = ["yt-dlp", "yt-dlp-ejs", "ffmpeg"]
 
 [project.urls]
 Homepage = "http://gpodder.org"

--- a/share/gpodder/extensions/10_youtube-dl.py
+++ b/share/gpodder/extensions/10_youtube-dl.py
@@ -632,8 +632,11 @@ class gPodderExtension:
 
     def do_update(self, widget):
         try:
+            arguments = ['pythonw', '-m', 'pip', 'install', '--upgrade', program_name]
+            if program_name == 'yt-dlp':
+                arguments.append('yt-dlp-ejs')
             subprocess.check_output(
-                    ['pythonw', '-m', 'pip', 'install', '--upgrade', program_name],
+                    arguments,
                     stderr=subprocess.STDOUT,
                     encoding='utf-8',
                     close_fds=True,

--- a/tools/mac-osx/release_on_mac.sh
+++ b/tools/mac-osx/release_on_mac.sh
@@ -73,7 +73,7 @@ $run_pip debug -v
 $run_pip install -v brotli || exit 1
 $run_pip install -v pycryptodomex || exit 1
 # install extension dependencies; no explicit version for yt-dlp
-$run_pip install mutagen==1.47.0 yt-dlp || exit 1
+$run_pip install mutagen==1.47.0 yt-dlp yt-dlp-ejs || exit 1
 $run_pip install pillow==11.0.0 filelock==3.16.1 || exit 1
 
 cd "$checkout"

--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -109,6 +109,7 @@ webencodings==0.5.1
 pillow==11.0.0
 filelock==3.16.1
 yt-dlp
+yt-dlp-ejs
 "
 
 SEVENZINST='7z2301.exe' # http://www.7-zip.org/


### PR DESCRIPTION
Deno must still be installed separately.