### PR TITLE
Initial switch from mingw32 to ucrt64 windows build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,8 +12,8 @@ image:
 
 environment:
   matrix:
-    - MSYS2_ARCH: i686
-      MSYSTEM: MINGW32
+    - MSYS2_ARCH: x86_64
+      MSYSTEM: UCRT64
 
 build_script:
   - set

--- a/tools/win_installer/README.rst
+++ b/tools/win_installer/README.rst
@@ -29,13 +29,13 @@ Setting Up the MSYS2 Environment
 
 * Download msys2 64-bit from https://msys2.github.io/
 * Follow instructions on https://msys2.github.io/
-* Execute ``C:\msys64\mingw64.exe``
+* Execute ``C:\msys64\ucrt64.exe``
 * Run ``pacman -S git`` to install git
 * Run ``git clone https://github.com/gpodder/gpodder.git``
 * Run ``cd gpodder/tools/win_installer`` to end up where this README exists.
 * Execute ``./bootstrap.sh`` to install all the needed dependencies.
 * Now go to the application source code ``cd ../..``
-* To run gPodder execute ``./bin/gpodder``
+* To run gPodder execute ``PYTHONPATH="./tools/fake-dbus-module/" ./bin/gpodder``
 
 If you want to use py.test directly you have to unset the MSYSTEM env var:
 ``MSYSTEM= py.test tests/test_util.py``

--- a/tools/win_installer/_base.sh
+++ b/tools/win_installer/_base.sh
@@ -94,20 +94,8 @@ function extract_installer {
 }
 
 PIP_REQUIREMENTS="\
-certifi==2024.12.14
-chardet==5.2.0
-comtypes==1.4.8
-git+https://github.com/jaraco/pywin32-ctypes.git@f27d6a0
-idna==3.10
-mutagen==1.47.0
 mygpoclient==1.10
-podcastparser==0.6.10
-PySocks==1.7.1
-requests==2.32.3
-urllib3==2.2.2
-webencodings==0.5.1
-pillow==11.0.0
-filelock==3.16.1
+podcastparser==0.6.11
 yt-dlp
 "
 
@@ -118,7 +106,7 @@ function install_deps {
     # cache update step during package installation
     export MSYS2_FC_CACHE_SKIP=1
 
-    build_pacman --noconfirm -S \
+    build_pacman --noconfirm --needed -S \
         git \
         "${MINGW_PACKAGE_PREFIX}"-gdk-pixbuf2 \
         "${MINGW_PACKAGE_PREFIX}"-librsvg \
@@ -128,9 +116,21 @@ function install_deps {
         "${MINGW_PACKAGE_PREFIX}"-python-cairo \
         "${MINGW_PACKAGE_PREFIX}"-python-pip \
         "${MINGW_PACKAGE_PREFIX}"-python-six \
+        "${MINGW_PACKAGE_PREFIX}"-python-certifi \
+        "${MINGW_PACKAGE_PREFIX}"-python-chardet \
+        "${MINGW_PACKAGE_PREFIX}"-python-comtypes \
+        "${MINGW_PACKAGE_PREFIX}"-python-pywin32-ctypes \
+        "${MINGW_PACKAGE_PREFIX}"-python-idna \
+        "${MINGW_PACKAGE_PREFIX}"-python-mutagen \
+        "${MINGW_PACKAGE_PREFIX}"-python-pysocks \
+        "${MINGW_PACKAGE_PREFIX}"-python-requests \
+        "${MINGW_PACKAGE_PREFIX}"-python-urllib3 \
+        "${MINGW_PACKAGE_PREFIX}"-python-webencodings \
+        "${MINGW_PACKAGE_PREFIX}"-python-pillow \
+        "${MINGW_PACKAGE_PREFIX}"-python-filelock \
         "${MINGW_PACKAGE_PREFIX}"-make
 
-    build_pip install --no-deps --no-binary ":all:" --upgrade \
+    build_pip install --break-system-packages --no-deps --no-binary ":all:" --upgrade \
         --force-reinstall $(echo "$PIP_REQUIREMENTS" | tr "\\n" " ")
 
     # replace ca-certificates with certifi's
@@ -145,7 +145,7 @@ function install_deps {
     #    "${MINGW_PACKAGE_PREFIX}"-python-pip \
     #    || true
 
-    build_pacman --noconfirm -S \
+    build_pacman --noconfirm --needed -S \
         "${MINGW_PACKAGE_PREFIX}"-python-setuptools \
         "${MINGW_PACKAGE_PREFIX}"-python-build \
         "${MINGW_PACKAGE_PREFIX}"-python-installer

--- a/tools/win_installer/bootstrap.sh
+++ b/tools/win_installer/bootstrap.sh
@@ -24,12 +24,16 @@ function main {
         "${MINGW_PACKAGE_PREFIX}"-python \
         "${MINGW_PACKAGE_PREFIX}"-python-gobject \
         "${MINGW_PACKAGE_PREFIX}"-python-cairo \
-        "${MINGW_PACKAGE_PREFIX}"-python-pip
+        "${MINGW_PACKAGE_PREFIX}"-python-pip \
+        "${MINGW_PACKAGE_PREFIX}"-python-six \
+        "${MINGW_PACKAGE_PREFIX}"-python-webencodings \
+        "${MINGW_PACKAGE_PREFIX}"-python-html5lib \
+        "${MINGW_PACKAGE_PREFIX}"-python-requests \
+        "${MINGW_PACKAGE_PREFIX}"-python-pillow \
+        "${MINGW_PACKAGE_PREFIX}"-python-filelock \
+        "${MINGW_PACKAGE_PREFIX}"-python-pywin32-ctypes \
 
-    pip3 install --user podcastparser mygpoclient \
-                        pywin32-ctypes \
-                        webencodings six \
-                        pillow filelock
+    CFLAGS="-I${MINGW_PREFIX}/include -L${MINGW_PREFIX}/lib" pip3 install --user podcastparser mygpoclient
 }
 
 main;

--- a/tools/win_installer/misc/win_installer.nsi
+++ b/tools/win_installer/misc/win_installer.nsi
@@ -120,7 +120,7 @@ Section "Install"
 
     ; Use this to make things faster for testing installer changes
     ;~ SetOutPath "$INSTDIR\bin"
-    ;~ File /r "mingw32\bin\*.exe"
+    ;~ File /r "${ROOT}\bin\*.exe"
 
     SetOutPath "$INSTDIR"
     File /r "${ROOT}\*.*"

--- a/tools/win_installer/misc/win_installer.nsi
+++ b/tools/win_installer/misc/win_installer.nsi
@@ -18,6 +18,7 @@ Unicode true
 !define GPO_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GPO_NAME}"
 !define GPO_INSTDIR_KEY "Software\${GPO_NAME}"
 !define GPO_INSTDIR_VALUENAME "InstDir"
+!define ROOT "ucrt64"
 
 !define MUI_CUSTOMFUNCTION_GUIINIT custom_gui_init
 !include "MUI2.nsh"
@@ -122,7 +123,7 @@ Section "Install"
     ;~ File /r "mingw32\bin\*.exe"
 
     SetOutPath "$INSTDIR"
-    File /r "mingw32\*.*"
+    File /r "${ROOT}\*.*"
 
     StrCpy $GPO_CMD_INST_BIN "$INSTDIR\bin\gpo.exe"
     StrCpy $GPO_INST_BIN "$INSTDIR\bin\gpodder.exe"


### PR DESCRIPTION
I was able to successfully build on my local msys2 ucrt64 environment by running the `tools/win_installer/build.sh` script in ucrt64 env.
I believe the environment that appveyor uses must be set in their website by @auouymous
