### PR TITLE
Don't use deprecated app menu

### DIFF
--- a/src/gpodder/gtkui/app.py
+++ b/src/gpodder/gtkui/app.py
@@ -178,7 +178,7 @@ class gPodderApplication(Gtk.Application):
                 self.add_accelerator(accel, action, None)
 
         else:
-            self.set_app_menu(self.app_menu)
+            menubar.prepend_submenu(_("_Application"), self.app_menu)
 
         Gtk.Window.set_default_icon_name('gpodder')
 


### PR DESCRIPTION
This ensures that the menu is visible when using client-side decoration.

When client-side decoration is used, the app menu appears on the title bar instead on the menu bar, but only if the `appmenu` is added to the window button layout in user's settings.