### PR TITLE
iPod sync: Allow empty / NULL string values, use ffmpeg to get track length

### DIFF
--- a/src/gpodder/libgpod_ctypes.py
+++ b/src/gpodder/libgpod_ctypes.py
@@ -289,11 +289,17 @@ class iPodTrack(object):
         self.db = db
         self.track = track
 
-        self.episode_title = track[0].title.decode()
-        self.podcast_title = track[0].album.decode()
+        def string_or_none(c_char_p):
+            if c_char_p:
+                return c_char_p.decode()
+            else:
+                return None
 
-        self.podcast_url = track[0].podcasturl.decode()
-        self.podcast_rss = track[0].podcastrss.decode()
+        self.episode_title = string_or_none(track[0].title)
+        self.podcast_title = string_or_none(track[0].album)
+
+        self.podcast_url = string_or_none(track[0].podcasturl)
+        self.podcast_rss = string_or_none(track[0].podcastrss)
 
         self.playcount = track[0].playcount
         self.bookmark_time = track[0].bookmark_time
@@ -302,7 +308,7 @@ class iPodTrack(object):
         # around a bit and take a copy of the string before free'ing it again.
         filename_ptr = libgpod.itdb_filename_on_ipod(track)
         if filename_ptr:
-            self.filename_on_ipod = ctypes.string_at(filename_ptr).decode()
+            self.filename_on_ipod = string_or_none(ctypes.string_at(filename_ptr))
             libglib.g_free(filename_ptr)
         else:
             self.filename_on_ipod = None

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -27,6 +27,7 @@ import logging
 import os.path
 import threading
 import time
+from subprocess import PIPE
 
 import gpodder
 from gpodder import download, services, util
@@ -47,6 +48,8 @@ try:
 except:
     logger.info('iPod sync not available')
     gpod_available = False
+
+ffmpeg_available = True if util.find_command('ffmpeg') is not None else False
 
 mplayer_available = True if util.find_command('mplayer') is not None else False
 
@@ -87,6 +90,16 @@ def get_track_length(filename):
             return length
         except Exception:
             logger.error('eyed3.mp3 could not determine length: %s', filename, exc_info=True)
+            attempted = True
+
+    if ffmpeg_available:
+        try:
+            _x, ffmpeg_output = util.Popen(['ffmpeg', '-i', filename], stderr=PIPE).communicate()
+            len_str = ffmpeg_output[ffmpeg_output.index(b'Duration:'):].split(b',')[0][10:].decode()
+            logger.debug("ffmpeg found length string for '%s': %s", filename, len_str)
+            return int(sum(float(s) * t for s, t in zip(len_str.split(':'), [3600, 60, 1])) * 1000)
+        except Exception:
+            logger.error('ffmpeg could not determine length: %s', filename, exc_info=True)
             attempted = True
 
     if mplayer_available:

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -311,6 +311,7 @@ class iPodDevice(Device):
             logger.error('Please install libgpod 0.8.3 to sync with an iPod device.')
             return False
         if not os.path.isdir(self.mountpoint):
+            logger.error(f"iPod mountpoint '{self.mountpoint}' is not a directory")
             return False
 
         self.notify('status', _('Opening iPod database'))

--- a/src/gpodder/sync.py
+++ b/src/gpodder/sync.py
@@ -77,14 +77,6 @@ def open_device(gui):
 def get_track_length(filename):
     attempted = False
 
-    if mplayer_available:
-        try:
-            mplayer_output = os.popen('mplayer -msglevel all=-1 -identify -vo null -ao null -frames 0 "%s" 2>/dev/null' % filename).read()
-            return int(float(mplayer_output[mplayer_output.index('ID_LENGTH'):].splitlines()[0][10:]) * 1000)
-        except Exception:
-            logger.error('MPlayer could not determine length: %s', filename, exc_info=True)
-            attempted = True
-
     if eyed3mp3_available:
         try:
             length = int(eyed3.mp3.Mp3AudioFile(filename).info.time_secs * 1000)
@@ -95,6 +87,14 @@ def get_track_length(filename):
             return length
         except Exception:
             logger.error('eyed3.mp3 could not determine length: %s', filename, exc_info=True)
+            attempted = True
+
+    if mplayer_available:
+        try:
+            mplayer_output = os.popen('mplayer -msglevel all=-1 -identify -vo null -ao null -frames 0 "%s" 2>/dev/null' % filename).read()
+            return int(float(mplayer_output[mplayer_output.index('ID_LENGTH'):].splitlines()[0][10:]) * 1000)
+        except Exception:
+            logger.error('MPlayer could not determine length: %s', filename, exc_info=True)
             attempted = True
 
     if not attempted:


### PR DESCRIPTION
I tested syncing to a video iPod and did not succeed with current gPodder master. This fixes the immediate problems I had, namely the exceptions caused by empty strings and wrong track lengths, if mplayer or eyed3 are not installed (but ffmpeg is).

iPod sync now works somehow, but seems to have other bugs. Unfortunately gtkpod has been dropped from recent linux distros, so fixing the FS in the iPod is tricky.

This may help with #1753, since it also seems to have something to do with NULL pointers.