### PR TITLE
Fix ytdlp channel parsing.

### DIFF
--- a/share/gpodder/extensions/10_youtube-dl.py
+++ b/share/gpodder/extensions/10_youtube-dl.py
@@ -236,18 +236,24 @@ class YoutubeFeed(model.Feed):
         return None
 
     def get_new_episodes(self, channel, existing_guids):
+        # TODO: timestamp is not available and thus entries are unlikely to be sorted
         # entries are already sorted by decreasing date
         # trim guids to max episodes
         entries = [e for i, e in enumerate(self._ie_result['entries'])
                    if not self._max_episodes or i < self._max_episodes]
         all_seen_guids = {e['guid'] for e in entries}
+
         # only fetch new ones from youtube since they are so slow to get
-        new_entries = [e for e in entries if e['guid'] not in existing_guids]
+        # changes to existing episodes will not be fetched
+        # however, if total_time was zero (premieres), include episode for update
+        new_entries = [e for e in entries if e['guid'] not in existing_guids or existing_guids[e['guid']].total_time == 0]
+
         logger.debug('%i/%i new entries', len(new_entries), len(all_seen_guids))
         self._ie_result['entries'] = new_entries
         self._downloader.refresh_entries(self._ie_result)
+
         # episodes from entries
-        episodes = []
+        new_episodes = []
         for en in self._ie_result['entries']:
             guid = video_guid(en['id'])
             if en.get('ext'):
@@ -259,23 +265,50 @@ class YoutubeFeed(model.Feed):
             else:
                 filesize = sum(int(f.get('filesize') or 0)
                                for f in en.get('requested_formats', []))
+            if thumbnail := en.get('thumbnails', [{}])[0].get('url'):
+                thumbnail = re.sub(r'[?].*', '', thumbnail)
+            description = en.get('description') or ''
+            if en.get('upload_date'):
+                timestamp = youtube_parsedate(en.get('upload_date'))
+            elif en.get('release_timestamp'):
+                # TODO: unknown if string or unix timestamp
+                timestamp = en.get('release_timestamp')
+            elif en.get('timestamp'):
+                # TODO: unknown if string or unix timestamp
+                timestamp = en.get('timestamp')
+            else:
+                # no timestamp, fetch it directly from the video page
+                # also fetch the full description
+                timestamp, description = youtube.get_timestamp_description(en['id'])
             ep = {
                 'title': en.get('title', guid),
-                'link': en.get('webpage_url'),
-                'episode_art_url': en.get('thumbnail'),
-                'description': util.remove_html_tags(en.get('description') or ''),
+                'link': en.get('webpage_url') or en.get('url'),
+                'episode_art_url': thumbnail,
+                'description': util.remove_html_tags(description),
                 'description_html': '',
-                'url': en.get('webpage_url'),
+                'url': en.get('webpage_url') or en.get('url'),
                 'file_size': filesize,
                 'mime_type': mime_type,
                 'guid': guid,
-                'published': youtube_parsedate(en.get('upload_date', None)),
+                'published': timestamp,
                 'total_time': int(en.get('duration') or 0),
             }
+
             episode = channel.episode_factory(ep)
+
+            # Detect (and update) existing episode based on GUIDs
+            existing_episode = existing_guids.get(episode.guid, None)
+            if existing_episode:
+                # update existing_episode from episode
+                # exclude description since it is either empty or clipped
+                for k in ('title', 'link', 'url', 'episode_art_url', 'total_time'):
+                    setattr(existing_episode, k, getattr(episode, k))
+                episode = existing_episode
+            else:
+                new_episodes.append(episode)
+
             episode.save()
-            episodes.append(episode)
-        return episodes, all_seen_guids
+        return new_episodes, all_seen_guids
 
     def get_next_page(self, channel, max_episodes):
         """Paginated feed support (RFC 5005).

--- a/src/gpodder/youtube.py
+++ b/src/gpodder/youtube.py
@@ -20,10 +20,12 @@
 #  Justin Forest <justin.forest@gmail.com> 2008-10-13
 #
 
+import datetime
 import io
 import json
 import logging
 import re
+import time
 import urllib
 import xml.etree.ElementTree
 from functools import lru_cache
@@ -157,6 +159,17 @@ INITIAL_PLAYER_RESPONSE_RE1 = r'ytInitialPlayerResponse\s*=\s*({.+})\s*;\s*</scr
 INITIAL_PLAYER_RESPONSE_RE2 = r'ytInitialPlayerResponse\s*=\s*({.+?})\s*;'
 
 
+def get_initial_data(page):
+    r = re.compile(r'.*var ytInitialData = (.+?);</script>.*')
+    for line in page.splitlines():
+        m = re.match(r, line)
+        if m is None:
+            continue
+        data = m.group(1)
+        return json.loads(data)
+    return None
+
+
 def get_ipr(page):
     for regex in (INITIAL_PLAYER_RESPONSE_RE1, INITIAL_PLAYER_RESPONSE_RE2):
         ipr = re.search(regex, page)
@@ -232,6 +245,102 @@ def youtube_get_new_endpoint(vid):
             raise YouTubeError('Youtube "%s": No ytInitialPlayerResponse found' % url)
 
     return None, ipr.group(1)
+
+
+def get(xs, *args):
+    for a in args:
+        if isinstance(a, int):
+            if not isinstance(xs, list) or a < 0 or a >= len(xs):
+                return None
+            xs = xs[a]
+        elif isinstance(a, str):
+            if not isinstance(xs, dict) or a not in xs:
+                return None
+            xs = xs[a]
+        else:
+            logger.error('unsupported key or index to get "%s", or unsupported object type "%s"' % (str(a), type(xs)))
+            return None
+    return xs
+
+
+def get_timestamp_description(vid):
+    # use current time if a valid time/date is not found in video page
+    timestamp = int(time.time())
+    description = ''
+
+    try:
+        url = WATCH_ENDPOINT + vid
+        r = util.urlopen(url)
+        if not r.ok:
+            return timestamp, description
+
+        idata = get_initial_data(r.text)
+        if idata is None:
+            url = get_gdpr_consent_url(r.text)
+            r = util.urlopen(url)
+            if not r.ok:
+                return timestamp, description
+
+            idata = get_initial_data(r.text)
+            if idata is None:
+                return timestamp, description
+
+        vs = get(idata, 'contents', 'twoColumnWatchNextResults', 'results', 'results', 'contents')
+        for v in vs:
+            if 'videoPrimaryInfoRenderer' in v:
+                primary_v = get(v, 'videoPrimaryInfoRenderer')
+            elif 'videoSecondaryInfoRenderer' in v:
+                secondary_v = get(v, 'videoSecondaryInfoRenderer')
+
+        description = get(secondary_v, 'attributedDescription', 'content') or ''
+
+        # get partial or relative time
+        if primary_v is None:
+            return timestamp, description
+        t = get(primary_v, 'dateText', 'simpleText')
+        if t is None:
+            t = get(primary_v, 'relativeDateText', 'simpleText')
+            if t is None:
+                return timestamp, description
+
+        # "Jan 1, 1970"
+        # "Premiered Jan 1, 1970"
+        m = re.search(r'(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+([0-9]{1,2}),\s+([0-9]{4})', t)
+        if m is not None:
+            _months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+            months = {month: index + 1 for index, month in enumerate(_months)}
+            timestamp = int(datetime.datetime(int(m[3]), months[m[1]], int(m[2])).timestamp())
+            return timestamp, description
+
+        n = 0
+        # "1 day ago"
+        m = re.search(r'([0-9]+)\s*(seconds?|minutes?|hours?|days?|weeks?|months?|years?)\s+ago', t)
+        if m is not None:
+            n = int(m[1])
+            u = m[2]
+        # "1d"
+        m = re.search(r'^([0-9]+)\s*(s|m|h|d|w|mo|y)$', t)
+        if m is not None:
+            n = int(m[1])
+            u = m[2]
+        if n > 0:
+            if u.startswith('y'):
+                return timestamp - 365.25 * 86400 * n, description
+            elif u.startswith('mo'):
+                return timestamp - 30 * 86400 * n, description
+            elif u.startswith('w'):
+                return timestamp - 7 * 86400 * n, description
+            elif u.startswith('d'):
+                return timestamp - 86400 * n, description
+            elif u.startswith('h'):
+                return timestamp - 3600 * n, description
+            elif u.startswith('m'):
+                return timestamp - 60 * n, description
+            elif u.startswith('s'):
+                return timestamp - n, description
+    except Exception:
+        pass
+    return timestamp, description
 
 
 def get_total_time(episode):


### PR DESCRIPTION
Youtube no longer includes the unix timestamp in video listings. Instead, it uses a relative textual timestamp such as "1 day ago". Yt-dlp makes no attempt to resolve the string to a timestamp, therefore, Gpodder must fetch the video page to get the date without time and parse it to a semi-accurate timestamp assuming 00:00 for the time.

The description in video listings was clipped, but is no empty. While fetching timestamp, gpodder must also read the full description from video page.

Gpodder was not updating existing episodes with yt-dlp. This caused premiered videos, which were added without a total time, to never show one after they were eventually released. These videos are now properly updated.